### PR TITLE
Fix list-item headings in 2017-2018 meeting logs

### DIFF
--- a/2017/DevMeeting-2017-01-19.md
+++ b/2017/DevMeeting-2017-01-19.md
@@ -135,7 +135,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 ## About 2.5 timeframe
 
-- ## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087044831669&usg=AOvVaw30sTnRuPz45NYawvPNCGNa)
+## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087044831669&usg=AOvVaw30sTnRuPz45NYawvPNCGNa)
 
 - 合宿
 
@@ -154,7 +154,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 ## Carry-over from previous meeting(s)
 
-- ## \[Feature [#12180](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12180&sa=D&source=editors&ust=1686087044832934&usg=AOvVaw2M0hU6Px9QdrZEATwOmvrL)\] switch id\_table.c variant (shyouhei)
+## \[Feature [#12180](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12180&sa=D&source=editors&ust=1686087044832934&usg=AOvVaw2M0hU6Px9QdrZEATwOmvrL)\] switch id\_table.c variant (shyouhei)
 
 
 - ko1: funny-falcon’s open addressing hash is beating mine.
@@ -163,7 +163,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - akr: isn’t it too big for a new comer?
 - ko1: I see. I’ll do.
 
-- ## \[Feature [#12944](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12944&sa=D&source=editors&ust=1686087044833660&usg=AOvVaw3HKVzTUjTWaORCM9KWWa8r)\] Change Kernel#warn to call Warning.warn (shyouhei)
+## \[Feature [#12944](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12944&sa=D&source=editors&ust=1686087044833660&usg=AOvVaw3HKVzTUjTWaORCM9KWWa8r)\] Change Kernel#warn to call Warning.warn (shyouhei)
 
 
 - nobu: what spec?
@@ -171,7 +171,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - akr: compatibility concern?
 - matz: why not just try it.
 
-- ## \[Feature [#13124](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13124&sa=D&source=editors&ust=1686087044834227&usg=AOvVaw3Egmi16N6KEpmfjjVqbPM8)\] Should #puts convert to external encoding? (shyouhei)
+## \[Feature [#13124](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13124&sa=D&source=editors&ust=1686087044834227&usg=AOvVaw3Egmi16N6KEpmfjjVqbPM8)\] Should #puts convert to external encoding? (shyouhei)
 
 
 - shyouhei: what’s this?
@@ -182,7 +182,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - akr: I think it’s OK for particular IO that needs encoding, it’s convenient to have such feature.
 - naruse: OK, I’ll respond.
 
-- ## \[Feature [#13017](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13017&sa=D&source=editors&ust=1686087044835003&usg=AOvVaw2yCBZNtgVUPqe80GD_ojHN)\] Switch SipHash from SipHash24 to SipHash13 (shyouhei)
+## \[Feature [#13017](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13017&sa=D&source=editors&ust=1686087044835003&usg=AOvVaw2yCBZNtgVUPqe80GD_ojHN)\] Switch SipHash from SipHash24 to SipHash13 (shyouhei)
 
 
 - shyouhei: I'm confident it's OK to go to 2.5.
@@ -191,7 +191,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - shyouhei: I will
 - matz: go ahead.
 
-- ## \[Bug [#12998](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12998&sa=D&source=editors&ust=1686087044835786&usg=AOvVaw3tDHLY2fuUMM2uyCv557po)\] paragraph mode inconsistency between IO#each\_line and String#each\_line(nobu)
+## \[Bug [#12998](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12998&sa=D&source=editors&ust=1686087044835786&usg=AOvVaw3tDHLY2fuUMM2uyCv557po)\] paragraph mode inconsistency between IO#each\_line and String#each\_line(nobu)
 
 
 - ko1: ideal behaviour?
@@ -199,7 +199,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - matz: (nod)
 - nobu: I already merged this.
 
-- ## \[Feature [#8158](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8158&sa=D&source=editors&ust=1686087044836528&usg=AOvVaw3nDaN7kMfCgJujkMQhipau)\] lightweight structure for loaded features index (shyouhei)
+## \[Feature [#8158](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8158&sa=D&source=editors&ust=1686087044836528&usg=AOvVaw3nDaN7kMfCgJujkMQhipau)\] lightweight structure for loaded features index (shyouhei)
 
 
 - ko1: nobody but nobu can say if it’s OK.
@@ -207,7 +207,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - hsbt: why not let funny-falcon merge this?
 - matz: I take the idea.
 
-- ## \[Feature [#12854](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12854&sa=D&source=editors&ust=1686087044837109&usg=AOvVaw2jaCwfSENi9_-M71iAcw9c)\] Proc#curry should return an instance of the class, not Proc (shyouhei)
+## \[Feature [#12854](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12854&sa=D&source=editors&ust=1686087044837109&usg=AOvVaw2jaCwfSENi9_-M71iAcw9c)\] Proc#curry should return an instance of the class, not Proc (shyouhei)
 
 
 - ko1: general idea?
@@ -216,7 +216,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - matz: seems they are different proposals than applications of #curry.
 - matz: I’ll ask for use cases.
 
-- ## \[Feature [#5481](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5481&sa=D&source=editors&ust=1686087044837835&usg=AOvVaw3a8LfDLz3x0H0X8zavV596)\] Gemifying Ruby standard library (hsbt)
+## \[Feature [#5481](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5481&sa=D&source=editors&ust=1686087044837835&usg=AOvVaw3a8LfDLz3x0H0X8zavV596)\] Gemifying Ruby standard library (hsbt)
 
 
 - hsbt: Waiting approval of Matz
@@ -234,7 +234,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - akr: I see concerns of dependency hell.
 - hsbt: it’s OK we create separate ML threads for each library to discuss.
 
-- ## \[Feature [#12901](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12901&sa=D&source=editors&ust=1686087044838946&usg=AOvVaw2kwRfNIyCYGSXlD-tc0Sil)\] Anonymous functions without scope lookup overhead (shyouhei)
+## \[Feature [#12901](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12901&sa=D&source=editors&ust=1686087044838946&usg=AOvVaw2kwRfNIyCYGSXlD-tc0Sil)\] Anonymous functions without scope lookup overhead (shyouhei)
 
 
 - ko1: matz said we should automatically optimize procs when possible, not explicitly stating like this.
@@ -250,7 +250,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 - matz will respond, ko1 to create a new ticket that refer this one.
 
-- ## \[Feature [#12906](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12906&sa=D&source=editors&ust=1686087044839948&usg=AOvVaw2YI7HFfXjQwSY_DmThuuQy)\] do/end blocks work with ensure/rescue/else (shyouhei)
+## \[Feature [#12906](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12906&sa=D&source=editors&ust=1686087044839948&usg=AOvVaw2YI7HFfXjQwSY_DmThuuQy)\] do/end blocks work with ensure/rescue/else (shyouhei)
 
 
 - shyouhei: OP is wise because he do not talk about { … }
@@ -261,7 +261,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - akr: generally speaking it is good to reduce indent.
 - matz: Let me think about it. -> OK
 
-- ## \[Feature [#12926](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12926&sa=D&source=editors&ust=1686087044840939&usg=AOvVaw3tvJjHLJu4c926W41uXycr)\] -l flag for line end processing should use chomp! instead of chop! (shyouhei)
+## \[Feature [#12926](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12926&sa=D&source=editors&ust=1686087044840939&usg=AOvVaw3tvJjHLJu4c926W41uXycr)\] -l flag for line end processing should use chomp! instead of chop! (shyouhei)
 
 
 - nobu: perl behaves like chomp.
@@ -270,7 +270,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - akr: chomp is ruby1.1+, \-l already exists in ruby 0.95
 - matz: OK.
 
-- ## \[Feature [#12912](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12912&sa=D&source=editors&ust=1686087044841795&usg=AOvVaw12psrHLdrkKGFtjvYZhNGE)\] An endless range (1..) (shyouhei)
+## \[Feature [#12912](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12912&sa=D&source=editors&ust=1686087044841795&usg=AOvVaw12psrHLdrkKGFtjvYZhNGE)\] An endless range (1..) (shyouhei)
 
 
 - shyouhei: what about opossite side ...1?
@@ -285,13 +285,13 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - nobu: (1..) seems visually odd.
 - akr: for now, use step and drop.
 
-- ## \[Feature [#12933](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12933&sa=D&source=editors&ust=1686087044843060&usg=AOvVaw0keM6i4xTY8lmU5azdAraJ)\] Add Some and Optional (shyouhei)
+## \[Feature [#12933](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12933&sa=D&source=editors&ust=1686087044843060&usg=AOvVaw0keM6i4xTY8lmU5azdAraJ)\] Add Some and Optional (shyouhei)
 
 
 - nobu: start as a gem.
 - matz: agree.
 
-- ## \[Feature [#12931](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12931&sa=D&source=editors&ust=1686087044843720&usg=AOvVaw1TRT60YZv5rwfwj4QCqZlk)\] Add support for Binding#instance\_eval (shyouhei)
+## \[Feature [#12931](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12931&sa=D&source=editors&ust=1686087044843720&usg=AOvVaw1TRT60YZv5rwfwj4QCqZlk)\] Add support for Binding#instance\_eval (shyouhei)
 
 
 - shyouhei: what is needed ultimately is to pass a block to Binding#eval
@@ -299,7 +299,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - nobu: I think it’s not faster, if not impossible.
 - nobu will reject.
 
-- ## \[Feature [#12929](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12929&sa=D&source=editors&ust=1686087044844592&usg=AOvVaw0-MTVCgzZMqz0MjyNEWQmL)\] ternary should look ahead w/in a block (and not care about newlines) (shyouhei)
+## \[Feature [#12929](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12929&sa=D&source=editors&ust=1686087044844592&usg=AOvVaw0-MTVCgzZMqz0MjyNEWQmL)\] ternary should look ahead w/in a block (and not care about newlines) (shyouhei)
 
 
 - naruse: perl people tends to write it.
@@ -307,14 +307,14 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - shyouhei: Martin says we already look-ahead for periods.
 - matz: Python ignores newlines inside of parens.
 
-- ## \[Misc [#12935](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12935&sa=D&source=editors&ust=1686087044845395&usg=AOvVaw1n_0zBk9KpmPISUdRLC2Jv)\] Webrick: Update HTTP Status codes, share them (shyouhei)
+## \[Misc [#12935](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12935&sa=D&source=editors&ust=1686087044845395&usg=AOvVaw1n_0zBk9KpmPISUdRLC2Jv)\] Webrick: Update HTTP Status codes, share them (shyouhei)
 
 
 - nobu: is it Webrick?
 - akr: Webrick has this code but no one wants to require the whole.
 - akira: nobody looks at anywhere but Rack.
 
-- ## \[Feature [#12962](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12962&sa=D&source=editors&ust=1686087044846104&usg=AOvVaw38o3XVryvBzaqbBXuxxujV)\] Feature Proposal: Extend 'protected' to support module friendship (shyouhei)
+## \[Feature [#12962](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12962&sa=D&source=editors&ust=1686087044846104&usg=AOvVaw38o3XVryvBzaqbBXuxxujV)\] Feature Proposal: Extend 'protected' to support module friendship (shyouhei)
 
 
 - akr: use of protected is discouraged.
@@ -323,31 +323,31 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - naruse: I think it’s RuboCop’s duty to warn such thing.
 - akr: it’s a good thing anyway to update rdoc to discourage usages.
 
-- ## \[Feature [#12957](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12957&sa=D&source=editors&ust=1686087044846988&usg=AOvVaw0w142OIQA-do77B8UGCdRy)\] A more OO way to create lambda Procs (shyouhei)
+## \[Feature [#12957](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12957&sa=D&source=editors&ust=1686087044846988&usg=AOvVaw0w142OIQA-do77B8UGCdRy)\] A more OO way to create lambda Procs (shyouhei)
 
 
 - akr: I don’t understand the OP’s intension.
 - shyouhei: I think they want a subclass of lambda.  that’s not possible today.
 - akr: it is possible. complicated though. ->  commented.
 
-- ## \[Feature [#12966](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12966&sa=D&source=editors&ust=1686087044847638&usg=AOvVaw0TeErYg--zJl6KLHKHHhoD)\] net/ftp to include fxp support? (shyouhei) who's going to handle this?
+## \[Feature [#12966](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12966&sa=D&source=editors&ust=1686087044847638&usg=AOvVaw0TeErYg--zJl6KLHKHHhoD)\] net/ftp to include fxp support? (shyouhei) who's going to handle this?
 
 
 - shugo is handling.
 
-- ## \[Feature [#12967](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12967&sa=D&source=editors&ust=1686087044848140&usg=AOvVaw04PGoz0T9D1OHWYq27P9Vn)\] Add a default for RUBY\_GC\_HEAP\_GROWTH\_MAX\_SLOTS out-of-the-box (shyouhei)
+## \[Feature [#12967](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12967&sa=D&source=editors&ust=1686087044848140&usg=AOvVaw04PGoz0T9D1OHWYq27P9Vn)\] Add a default for RUBY\_GC\_HEAP\_GROWTH\_MAX\_SLOTS out-of-the-box (shyouhei)
 
 
 - ko1: I’m not sure if this parameter is a sane default.
 - ko1: also, I think there should be a comprehensive approach to parameterize GC, not individually like this.
 
-- ## \[Feature [#12969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12969&sa=D&source=editors&ust=1686087044848725&usg=AOvVaw1Tr_Bmpl_tsm9mZnfc5PfV)\] Allow optional parameter in String#strip and related (shyouhei)
+## \[Feature [#12969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12969&sa=D&source=editors&ust=1686087044848725&usg=AOvVaw1Tr_Bmpl_tsm9mZnfc5PfV)\] Allow optional parameter in String#strip and related (shyouhei)
 
 
 - naruse: I think regexp is the best for this purpose.
 - naruse: I don’t like the tr-like argument string.
 
-- ## \[Feature [#13016](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13016&sa=D&source=editors&ust=1686087044849359&usg=AOvVaw3ofGy1w8lZq-Kbh8QeoM6G)\] String#gsub(hash) (shyouhei)
+## \[Feature [#13016](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13016&sa=D&source=editors&ust=1686087044849359&usg=AOvVaw3ofGy1w8lZq-Kbh8QeoM6G)\] String#gsub(hash) (shyouhei)
 
 
 - akr: what’s wrong with union?
@@ -357,49 +357,49 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - shyouhei: understand that point.
 - naruse: you have to sort by length before union. Otherwise カ can match before ガ.
 
-- ## \[Bug [#8241](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8241&sa=D&source=editors&ust=1686087044850256&usg=AOvVaw3maXB-A1V_oKnE2iCJyQ8o)\] If uri host-part has underscore ( '\_' ), 'URI#parse' raise 'URI::InvalidURIError' (shyouhei)
+## \[Bug [#8241](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8241&sa=D&source=editors&ust=1686087044850256&usg=AOvVaw3maXB-A1V_oKnE2iCJyQ8o)\] If uri host-part has underscore ( '\_' ), 'URI#parse' raise 'URI::InvalidURIError' (shyouhei)
 
 
 - naruse: I think this is done.
 
-- ## \[Bug [#8826](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8826&sa=D&source=editors&ust=1686087044850670&usg=AOvVaw2XNggg9fOKI6Umf6b27sJN)\] BigDecimal#div and #quo different behavior and inconsistencies (shyouhei) status?>mrkn
+## \[Bug [#8826](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8826&sa=D&source=editors&ust=1686087044850670&usg=AOvVaw2XNggg9fOKI6Umf6b27sJN)\] BigDecimal#div and #quo different behavior and inconsistencies (shyouhei) status?>mrkn
 
 
 - mkrn: I'll start to fix it as soon as possible.
 
-- ## \[Feature [#13048](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13048&sa=D&source=editors&ust=1686087044851085&usg=AOvVaw3SSTmLdydOmQFj75lPqiFO)\] Better way to do Regexp.new(Regexp.escape("some string")) (shyouhei)
+## \[Feature [#13048](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13048&sa=D&source=editors&ust=1686087044851085&usg=AOvVaw3SSTmLdydOmQFj75lPqiFO)\] Better way to do Regexp.new(Regexp.escape("some string")) (shyouhei)
 
 
 - naruse: quick look at the github result seems every usage of Regexp.new(Regexp.escape()) are bad.
 - akr: Regexp.exact() ?
 
-- ## \[Bug [#13111](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13111&sa=D&source=editors&ust=1686087044851579&usg=AOvVaw3hk7M3LSn1Ia1G6YYdWTDA)\] Degraded performance for delegated methods through Forwardable module (shyouhei) assign who?
+## \[Bug [#13111](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13111&sa=D&source=editors&ust=1686087044851579&usg=AOvVaw3hk7M3LSn1Ia1G6YYdWTDA)\] Degraded performance for delegated methods through Forwardable module (shyouhei) assign who?
 
 
 - nobu: I did this already I think.
 
-- ## \[Bug [#13098](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13098&sa=D&source=editors&ust=1686087044851959&usg=AOvVaw2PVcqG3dkj4MmA3qVFZhIE)\] miniruby fails with SEGV on NetBSD/powerpc (shyouhei) look at the backtarce (shyouhei)
+## \[Bug [#13098](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13098&sa=D&source=editors&ust=1686087044851959&usg=AOvVaw2PVcqG3dkj4MmA3qVFZhIE)\] miniruby fails with SEGV on NetBSD/powerpc (shyouhei) look at the backtarce (shyouhei)
 
 
 - nobu: will take a look.
 
-- ## \[Bug [#13125](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13125&sa=D&source=editors&ust=1686087044852369&usg=AOvVaw2gujwfPf71ta-jbKElTVRp)\] MRI has too much Qtrue : Qfalse; (shyouhei)
+## \[Bug [#13125](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13125&sa=D&source=editors&ust=1686087044852369&usg=AOvVaw2gujwfPf71ta-jbKElTVRp)\] MRI has too much Qtrue : Qfalse; (shyouhei)
 
 
 - nobu: nobody is against the needs of macro but the name?
 - shyouhei: will update the ticket.
 
-- ## \[Bug [#13127](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13127&sa=D&source=editors&ust=1686087044852919&usg=AOvVaw1LLHgzk8OKi1d_2sVVZ7gr)\] DRb \`load': connection closed (DRb::DRbConnError) when client exit's from within a loop iterating over remote objects (shyouhei)
+## \[Bug [#13127](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13127&sa=D&source=editors&ust=1686087044852919&usg=AOvVaw1LLHgzk8OKi1d_2sVVZ7gr)\] DRb \`load': connection closed (DRb::DRbConnError) when client exit's from within a loop iterating over remote objects (shyouhei)
 
 
 - assign seki
 
-- ## \[Feature [#13067](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13067&sa=D&source=editors&ust=1686087044853423&usg=AOvVaw1iqYejPjiQA7MoCw1gFevk)\] TrueClass,FalseClass to provide \=== to match truthy/falsy values. (shyouhei)
+## \[Feature [#13067](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13067&sa=D&source=editors&ust=1686087044853423&usg=AOvVaw1iqYejPjiQA7MoCw1gFevk)\] TrueClass,FalseClass to provide \=== to match truthy/falsy values. (shyouhei)
 
 
 - matz: I give up.
 
-- ## \[Bug [#13064](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13064&sa=D&source=editors&ust=1686087044853890&usg=AOvVaw3-c0qgyUEi8ZRBoniVnAbn)\] Inconsistent behavior with next inside begin/end across different implementations. (shyouhei) spec or...?
+## \[Bug [#13064](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13064&sa=D&source=editors&ust=1686087044853890&usg=AOvVaw3-c0qgyUEi8ZRBoniVnAbn)\] Inconsistent behavior with next inside begin/end across different implementations. (shyouhei) spec or...?
 
 
 - ko1: it’s 1 to me.
@@ -407,12 +407,12 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - ko1:  it is.  Because you can’t place next here statically.
 - akr: should the JIS/ISO specify as such?
 
-- ## \[Bug [#13104](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13104&sa=D&source=editors&ust=1686087044854726&usg=AOvVaw2eEiMm67gOw-jGbIVhc4Wj)\] math.rb affects Rational literals (nobu)
+## \[Bug [#13104](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13104&sa=D&source=editors&ust=1686087044854726&usg=AOvVaw2eEiMm67gOw-jGbIVhc4Wj)\] math.rb affects Rational literals (nobu)
 
 
 - matz: it’s ugly, but mathn is ugly by nature.
 
-- ## \[Bug [#9569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9569&sa=D&source=editors&ust=1686087044855248&usg=AOvVaw33OUNjR8XTKHqw5QZE4B7O)\] SecureRandom should try /dev/urandom first (shyouhei) I now think it's OK
+## \[Bug [#9569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9569&sa=D&source=editors&ust=1686087044855248&usg=AOvVaw33OUNjR8XTKHqw5QZE4B7O)\] SecureRandom should try /dev/urandom first (shyouhei) I now think it's OK
 
 
 - shyouhei: I will

--- a/2017/DevMeeting-2017-03-13.md
+++ b/2017/DevMeeting-2017-03-13.md
@@ -123,7 +123,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 ## About 2.5 timeframe
 
-- ## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087099213820&usg=AOvVaw3vacAuKsyIn9qLjxob6FaO)
+## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087099213820&usg=AOvVaw3vacAuKsyIn9qLjxob6FaO)
 
 - 合宿
 

--- a/2017/DevMeeting-2017-04-17.md
+++ b/2017/DevMeeting-2017-04-17.md
@@ -142,7 +142,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 ## About 2.5 timeframe
 
-- ## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087122716162&usg=AOvVaw1NHej4Qvc-yFM-fEqLMqsg)
+## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087122716162&usg=AOvVaw1NHej4Qvc-yFM-fEqLMqsg)
 
 - Previrew 1 in June?
 - 合宿

--- a/2017/DevMeeting-2017-05-19.md
+++ b/2017/DevMeeting-2017-05-19.md
@@ -152,7 +152,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 ## About 2.5 timeframe
 
-- ## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087156480146&usg=AOvVaw0VF_ATzWdeZPXffCleFlIC)
+## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087156480146&usg=AOvVaw0VF_ATzWdeZPXffCleFlIC)
 
 - Previrew 1 in June?
 

--- a/2017/DevMeeting-2017-06-16.md
+++ b/2017/DevMeeting-2017-06-16.md
@@ -122,12 +122,12 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 # About 2.5 timeframe
 
-- # [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087184888539&usg=AOvVaw043T4verO1u-pRUKG6Mc_E)
+# [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087184888539&usg=AOvVaw043T4verO1u-pRUKG6Mc_E)
 
 
 ## Carry-over from previous meeting(s)
 
-- ## \[Feature [#12733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12733&sa=D&source=editors&ust=1686087184889024&usg=AOvVaw0gHwd6vDBbqp7qSRzuJBV-)\] Bundle bundler to ruby core (shyouhei) updates?
+## \[Feature [#12733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12733&sa=D&source=editors&ust=1686087184889024&usg=AOvVaw0gHwd6vDBbqp7qSRzuJBV-)\] Bundle bundler to ruby core (shyouhei) updates?
 
 
 - hsbt: rubygems/rubygems 2.7 requires bundler.  After it is released, when ruby-core merges that version, we have to take care.
@@ -138,23 +138,23 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: is there any blocker?
 - hsbt: rspec.
 
-- ## \[Feature [#13332](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13332&sa=D&source=editors&ust=1686087184889733&usg=AOvVaw1CcdqiB6YdbxIhbWJbFX_1)\] Forwardable#def\_instance\_delegator nil (shyouhei)
+## \[Feature [#13332](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13332&sa=D&source=editors&ust=1686087184889733&usg=AOvVaw1CcdqiB6YdbxIhbWJbFX_1)\] Forwardable#def\_instance\_delegator nil (shyouhei)
 
 
 - assign nobu
 
-- ## \[Feature [#13333](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13333&sa=D&source=editors&ust=1686087184890295&usg=AOvVaw0GqC30q3mUgemm9FBfOuIb)\] block to yield (shyouhei)
+## \[Feature [#13333](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13333&sa=D&source=editors&ust=1686087184890295&usg=AOvVaw0GqC30q3mUgemm9FBfOuIb)\] block to yield (shyouhei)
 
 
 - ko1: we need more use cases.
 - martin: nobu: add them to the ticket.
 
-- ## \[Feature [#13378](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13378&sa=D&source=editors&ust=1686087184890861&usg=AOvVaw01R3vn2nSGuEbMj6mswm8d)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+## \[Feature [#13378](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13378&sa=D&source=editors&ust=1686087184890861&usg=AOvVaw01R3vn2nSGuEbMj6mswm8d)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
 
 
 - nobu: I don’t want to handle fds this way because we can’t close properly on exceptions. I think we should wrap them using IOs.
 
-- ## \[Feature [#13381](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13381&sa=D&source=editors&ust=1686087184891306&usg=AOvVaw2zjJLQ9Mw0cLcrODpULDzV)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## \[Feature [#13381](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13381&sa=D&source=editors&ust=1686087184891306&usg=AOvVaw2zjJLQ9Mw0cLcrODpULDzV)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
 
 
 - ko1: how about it? I don’t like “f”string naming.
@@ -162,137 +162,137 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: true but we already have rb\_intern().
 - ko1: nobody has idea. so that nobu and ko1 will decide it. nobody against exposing this functionality.
 
-- ## \[Feature [#13385](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13385&sa=D&source=editors&ust=1686087184891916&usg=AOvVaw2RVOIyAr1VhU4Gt8NHdOS7)\] \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
+## \[Feature [#13385](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13385&sa=D&source=editors&ust=1686087184891916&usg=AOvVaw2RVOIyAr1VhU4Gt8NHdOS7)\] \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
 
 
 - akr: I can’t say if this is valid until I fully understand the RFC.
 - akira: what about using domain\_name gem?
 - assign akr.
 
-- ## \[Feature [#13383](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13383&sa=D&source=editors&ust=1686087184892450&usg=AOvVaw1EEHWUhq4dhMc6OymCu0aP)\] \[PATCH\] Module#source\_location (shyouhei)
+## \[Feature [#13383](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13383&sa=D&source=editors&ust=1686087184892450&usg=AOvVaw1EEHWUhq4dhMc6OymCu0aP)\] \[PATCH\] Module#source\_location (shyouhei)
 
 
 - akira: needs?
 - shyouhei: I think source\_locations makes more sense than source\_location.
 - akira: I started to confuse.  Is it useful?  We can already get Method#source\_location.
 
-- ## \[Feature [#12063](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12063&sa=D&source=editors&ust=1686087184893030&usg=AOvVaw2Fo_FzZrLeD7RWEGzoofyN)\] KeyError#receiver and KeyError#name (shyouhei) status?
+## \[Feature [#12063](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12063&sa=D&source=editors&ust=1686087184893030&usg=AOvVaw2Fo_FzZrLeD7RWEGzoofyN)\] KeyError#receiver and KeyError#name (shyouhei) status?
 
 
 - matz: I take KeyError#key.
 
-- ## \[Bug [#13397](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13397&sa=D&source=editors&ust=1686087184893580&usg=AOvVaw3zo4Xb1qFIH5rUZyPSr234)\] #object\_id should not be signed (shyouhei)
+## \[Bug [#13397](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13397&sa=D&source=editors&ust=1686087184893580&usg=AOvVaw3zo4Xb1qFIH5rUZyPSr234)\] #object\_id should not be signed (shyouhei)
 
 
 - akr: isn’t it possible to somehow calculate so that we can avoid negative object\_id?  Because pointers are 8 byte aligned, while positive fixnums are of 262 space.
 - nobu: it’s true we can avoid negative numbers on some environment, but not always.
 - reject this specific issue and request for new issue that address the inspect helper.
 
-- ## \[Feature [#13396](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13396&sa=D&source=editors&ust=1686087184894240&usg=AOvVaw1vefgo5p62kDz6Zt2V-Onx)\] Net::HTTP has no write timeout (shyouhei)
+## \[Feature [#13396](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13396&sa=D&source=editors&ust=1686087184894240&usg=AOvVaw1vefgo5p62kDz6Zt2V-Onx)\] Net::HTTP has no write timeout (shyouhei)
 
-- ## \[Bug [#13407](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13407&sa=D&source=editors&ust=1686087184894587&usg=AOvVaw010kIpPf30MdMEq_ZGIxol)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+## \[Bug [#13407](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13407&sa=D&source=editors&ust=1686087184894587&usg=AOvVaw010kIpPf30MdMEq_ZGIxol)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
 
-- ## \[Feature [#13395](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13395&sa=D&source=editors&ust=1686087184894947&usg=AOvVaw1dSl1pcnJg6bUAWWDKWZME)\] Add a method to check for not nil (shyouhei)
+## \[Feature [#13395](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13395&sa=D&source=editors&ust=1686087184894947&usg=AOvVaw1dSl1pcnJg6bUAWWDKWZME)\] Add a method to check for not nil (shyouhei)
 
-- ## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087184895275&usg=AOvVaw12wiXOGVB4bD4Dgc6Zvrrn)\] better method definition in C API (shyouhei)
+## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087184895275&usg=AOvVaw12wiXOGVB4bD4Dgc6Zvrrn)\] better method definition in C API (shyouhei)
 
 
 - nobu: I think parsing string is not a good idea.
 
-- ## \[Feature [#13512](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13512&sa=D&source=editors&ust=1686087184895695&usg=AOvVaw1ZVaRuFFe3tgN5RfwBkN5a)\] System Threads (shyouhei)
+## \[Feature [#13512](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13512&sa=D&source=editors&ust=1686087184895695&usg=AOvVaw1ZVaRuFFe3tgN5RfwBkN5a)\] System Threads (shyouhei)
 
-- ## \[Feature [#13518](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13518&sa=D&source=editors&ust=1686087184896015&usg=AOvVaw1sXeOWCScQIvhZiiCrMi8k)\] Indented multiline comments (shyouhei)
+## \[Feature [#13518](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13518&sa=D&source=editors&ust=1686087184896015&usg=AOvVaw1sXeOWCScQIvhZiiCrMi8k)\] Indented multiline comments (shyouhei)
 
-- ## \[Feature [#13516](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13516&sa=D&source=editors&ust=1686087184896391&usg=AOvVaw0F00iM2ALPgPaq05Ic1Mys)\] Improve the text of the circular require warning (shyouhei)
+## \[Feature [#13516](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13516&sa=D&source=editors&ust=1686087184896391&usg=AOvVaw0F00iM2ALPgPaq05Ic1Mys)\] Improve the text of the circular require warning (shyouhei)
 
-- ## \[Feature [#13532](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13532&sa=D&source=editors&ust=1686087184896734&usg=AOvVaw0kcDakKJAaX2XxL-cWPSb-)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
+## \[Feature [#13532](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13532&sa=D&source=editors&ust=1686087184896734&usg=AOvVaw0kcDakKJAaX2XxL-cWPSb-)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
 
-- ## \[Bug [#13535](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13535&sa=D&source=editors&ust=1686087184897069&usg=AOvVaw2uatNbvc6g9yzT1sHwl1Vx)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
+## \[Bug [#13535](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13535&sa=D&source=editors&ust=1686087184897069&usg=AOvVaw2uatNbvc6g9yzT1sHwl1Vx)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
 
-- ## \[Feature [#13568](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13568&sa=D&source=editors&ust=1686087184897401&usg=AOvVaw0lOVxztWlY59eqrQVGmHHz)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
+## \[Feature [#13568](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13568&sa=D&source=editors&ust=1686087184897401&usg=AOvVaw0lOVxztWlY59eqrQVGmHHz)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
 
-- ## \[Feature [#13563](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13563&sa=D&source=editors&ust=1686087184897740&usg=AOvVaw1J_tfM5W2xRrzg0lc3Uxoa)\] Implement Hash#choice method. (shyouhei)
+## \[Feature [#13563](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13563&sa=D&source=editors&ust=1686087184897740&usg=AOvVaw1J_tfM5W2xRrzg0lc3Uxoa)\] Implement Hash#choice method. (shyouhei)
 
-- ## Previous bugs that were not assigned (shyouhei)
-
-
-- ## \[Bug [#13196](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13196&sa=D&source=editors&ust=1686087184898244&usg=AOvVaw2s9kAK_W1dClDf6-K_fI5S)\] Improve keyword argument errors when non-keyword arguments given
-
-- ## \[Bug [#13320](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13320&sa=D&source=editors&ust=1686087184898590&usg=AOvVaw0aF6yt42Xx2uNx1-w2qjwI)\] rescue blocks get an entry in backtrace locations
-
-- ## \[Bug [#13336](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13336&sa=D&source=editors&ust=1686087184898914&usg=AOvVaw2xD22Y6Etgd6P1c6GQNaR3)\] Default Parameters don't work
-
-- ## \[Bug [#13337](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13337&sa=D&source=editors&ust=1686087184899255&usg=AOvVaw2ujMtb45viBHo_OAOKh5pU)\] Eval and Later Defined Local Variables
-
-- ## \[Bug [#13350](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13350&sa=D&source=editors&ust=1686087184899627&usg=AOvVaw0Y37tTZsLOSHz6PvnlXlYT)\] File.read :newline option not respected on Linux
-
-- ## \[Bug [#13373](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13373&sa=D&source=editors&ust=1686087184899976&usg=AOvVaw0iPn3ks7iHAVt-YCOzHRr5)\] FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
-
-- ## \[Bug [#13101](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13101&sa=D&source=editors&ust=1686087184900315&usg=AOvVaw0kLgayEfaLiOOFxoiHOKLQ)\] Date#rfc2822 and Time#rfc2822 don't return the same format
-
-- ## \[Bug [#12684](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12684&sa=D&source=editors&ust=1686087184900653&usg=AOvVaw2qHpzrmz4YU_aecfWQDLKQ)\] Delegator#eql? missing
-
-- ## \[Feature [#13389](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13389&sa=D&source=editors&ust=1686087184900993&usg=AOvVaw0dSpBqNXGYJqsQaEz9JdUx)\] \[PATCH\] POP3 support timeout for TLS handshake
-
-- ## \[Bug [#13404](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13404&sa=D&source=editors&ust=1686087184901373&usg=AOvVaw1jNhbQ54aLoDrwfGpR0nMU)\] Hash#any? yields arguments to lambdas with proc semantics
-
-- ## \[Bug [#13413](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13413&sa=D&source=editors&ust=1686087184901778&usg=AOvVaw0MUJmkOc2xjZzFAarrHnzv)\] --with-static-linked-ext doesn't install extension files on make install
-
-- ## \[Bug [#13429](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13429&sa=D&source=editors&ust=1686087184902166&usg=AOvVaw2vUhYc__TmQwFvAFvik40b)\] Net::SMTP has no read timeout when connexion over TLS
-
-- ## \[Bug [#13432](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13432&sa=D&source=editors&ust=1686087184902515&usg=AOvVaw0VhpLLckIFymF7S_SOKHGa)\] set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
-
-- ## \[Bug [#13446](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13446&sa=D&source=editors&ust=1686087184902866&usg=AOvVaw2dccQS0f2yC7sz0PBrfNuW)\] refinements with prepend for module has strange behavior
-
-- ## \[Bug [#13498](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13498&sa=D&source=editors&ust=1686087184903292&usg=AOvVaw1ofZUaZcw3yXfctIvzI_f5)\] Weakref, Weakmap and define\_finalizer don't work on frozen objects
-
-- ## \[Bug [#13513](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13513&sa=D&source=editors&ust=1686087184903638&usg=AOvVaw3AnkJPxJEaO4T3Fhaey05W)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
-
-- ## \[Bug [#13501](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13501&sa=D&source=editors&ust=1686087184903981&usg=AOvVaw0dGD3hZmpaJAHSLzIgyqOq)\] Process.kill behaviour for negative pid is not documented and may be wrong
-
-- ## \[Bug [#13515](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13515&sa=D&source=editors&ust=1686087184904325&usg=AOvVaw0639yqnZnSpsBlbTs0kC-X)\] Pathname#join doesn't add separator on UNC paths
-
-- ## \[Bug [#13521](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13521&sa=D&source=editors&ust=1686087184904666&usg=AOvVaw2DI9jgBeqgpGn2F2Iz9ZnX)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
-
-- ## \[Bug [#13537](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13537&sa=D&source=editors&ust=1686087184904990&usg=AOvVaw216houodGjR-03fVO552gj)\] ruby crash in rb\_gc\_mark
-
-- ## \[Bug [#13548](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13548&sa=D&source=editors&ust=1686087184905334&usg=AOvVaw2e7oo7kRI3i4HURpxAlppb)\] miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
-
-- ## \[Bug [#13555](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13555&sa=D&source=editors&ust=1686087184905672&usg=AOvVaw3os2StQA6bZbMG9f_yTbwM)\] Disable TestTrace#test\_trace\_stackoverflow
-
-- ## \[Bug [#13557](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13557&sa=D&source=editors&ust=1686087184906024&usg=AOvVaw07BpTjse2I4tatsCgyXDOT)\] there's no way to pass backtrace locations as a massaged backtrace
-
-- ## \[Bug [#10290](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10290&sa=D&source=editors&ust=1686087184906356&usg=AOvVaw2wp1u4a8-HWNT9tZKdtpIJ)\] segfault when calling a lambda recursively after rescuing SystemStackError
+- Previous bugs that were not assigned (shyouhei)
 
 
-- ## Fix confirmed?
+## \[Bug [#13196](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13196&sa=D&source=editors&ust=1686087184898244&usg=AOvVaw2s9kAK_W1dClDf6-K_fI5S)\] Improve keyword argument errors when non-keyword arguments given
+
+## \[Bug [#13320](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13320&sa=D&source=editors&ust=1686087184898590&usg=AOvVaw0aF6yt42Xx2uNx1-w2qjwI)\] rescue blocks get an entry in backtrace locations
+
+## \[Bug [#13336](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13336&sa=D&source=editors&ust=1686087184898914&usg=AOvVaw2xD22Y6Etgd6P1c6GQNaR3)\] Default Parameters don't work
+
+## \[Bug [#13337](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13337&sa=D&source=editors&ust=1686087184899255&usg=AOvVaw2ujMtb45viBHo_OAOKh5pU)\] Eval and Later Defined Local Variables
+
+## \[Bug [#13350](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13350&sa=D&source=editors&ust=1686087184899627&usg=AOvVaw0Y37tTZsLOSHz6PvnlXlYT)\] File.read :newline option not respected on Linux
+
+## \[Bug [#13373](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13373&sa=D&source=editors&ust=1686087184899976&usg=AOvVaw0iPn3ks7iHAVt-YCOzHRr5)\] FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
+
+## \[Bug [#13101](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13101&sa=D&source=editors&ust=1686087184900315&usg=AOvVaw0kLgayEfaLiOOFxoiHOKLQ)\] Date#rfc2822 and Time#rfc2822 don't return the same format
+
+## \[Bug [#12684](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12684&sa=D&source=editors&ust=1686087184900653&usg=AOvVaw2qHpzrmz4YU_aecfWQDLKQ)\] Delegator#eql? missing
+
+## \[Feature [#13389](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13389&sa=D&source=editors&ust=1686087184900993&usg=AOvVaw0dSpBqNXGYJqsQaEz9JdUx)\] \[PATCH\] POP3 support timeout for TLS handshake
+
+## \[Bug [#13404](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13404&sa=D&source=editors&ust=1686087184901373&usg=AOvVaw1jNhbQ54aLoDrwfGpR0nMU)\] Hash#any? yields arguments to lambdas with proc semantics
+
+## \[Bug [#13413](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13413&sa=D&source=editors&ust=1686087184901778&usg=AOvVaw0MUJmkOc2xjZzFAarrHnzv)\] --with-static-linked-ext doesn't install extension files on make install
+
+## \[Bug [#13429](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13429&sa=D&source=editors&ust=1686087184902166&usg=AOvVaw2vUhYc__TmQwFvAFvik40b)\] Net::SMTP has no read timeout when connexion over TLS
+
+## \[Bug [#13432](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13432&sa=D&source=editors&ust=1686087184902515&usg=AOvVaw0VhpLLckIFymF7S_SOKHGa)\] set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
+
+## \[Bug [#13446](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13446&sa=D&source=editors&ust=1686087184902866&usg=AOvVaw2dccQS0f2yC7sz0PBrfNuW)\] refinements with prepend for module has strange behavior
+
+## \[Bug [#13498](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13498&sa=D&source=editors&ust=1686087184903292&usg=AOvVaw1ofZUaZcw3yXfctIvzI_f5)\] Weakref, Weakmap and define\_finalizer don't work on frozen objects
+
+## \[Bug [#13513](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13513&sa=D&source=editors&ust=1686087184903638&usg=AOvVaw3AnkJPxJEaO4T3Fhaey05W)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
+
+## \[Bug [#13501](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13501&sa=D&source=editors&ust=1686087184903981&usg=AOvVaw0dGD3hZmpaJAHSLzIgyqOq)\] Process.kill behaviour for negative pid is not documented and may be wrong
+
+## \[Bug [#13515](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13515&sa=D&source=editors&ust=1686087184904325&usg=AOvVaw0639yqnZnSpsBlbTs0kC-X)\] Pathname#join doesn't add separator on UNC paths
+
+## \[Bug [#13521](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13521&sa=D&source=editors&ust=1686087184904666&usg=AOvVaw2DI9jgBeqgpGn2F2Iz9ZnX)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
+
+## \[Bug [#13537](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13537&sa=D&source=editors&ust=1686087184904990&usg=AOvVaw216houodGjR-03fVO552gj)\] ruby crash in rb\_gc\_mark
+
+## \[Bug [#13548](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13548&sa=D&source=editors&ust=1686087184905334&usg=AOvVaw2e7oo7kRI3i4HURpxAlppb)\] miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
+
+## \[Bug [#13555](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13555&sa=D&source=editors&ust=1686087184905672&usg=AOvVaw3os2StQA6bZbMG9f_yTbwM)\] Disable TestTrace#test\_trace\_stackoverflow
+
+## \[Bug [#13557](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13557&sa=D&source=editors&ust=1686087184906024&usg=AOvVaw07BpTjse2I4tatsCgyXDOT)\] there's no way to pass backtrace locations as a massaged backtrace
+
+## \[Bug [#10290](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10290&sa=D&source=editors&ust=1686087184906356&usg=AOvVaw2wp1u4a8-HWNT9tZKdtpIJ)\] segfault when calling a lambda recursively after rescuing SystemStackError
+
+
+- Fix confirmed?
 
 - nobu: the variant of setjmp seems to be the root cause.  The proposed workaround works, but may impact performance.  We have to measure before changing the default.
 
-- ## \[Feature [#10674](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10674&sa=D&source=editors&ust=1686087184906916&usg=AOvVaw3SUSEjy1EaXpxSgy3xSxyo)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
+## \[Feature [#10674](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10674&sa=D&source=editors&ust=1686087184906916&usg=AOvVaw3SUSEjy1EaXpxSgy3xSxyo)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
 
-- ## \[Bug [#13542](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13542&sa=D&source=editors&ust=1686087184907304&usg=AOvVaw2XWXtg-WuS09dTI9it5xU1)\] MinGW trunk Builds - Summary of Issues
-
-
-- ## \[Bug [#13549](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13549&sa=D&source=editors&ust=1686087184907658&usg=AOvVaw3kIWSVox5-bKH-9eTSWyGr)\] MinGW / Windows encoding - Two issues
-
-- ## \[Bug [#13556](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13556&sa=D&source=editors&ust=1686087184907991&usg=AOvVaw1g8diUekmroHrffreje6hN)\] MinGW readline Alt / Meta keys
-
-- ## \[Bug [#13569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13569&sa=D&source=editors&ust=1686087184908312&usg=AOvVaw276LVEhPv68k00UZ8QN46G)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+## \[Bug [#13542](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13542&sa=D&source=editors&ust=1686087184907304&usg=AOvVaw2XWXtg-WuS09dTI9it5xU1)\] MinGW trunk Builds - Summary of Issues
 
 
-- ## \[Bug [#13564](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13564&sa=D&source=editors&ust=1686087184908648&usg=AOvVaw0k8Swo5B7C6Dl_IFoZ-QRJ)\] Exception message management
+## \[Bug [#13549](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13549&sa=D&source=editors&ust=1686087184907658&usg=AOvVaw3kIWSVox5-bKH-9eTSWyGr)\] MinGW / Windows encoding - Two issues
+
+## \[Bug [#13556](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13556&sa=D&source=editors&ust=1686087184907991&usg=AOvVaw1g8diUekmroHrffreje6hN)\] MinGW readline Alt / Meta keys
+
+## \[Bug [#13569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13569&sa=D&source=editors&ust=1686087184908312&usg=AOvVaw276LVEhPv68k00UZ8QN46G)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+
+
+## \[Bug [#13564](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13564&sa=D&source=editors&ust=1686087184908648&usg=AOvVaw0k8Swo5B7C6Dl_IFoZ-QRJ)\] Exception message management
 
 
 ## From attendees
 
-- ## \[Bug [#12159](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12159&sa=D&source=editors&ust=1686087184909106&usg=AOvVaw14r73bZdmJllJm8eG3zqKP)\] Thread::Backtrace::Location#path returns absolute path for files loaded by require\_relative (ko1)
+## \[Bug [#12159](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12159&sa=D&source=editors&ust=1686087184909106&usg=AOvVaw14r73bZdmJllJm8eG3zqKP)\] Thread::Backtrace::Location#path returns absolute path for files loaded by require\_relative (ko1)
 
 
 - ko1: I want to add Thread::Backtrace::Location#realpath to deprecate #absplute\_path instead.
 - matz: no objection.
 
-- ## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087184909602&usg=AOvVaw3rADmKR6FcB1SuxI2rcT-5)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
+## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087184909602&usg=AOvVaw3rADmKR6FcB1SuxI2rcT-5)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
 
 - \[Bug [#13576](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13576&sa=D&source=editors&ust=1686087184909934&usg=AOvVaw1b5uOl23_juIpxUJaHDZpt)\] File#to\_path shall be deleted (shyouhei)
 
@@ -304,7 +304,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Write your name and your interest (what do you want to ask and to whom?) please.
 
-- ## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087184910659&usg=AOvVaw1G8dM5_WXvz1jRn3bJCqOH)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (normalperson)
+## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087184910659&usg=AOvVaw1G8dM5_WXvz1jRn3bJCqOH)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (normalperson)
 
 
 - ko1: programmers transfer execution of fibers by hand.  Eric proposes to introduce “auto”-Fiber which are OK to transfer each other on blocking situations. His implementation is great. rb\_wait\_for\_single\_fd is the ponit of switching. matz wanted this feature, too.
@@ -321,12 +321,12 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: is it OK for you to accept Eric’s proposal as-is?
 - matz: I’m positive, but I know your concern so I won’t accept right now.
 
-- ## \[Feature [#12694](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12694&sa=D&source=editors&ust=1686087184912007&usg=AOvVaw0_w94BMBmN-E2kPUSFzcnD)\] Want a String method to remove heading substr.
+## \[Feature [#12694](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12694&sa=D&source=editors&ust=1686087184912007&usg=AOvVaw0_w94BMBmN-E2kPUSFzcnD)\] Want a String method to remove heading substr.
 
 
-- ## (sonots) I implemented with a name String#remove\_prefix. If the name is ok, I want to merge it. Matz, could you decide? There were other candidates such as lchomp, trim\_prefix. I dropped trim\_prefix because trim is used to remove a list of characters rather than a substring in some languages, so I felt trim\_prefix would raise confusion. I dropped lchomp because I just had never heard.
+- (sonots) I implemented with a name String#remove\_prefix. If the name is ok, I want to merge it. Matz, could you decide? There were other candidates such as lchomp, trim\_prefix. I dropped trim\_prefix because trim is used to remove a list of characters rather than a substring in some languages, so I felt trim\_prefix would raise confusion. I dropped lchomp because I just had never heard.
 
-- ## candidates discussed:
+- candidates discussed:
 
 
 - lchomp

--- a/2017/DevMeeting-2017-07-14.md
+++ b/2017/DevMeeting-2017-07-14.md
@@ -160,7 +160,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 # About 2.5 timeframe
 
-- # [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087205332186&usg=AOvVaw2hCtA_7P-leo4qLTdg0RKR)
+# [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087205332186&usg=AOvVaw2hCtA_7P-leo4qLTdg0RKR)
 
 
 - naruse: I’ll release PR1 at the end of this month
@@ -171,16 +171,16 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-- ## \[Feature [#13512](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13512&sa=D&source=editors&ust=1686087205333390&usg=AOvVaw1oRkAAHGIMfzkaxBA5tF1P)\] System Threads (shyouhei)
+## \[Feature [#13512](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13512&sa=D&source=editors&ust=1686087205333390&usg=AOvVaw1oRkAAHGIMfzkaxBA5tF1P)\] System Threads (shyouhei)
 
 
 - ko1: I don’t like this idea.  I don’t want more states over a Thread.
 - matz: I feel needs of more explainations.
 
-- ## Previous bugs that were not assigned (shyouhei)
+- Previous bugs that were not assigned (shyouhei)
 
 
-- ## \[Bug [#13350](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13350&sa=D&source=editors&ust=1686087205334279&usg=AOvVaw3juizL8nSXxN-kJSJsagco)\] File.read :newline option not respected on Linux
+## \[Bug [#13350](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13350&sa=D&source=editors&ust=1686087205334279&usg=AOvVaw3juizL8nSXxN-kJSJsagco)\] File.read :newline option not respected on Linux
 
 
 - nobu: on Linux we have to explicitly set text mode.
@@ -188,88 +188,88 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - nobu: then we should automatically assume text mode when newline: is specified.
 - matz: make it so,
 
-- ## \[Feature [#13389](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13389&sa=D&source=editors&ust=1686087205335100&usg=AOvVaw3v0mN0f6Lf6PFN4W2sxvTb)\] \[PATCH\] POP3 support timeout for TLS handshake
+## \[Feature [#13389](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13389&sa=D&source=editors&ust=1686087205335100&usg=AOvVaw3v0mN0f6Lf6PFN4W2sxvTb)\] \[PATCH\] POP3 support timeout for TLS handshake
 
 
 - hsbt: pop3 has no maintainer.
 - naruse: maybe shugo can review the patch?
 
-- ## \[Bug [#13404](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13404&sa=D&source=editors&ust=1686087205335718&usg=AOvVaw1nkGRmSqoGbvH7O52oIy-K)\] Hash#any? yields arguments to lambdas with proc semantics
+## \[Bug [#13404](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13404&sa=D&source=editors&ust=1686087205335718&usg=AOvVaw1nkGRmSqoGbvH7O52oIy-K)\] Hash#any? yields arguments to lambdas with proc semantics
 
 
 - assign ko1
 - cf: #13391
 
-- ## \[Bug [#13429](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13429&sa=D&source=editors&ust=1686087205336384&usg=AOvVaw1I2954ufU_K5cWL38BAryE)\] Net::SMTP has no read timeout when connexion over TLS
+## \[Bug [#13429](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13429&sa=D&source=editors&ust=1686087205336384&usg=AOvVaw1I2954ufU_K5cWL38BAryE)\] Net::SMTP has no read timeout when connexion over TLS
 
 
 - should be closed so that usa can be aware of it.
 
-- ## \[Bug [#13513](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13513&sa=D&source=editors&ust=1686087205336834&usg=AOvVaw1Cu-1QET4rWRRqFiQOrFm4)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
+## \[Bug [#13513](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13513&sa=D&source=editors&ust=1686087205336834&usg=AOvVaw1Cu-1QET4rWRRqFiQOrFm4)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
 
 
 - assign akr
 
-- ## \[Bug [#13501](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13501&sa=D&source=editors&ust=1686087205337383&usg=AOvVaw0GuXcpAo0Ebz1EpK8XkqTU)\] Process.kill behaviour for negative pid is not documented and may be wrong
+## \[Bug [#13501](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13501&sa=D&source=editors&ust=1686087205337383&usg=AOvVaw0GuXcpAo0Ebz1EpK8XkqTU)\] Process.kill behaviour for negative pid is not documented and may be wrong
 
 
 - shyouhei: doc issue?
 - akr: we take negative signal or negative pids.  signal.c:rb\_f\_kill() has special codes for negative signals but not for negative pids.
 - akr: what happens both signal and pid are negative?
 
-- ## \[Bug [#13521](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13521&sa=D&source=editors&ust=1686087205338050&usg=AOvVaw1eQ0bi0LlDCSzROTH9isY6)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
+## \[Bug [#13521](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13521&sa=D&source=editors&ust=1686087205338050&usg=AOvVaw1eQ0bi0LlDCSzROTH9isY6)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
 
 
 - nobu: 3rd party issue?
 
-- ## \[Bug [#13557](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13557&sa=D&source=editors&ust=1686087205338680&usg=AOvVaw2FR90c_szr8-PzUmvukYec)\] there's no way to pass backtrace locations as a massaged backtrace
+## \[Bug [#13557](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13557&sa=D&source=editors&ust=1686087205338680&usg=AOvVaw2FR90c_szr8-PzUmvukYec)\] there's no way to pass backtrace locations as a massaged backtrace
 
 
 - nobu: I have to discuss this with ko1.
 
-- ## \[Feature [#10674](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10674&sa=D&source=editors&ust=1686087205339166&usg=AOvVaw1_hrNOdQhCLc08nbykFIyk)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
+## \[Feature [#10674](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10674&sa=D&source=editors&ust=1686087205339166&usg=AOvVaw1_hrNOdQhCLc08nbykFIyk)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
 
 
 - assign naruse
 
-- ## \[Bug [#13542](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13542&sa=D&source=editors&ust=1686087205339788&usg=AOvVaw3sL5x0vSW7sqIvyWzVSM5s)\] MinGW trunk Builds - Summary of Issues
+## \[Bug [#13542](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13542&sa=D&source=editors&ust=1686087205339788&usg=AOvVaw3sL5x0vSW7sqIvyWzVSM5s)\] MinGW trunk Builds - Summary of Issues
 
 
-- ## \[Bug [#13549](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13549&sa=D&source=editors&ust=1686087205340197&usg=AOvVaw2hWJh5jaIsHVLvV-5rec34)\] MinGW / Windows encoding - Two issues
+## \[Bug [#13549](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13549&sa=D&source=editors&ust=1686087205340197&usg=AOvVaw2hWJh5jaIsHVLvV-5rec34)\] MinGW / Windows encoding - Two issues
 
-- ## \[Bug [#13556](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13556&sa=D&source=editors&ust=1686087205340605&usg=AOvVaw1R3JyV1EhQRvB1mXD-9JkK)\] MinGW readline Alt / Meta keys
+## \[Bug [#13556](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13556&sa=D&source=editors&ust=1686087205340605&usg=AOvVaw1R3JyV1EhQRvB1mXD-9JkK)\] MinGW readline Alt / Meta keys
 
-- ## \[Bug [#13569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13569&sa=D&source=editors&ust=1686087205340978&usg=AOvVaw1ePy4_g8xpOQ77PtddT4ht)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+## \[Bug [#13569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13569&sa=D&source=editors&ust=1686087205340978&usg=AOvVaw1ePy4_g8xpOQ77PtddT4ht)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
 
 - \-----
 - nobu: I cannot reproduce these problems.
 - shyouhei: It seems the reporter is not eligible to fix them.
 - hsbt: I made an environment so I’ll see if they reproduce.
 
-- ## \[Bug [#13564](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13564&sa=D&source=editors&ust=1686087205341613&usg=AOvVaw2iT4c51EJv_LfWMTxY7kjI)\] Exception message management
+## \[Bug [#13564](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13564&sa=D&source=editors&ust=1686087205341613&usg=AOvVaw2iT4c51EJv_LfWMTxY7kjI)\] Exception message management
 
 
 - matz I understand that it breaks encapsulation \_by theory\_, but in practice is it worth, for instance, duplicate every time?
 
 ## From attendees
 
-- ## \[Bug #13737\] "can't modify frozen String" when installing bundled gems (ko1)
+## \[Bug #13737\] "can't modify frozen String" when installing bundled gems (ko1)
 
 
 - should what happen for tainted string?
 - ko1: it seems there is string.c:fstring\_cmp.  Can’t we change this function?
 
-- ## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087205342542&usg=AOvVaw1SJPEKUC1GyYKSwAaA7a7R)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087205342542&usg=AOvVaw1SJPEKUC1GyYKSwAaA7a7R)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
 
 
 - akr: Socket to DB would normally be pooled / shared among threads in normal web applications.  There shall be some locking mechanism to do so.
 
-- ## \[Feature [#13583](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13583&sa=D&source=editors&ust=1686087205343077&usg=AOvVaw0NERbGFoTuSDgQDiHLrX8c)\] Adding Hash#transform\_keys method (shyouhei)
+## \[Feature [#13583](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13583&sa=D&source=editors&ust=1686087205343077&usg=AOvVaw0NERbGFoTuSDgQDiHLrX8c)\] Adding Hash#transform\_keys method (shyouhei)
 
 
 - matz: seems OK.
 
-- ## \[Feature [#12589](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12589&sa=D&source=editors&ust=1686087205343574&usg=AOvVaw3OnEyP0awwJxgjvtxhL4BW)\] VM performance improvement proposal (shyouhei)
+## \[Feature [#12589](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12589&sa=D&source=editors&ust=1686087205343574&usg=AOvVaw3OnEyP0awwJxgjvtxhL4BW)\] VM performance improvement proposal (shyouhei)
 
 
 - akr: is it OK for people to have C compilers in their production environment?
@@ -277,7 +277,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: I think scheme compilers tends to transpile into C.
 - matz: I like this idea itself.
 
-- ## \[Feature [#13676](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13676&sa=D&source=editors&ust=1686087205344473&usg=AOvVaw12roiV9BIxWJ1mKmHfJbvv)\] to\_s method is not overriden for Set (shyouhei)
+## \[Feature [#13676](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13676&sa=D&source=editors&ust=1686087205344473&usg=AOvVaw12roiV9BIxWJ1mKmHfJbvv)\] to\_s method is not overriden for Set (shyouhei)
 
 
 - assign knu
@@ -286,75 +286,75 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - knu: is it OK to call inspect?
 - matz: OK.
 
-- ## \[Feature [#10771](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10771&sa=D&source=editors&ust=1686087205345230&usg=AOvVaw0t3sWBC1vtd8g_FyrBpF6i)\] An easy way to get the source location of a constant (shyouhei)
+## \[Feature [#10771](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10771&sa=D&source=editors&ust=1686087205345230&usg=AOvVaw0t3sWBC1vtd8g_FyrBpF6i)\] An easy way to get the source location of a constant (shyouhei)
 
 
 - nobu: we already maintain constant source locations for redefinition warnings.
 
-- ## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087205345685&usg=AOvVaw1WkrfwQvIzMMj8OwICC6iY)\] better method definition in C API (shyouhei)
+## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087205345685&usg=AOvVaw1WkrfwQvIzMMj8OwICC6iY)\] better method definition in C API (shyouhei)
 
 
 - ko1: is it convenient for you to show backtrace of C methods?
 - akr: do we have to know that info?
 - naruse: I have wanted C level stack trace for a long time.
 
-- ## bugs that are not assigned (shyouhei)
+- bugs that are not assigned (shyouhei)
 
 
-- ## \[Bug [#13586](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13586&sa=D&source=editors&ust=1686087205346586&usg=AOvVaw2aRUKF8aDoR3DdqbrkFyKM)\] Ruby hangs when accessing array which is modified in instance\_eval after Coverage.start
+## \[Bug [#13586](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13586&sa=D&source=editors&ust=1686087205346586&usg=AOvVaw2aRUKF8aDoR3DdqbrkFyKM)\] Ruby hangs when accessing array which is modified in instance\_eval after Coverage.start
 
 
 - assign nobu
 - nobu: seems 2.5 is not affected.
 
-- ## \[Bug [#13574](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13574&sa=D&source=editors&ust=1686087205347076&usg=AOvVaw2KRQgpczmOqexg2QBovB80)\] Method redefinition warning
+## \[Bug [#13574](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13574&sa=D&source=editors&ust=1686087205347076&usg=AOvVaw2KRQgpczmOqexg2QBovB80)\] Method redefinition warning
 
 
 - akira: is it OK that we say this is the right way to suppress warning?
 - matz: reject.
 
-- ## \[Bug [#13616](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13616&sa=D&source=editors&ust=1686087205347715&usg=AOvVaw3smcBPrJD3MRheCx9MdXmU)\] Zlib::GzipReader#pos underflows after calling #ungetbyte or #ungetc at start of file
+## \[Bug [#13616](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13616&sa=D&source=editors&ust=1686087205347715&usg=AOvVaw3smcBPrJD3MRheCx9MdXmU)\] Zlib::GzipReader#pos underflows after calling #ungetbyte or #ungetc at start of file
 
 
 - naruse: I’ll merge this.
 
-- ## \[Bug [#13593](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13593&sa=D&source=editors&ust=1686087205348317&usg=AOvVaw0Pfq7mZWwZxH0Qc07XIvg1)\] Addrinfo#== behaves oddly
+## \[Bug [#13593](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13593&sa=D&source=editors&ust=1686087205348317&usg=AOvVaw0Pfq7mZWwZxH0Qc07XIvg1)\] Addrinfo#== behaves oddly
 
 
 - akr: it’s difficult by theory.
 
-- ## \[Bug [#13631](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13631&sa=D&source=editors&ust=1686087205348924&usg=AOvVaw0OoQkMmTTPx3dIMGgElO6q)\] Cannot disable site and vendor directories
+## \[Bug [#13631](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13631&sa=D&source=editors&ust=1686087205348924&usg=AOvVaw0OoQkMmTTPx3dIMGgElO6q)\] Cannot disable site and vendor directories
 
 
 - assign nobu
 
-- ## \[Bug [#13647](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13647&sa=D&source=editors&ust=1686087205349362&usg=AOvVaw2WJ_C4IabgIR8r-TtI50pd)\] Some weird behaviour with keyword arguments
+## \[Bug [#13647](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13647&sa=D&source=editors&ust=1686087205349362&usg=AOvVaw2WJ_C4IabgIR8r-TtI50pd)\] Some weird behaviour with keyword arguments
 
 
 - nobu: we can explain this behaviour.
 
-- ## \[Bug [#13649](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13649&sa=D&source=editors&ust=1686087205349808&usg=AOvVaw1WxeTUQkczA0AH-pxm48JZ)\] Net::IMAP doesn't support response from a Microsoft Exchange server (which is not compliant with RFC standards)
+## \[Bug [#13649](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13649&sa=D&source=editors&ust=1686087205349808&usg=AOvVaw1WxeTUQkczA0AH-pxm48JZ)\] Net::IMAP doesn't support response from a Microsoft Exchange server (which is not compliant with RFC standards)
 
 
 - assign shugo
 
-- ## \[Bug [#13654](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13654&sa=D&source=editors&ust=1686087205350187&usg=AOvVaw1AJZIFku61yPU6XwOG8f6z)\] irb save-history extension is not concurrency-safe
+## \[Bug [#13654](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13654&sa=D&source=editors&ust=1686087205350187&usg=AOvVaw1AJZIFku61yPU6XwOG8f6z)\] irb save-history extension is not concurrency-safe
 
 
 - akr: it’s same as shells.
 - assign keiju
 
-- ## \[Bug [#13655](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13655&sa=D&source=editors&ust=1686087205350664&usg=AOvVaw3gQmnkqeMXEkrVw2J5g3xk)\] external encoding named "-" (doc issue or…?)
+## \[Bug [#13655](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13655&sa=D&source=editors&ust=1686087205350664&usg=AOvVaw3gQmnkqeMXEkrVw2J5g3xk)\] external encoding named "-" (doc issue or…?)
 
 
 - naruse: doc issue.
 
-- ## \[Bug [#13660](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13660&sa=D&source=editors&ust=1686087205351069&usg=AOvVaw0hxXYQlLknRQ7P5abMgFfY)\] rb\_str\_hash\_m discards bits from the hash
+## \[Bug [#13660](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13660&sa=D&source=editors&ust=1686087205351069&usg=AOvVaw0hxXYQlLknRQ7P5abMgFfY)\] rb\_str\_hash\_m discards bits from the hash
 
 
 - akr: it’s intentional.
 
-- ## \[Bug [#13671](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13671&sa=D&source=editors&ust=1686087205351458&usg=AOvVaw3fPDCG-bxs-ltk9I2ZsIaM)\] Regexp with lookbehind and case-insensitivity raises RegexpError only on strings with certain characters
+## \[Bug [#13671](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13671&sa=D&source=editors&ust=1686087205351458&usg=AOvVaw3fPDCG-bxs-ltk9I2ZsIaM)\] Regexp with lookbehind and case-insensitivity raises RegexpError only on strings with certain characters
 
 
 - naruse: /(?<!ass)/iu is suffient to reproduce
@@ -366,7 +366,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - \=> nil
 - But I don't know the expected behavior.
 
-- ## \[Bug [#13735](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13735&sa=D&source=editors&ust=1686087205352246&usg=AOvVaw39fIfz4A5Jg6CiBMVLiO84)\] Initialization-error of sortedset
+## \[Bug [#13735](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13735&sa=D&source=editors&ust=1686087205352246&usg=AOvVaw39fIfz4A5Jg6CiBMVLiO84)\] Initialization-error of sortedset
 
 
 - assign knu
@@ -375,19 +375,19 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Write your name and your interest (what do you want to ask and to whom?) please.
 
-- ## \[Feature [#13666](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13666&sa=D&source=editors&ust=1686087205352871&usg=AOvVaw3Po-o362aVMKWIvFedFf0O)\] Allow to write specs instead of tests (nobody wants to write test code twice). (eregon)
+## \[Feature [#13666](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13666&sa=D&source=editors&ust=1686087205352871&usg=AOvVaw3Po-o362aVMKWIvFedFf0O)\] Allow to write specs instead of tests (nobody wants to write test code twice). (eregon)
 
 
 - Martin: Okay to me.
 - nobu: nobody disallows to write specs at the first place, do they?
 
-- ## \[Feature [#13665](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13665&sa=D&source=editors&ust=1686087205353342&usg=AOvVaw2wUqCkIJVzi2pQ2d0sIUHQ)\] Before I added String#delete\_prefix. For symmetry, is it okay to commit String#delete\_suffix? (sonots)
+## \[Feature [#13665](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13665&sa=D&source=editors&ust=1686087205353342&usg=AOvVaw2wUqCkIJVzi2pQ2d0sIUHQ)\] Before I added String#delete\_prefix. For symmetry, is it okay to commit String#delete\_suffix? (sonots)
 
 
 - shyouhei: should we add it?
 - matz: no objection.
 
-- ## \[Feature [#13743](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13743&sa=D&source=editors&ust=1686087205353899&usg=AOvVaw2f33NXuymDNo2g9nlJCe7g)\] Support linking of files opened with O\_TMPFILE (mmasaki)
+## \[Feature [#13743](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13743&sa=D&source=editors&ust=1686087205353899&usg=AOvVaw2f33NXuymDNo2g9nlJCe7g)\] Support linking of files opened with O\_TMPFILE (mmasaki)
 
 
 - nobu: File.link or File#link?

--- a/2017/DevMeeting-2017-08-31.md
+++ b/2017/DevMeeting-2017-08-31.md
@@ -175,7 +175,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 # About 2.5 timeframe
 
-- # [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087248437047&usg=AOvVaw1HOMVQwc0SAHj_rXp4stDU)
+# [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087248437047&usg=AOvVaw1HOMVQwc0SAHj_rXp4stDU)
 
 
 - naruse: I’ll release PR1 after stable releases are published
@@ -190,245 +190,245 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-- ## \[Feature [#13396](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13396&sa=D&source=editors&ust=1686087248439334&usg=AOvVaw3-fGaFhcM2KlhY_y_L2yuy)\] Net::HTTP has no write timeout (shyouhei)
+## \[Feature [#13396](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13396&sa=D&source=editors&ust=1686087248439334&usg=AOvVaw3-fGaFhcM2KlhY_y_L2yuy)\] Net::HTTP has no write timeout (shyouhei)
 
-- ## \[Bug [#13407](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13407&sa=D&source=editors&ust=1686087248439873&usg=AOvVaw2YJTo3FZIqnKNjwQOuq03Q)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+## \[Bug [#13407](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13407&sa=D&source=editors&ust=1686087248439873&usg=AOvVaw2YJTo3FZIqnKNjwQOuq03Q)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
 
-- ## \[Feature [#13395](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13395&sa=D&source=editors&ust=1686087248440342&usg=AOvVaw15bBEqC1LdFOmjjgeNdFCE)\] Add a method to check for not nil (shyouhei)
+## \[Feature [#13395](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13395&sa=D&source=editors&ust=1686087248440342&usg=AOvVaw15bBEqC1LdFOmjjgeNdFCE)\] Add a method to check for not nil (shyouhei)
 
-- ## \[Feature [#13516](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13516&sa=D&source=editors&ust=1686087248440777&usg=AOvVaw3KgdfA_xrkmWCH_Kl-cyf1)\] Improve the text of the circular require warning (shyouhei)
+## \[Feature [#13516](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13516&sa=D&source=editors&ust=1686087248440777&usg=AOvVaw3KgdfA_xrkmWCH_Kl-cyf1)\] Improve the text of the circular require warning (shyouhei)
 
-- ## \[Feature [#13532](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13532&sa=D&source=editors&ust=1686087248441257&usg=AOvVaw3IT9ett_AF2-6HhMt89leR)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
+## \[Feature [#13532](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13532&sa=D&source=editors&ust=1686087248441257&usg=AOvVaw3IT9ett_AF2-6HhMt89leR)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
 
-- ## \[Bug [#13535](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13535&sa=D&source=editors&ust=1686087248441745&usg=AOvVaw0vy26BeKZLtlUF8IIYh3vg)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
+## \[Bug [#13535](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13535&sa=D&source=editors&ust=1686087248441745&usg=AOvVaw0vy26BeKZLtlUF8IIYh3vg)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
 
-- ## \[Feature [#13568](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13568&sa=D&source=editors&ust=1686087248442162&usg=AOvVaw1VboLQX9rbkfJAGwfgVo2f)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
+## \[Feature [#13568](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13568&sa=D&source=editors&ust=1686087248442162&usg=AOvVaw1VboLQX9rbkfJAGwfgVo2f)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
 
 
 - raising exception
 
-- ## \[Feature [#13563](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13563&sa=D&source=editors&ust=1686087248442744&usg=AOvVaw3YrUc0niTfCDFtcDvRHz2F)\] Implement Hash#choice method. (shyouhei)
+## \[Feature [#13563](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13563&sa=D&source=editors&ust=1686087248442744&usg=AOvVaw3YrUc0niTfCDFtcDvRHz2F)\] Implement Hash#choice method. (shyouhei)
 
 
 - naming issue.
 
-- ## \[Feature [#13581](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13581&sa=D&source=editors&ust=1686087248443476&usg=AOvVaw3nIE35NNPirRuIshiXu_DL)\] Syntax sugar for method reference (shyouhei)
+## \[Feature [#13581](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13581&sa=D&source=editors&ust=1686087248443476&usg=AOvVaw3nIE35NNPirRuIshiXu_DL)\] Syntax sugar for method reference (shyouhei)
 
 
 - naming issue.
 
-- ## \[Bug [#13438](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13438&sa=D&source=editors&ust=1686087248444216&usg=AOvVaw1jHe1RISZwwWs-q6Xe-6Me)\] Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei)
+## \[Bug [#13438](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13438&sa=D&source=editors&ust=1686087248444216&usg=AOvVaw1jHe1RISZwwWs-q6Xe-6Me)\] Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei)
 
-- ## \[Misc [#12529](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12529&sa=D&source=editors&ust=1686087248444865&usg=AOvVaw2nHZ2tKp-38XzFDO_a2Y5C)\] LEGAL file covering all the license information within Ruby (shyouhei)
+## \[Misc [#12529](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12529&sa=D&source=editors&ust=1686087248444865&usg=AOvVaw2nHZ2tKp-38XzFDO_a2Y5C)\] LEGAL file covering all the license information within Ruby (shyouhei)
 
-- ## \[Feature [#13600](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13600&sa=D&source=editors&ust=1686087248445352&usg=AOvVaw0A_SwByifBGUtYSrNOeMV8)\] yield\_self should be chainable/composable (shyouhei)
+## \[Feature [#13600](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13600&sa=D&source=editors&ust=1686087248445352&usg=AOvVaw0A_SwByifBGUtYSrNOeMV8)\] yield\_self should be chainable/composable (shyouhei)
 
-- ## \[Misc [#13597](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13597&sa=D&source=editors&ust=1686087248445756&usg=AOvVaw2jMQLGDP5S0STVkMhmKUMf)\] Does read\_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
+## \[Misc [#13597](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13597&sa=D&source=editors&ust=1686087248445756&usg=AOvVaw2jMQLGDP5S0STVkMhmKUMf)\] Does read\_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
 
-- ## \[Feature [#13606](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13606&sa=D&source=editors&ust=1686087248446232&usg=AOvVaw2TRN4qpIthl4bX42-KtntP)\] Enumerator equality and comparison (shyouhei)
+## \[Feature [#13606](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13606&sa=D&source=editors&ust=1686087248446232&usg=AOvVaw2TRN4qpIthl4bX42-KtntP)\] Enumerator equality and comparison (shyouhei)
 
-- ## \[Feature [#13604](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13604&sa=D&source=editors&ust=1686087248446747&usg=AOvVaw0orG4YS8WpJkN7Q0SL2gXJ)\] Exposing alternative interface of readline (shyouhei)
+## \[Feature [#13604](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13604&sa=D&source=editors&ust=1686087248446747&usg=AOvVaw0orG4YS8WpJkN7Q0SL2gXJ)\] Exposing alternative interface of readline (shyouhei)
 
 - \-----
-- ## \[Feature [#13608](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13608&sa=D&source=editors&ust=1686087248447468&usg=AOvVaw2jNbM2WcIRAe9NpU71Fryy)\] Add TracePoint#thread (shyouhei)
+## \[Feature [#13608](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13608&sa=D&source=editors&ust=1686087248447468&usg=AOvVaw2jNbM2WcIRAe9NpU71Fryy)\] Add TracePoint#thread (shyouhei)
 
-- ## \[Feature [#13602](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13602&sa=D&source=editors&ust=1686087248448071&usg=AOvVaw1ZOTzKNoPx16A5oh3aefn-)\] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
+## \[Feature [#13602](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13602&sa=D&source=editors&ust=1686087248448071&usg=AOvVaw1ZOTzKNoPx16A5oh3aefn-)\] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
 
-- ## \[Feature [#13613](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13613&sa=D&source=editors&ust=1686087248448609&usg=AOvVaw3JBka6kTJEYPs0oZnsn6Pb)\] Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
+## \[Feature [#13613](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13613&sa=D&source=editors&ust=1686087248448609&usg=AOvVaw3JBka6kTJEYPs0oZnsn6Pb)\] Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
 
-- ## \[Feature [#13620](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13620&sa=D&source=editors&ust=1686087248449144&usg=AOvVaw1fkEA2It7SAksl0tB_WzCy)\] Simplifying MRI's build system: always install (shyouhei)
+## \[Feature [#13620](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13620&sa=D&source=editors&ust=1686087248449144&usg=AOvVaw1fkEA2It7SAksl0tB_WzCy)\] Simplifying MRI's build system: always install (shyouhei)
 
-- ## \[Feature [#13630](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13630&sa=D&source=editors&ust=1686087248449767&usg=AOvVaw0bNJAu9TH9TuPcI4Dn8Xfj)\] :\[\] method should accept block in nice syntax (shyouhei)
+## \[Feature [#13630](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13630&sa=D&source=editors&ust=1686087248449767&usg=AOvVaw0bNJAu9TH9TuPcI4Dn8Xfj)\] :\[\] method should accept block in nice syntax (shyouhei)
 
-- ## \[Feature [#13639](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13639&sa=D&source=editors&ust=1686087248450388&usg=AOvVaw0tiWUZScGHyqj-9S5q7tjj)\] Add "RTMIN" and "RTMAX" to Signal.list (shyouhei)
+## \[Feature [#13639](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13639&sa=D&source=editors&ust=1686087248450388&usg=AOvVaw0tiWUZScGHyqj-9S5q7tjj)\] Add "RTMIN" and "RTMAX" to Signal.list (shyouhei)
 
-- ## \[Feature [#11484](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11484&sa=D&source=editors&ust=1686087248450964&usg=AOvVaw2zndrSGKl9iuSAbTzb0j8V)\] add output offset for readpartial/read\_nonblock/etc (shyouhei)
+## \[Feature [#11484](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11484&sa=D&source=editors&ust=1686087248450964&usg=AOvVaw2zndrSGKl9iuSAbTzb0j8V)\] add output offset for readpartial/read\_nonblock/etc (shyouhei)
 
-- ## \[Feature [#9001](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9001&sa=D&source=editors&ust=1686087248451532&usg=AOvVaw1ZzGRPzSEjpGRoZNKpWgIz)\] Please package better standard library (shyouhei)
+## \[Feature [#9001](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9001&sa=D&source=editors&ust=1686087248451532&usg=AOvVaw1ZzGRPzSEjpGRoZNKpWgIz)\] Please package better standard library (shyouhei)
 
-- ## \[Feature [#13563](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13563&sa=D&source=editors&ust=1686087248452162&usg=AOvVaw2_wyOEoPiEtjBVRs0-kuU2)\] Implement Hash#choice method. (shyouhei)
+## \[Feature [#13563](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13563&sa=D&source=editors&ust=1686087248452162&usg=AOvVaw2_wyOEoPiEtjBVRs0-kuU2)\] Implement Hash#choice method. (shyouhei)
 
-- ## \[Feature [#12533](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12533&sa=D&source=editors&ust=1686087248452789&usg=AOvVaw23wc-w7X07v2deCmSCs-Re)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
+## \[Feature [#12533](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12533&sa=D&source=editors&ust=1686087248452789&usg=AOvVaw23wc-w7X07v2deCmSCs-Re)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
 
-- ## \[Feature [#13653](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13653&sa=D&source=editors&ust=1686087248453393&usg=AOvVaw3zsDISNcIvPs8gk-pd_916)\] Bundled zlib helper (shyouhei)
+## \[Feature [#13653](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13653&sa=D&source=editors&ust=1686087248453393&usg=AOvVaw3zsDISNcIvPs8gk-pd_916)\] Bundled zlib helper (shyouhei)
 
-- ## \[Feature [#13626](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13626&sa=D&source=editors&ust=1686087248454018&usg=AOvVaw3Ce8Gtwfhje739UgE44RN9)\] Add String#byteslice! (shyouhei)
+## \[Feature [#13626](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13626&sa=D&source=editors&ust=1686087248454018&usg=AOvVaw3Ce8Gtwfhje739UgE44RN9)\] Add String#byteslice! (shyouhei)
 
-- ## \[Feature [#13551](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13551&sa=D&source=editors&ust=1686087248454548&usg=AOvVaw2fUsOzfvSiLoqDMbLQTfba)\] Add a method to alias class methods (shyouhei)
+## \[Feature [#13551](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13551&sa=D&source=editors&ust=1686087248454548&usg=AOvVaw2fUsOzfvSiLoqDMbLQTfba)\] Add a method to alias class methods (shyouhei)
 
-- ## \[Feature [#13332](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13332&sa=D&source=editors&ust=1686087248455086&usg=AOvVaw2_kF4dBUP-dkmC3huyOfBF)\] Forwardable#def\_instance\_delegator nil (shyouhei)
+## \[Feature [#13332](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13332&sa=D&source=editors&ust=1686087248455086&usg=AOvVaw2_kF4dBUP-dkmC3huyOfBF)\] Forwardable#def\_instance\_delegator nil (shyouhei)
 
-- ## \[Feature [#13378](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13378&sa=D&source=editors&ust=1686087248455762&usg=AOvVaw1P18CD0ALL6o4sYqXgpml_)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+## \[Feature [#13378](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13378&sa=D&source=editors&ust=1686087248455762&usg=AOvVaw1P18CD0ALL6o4sYqXgpml_)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
 
-- ## \[Feature [#13381](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13381&sa=D&source=editors&ust=1686087248456346&usg=AOvVaw3meRHh_YiIEwgrIyfaIS_c)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## \[Feature [#13381](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13381&sa=D&source=editors&ust=1686087248456346&usg=AOvVaw3meRHh_YiIEwgrIyfaIS_c)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
 
-- ## \[Feature [#13677](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13677&sa=D&source=editors&ust=1686087248456833&usg=AOvVaw2a2pTFqaTvTrLzp-V1BLfy)\] Add more details to error "Name or service not known (SocketError)" (shyouhei)
+## \[Feature [#13677](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13677&sa=D&source=editors&ust=1686087248456833&usg=AOvVaw2a2pTFqaTvTrLzp-V1BLfy)\] Add more details to error "Name or service not known (SocketError)" (shyouhei)
 
-- ## \[Feature [#9323](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9323&sa=D&source=editors&ust=1686087248457365&usg=AOvVaw3exATmD5NSic34DNxKCOCG)\] IO#writev (shyouhei)
+## \[Feature [#9323](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9323&sa=D&source=editors&ust=1686087248457365&usg=AOvVaw3exATmD5NSic34DNxKCOCG)\] IO#writev (shyouhei)
 
-- ## \[Feature [#13686](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13686&sa=D&source=editors&ust=1686087248457844&usg=AOvVaw1eu5nSkp5qy9x06PS1rsEj)\] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (shyouhei)
+## \[Feature [#13686](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13686&sa=D&source=editors&ust=1686087248457844&usg=AOvVaw1eu5nSkp5qy9x06PS1rsEj)\] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (shyouhei)
 
-- ## \[Feature [#13693](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13693&sa=D&source=editors&ust=1686087248458271&usg=AOvVaw2YqvbaRFRk0ikfCkgwlilt)\] Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
+## \[Feature [#13693](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13693&sa=D&source=editors&ust=1686087248458271&usg=AOvVaw2YqvbaRFRk0ikfCkgwlilt)\] Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
 
-- ## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087248458776&usg=AOvVaw3QYdt7mUmFcB0IN6-vxr48)\] better method definition in C API (shyouhei)
+## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087248458776&usg=AOvVaw3QYdt7mUmFcB0IN6-vxr48)\] better method definition in C API (shyouhei)
 
-- ## \[Feature [#13696](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13696&sa=D&source=editors&ust=1686087248459367&usg=AOvVaw3um9tviugUPTjiNSm4IcuB)\] Add exchange and noreplace options to File.rename (shyouhei)
+## \[Feature [#13696](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13696&sa=D&source=editors&ust=1686087248459367&usg=AOvVaw3um9tviugUPTjiNSm4IcuB)\] Add exchange and noreplace options to File.rename (shyouhei)
 
-- ## \[Feature [#13683](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13683&sa=D&source=editors&ust=1686087248459901&usg=AOvVaw0T1_1NuFRGDMwKrUlh28Or)\] Add strict Enumerable#single (shyouhei)
+## \[Feature [#13683](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13683&sa=D&source=editors&ust=1686087248459901&usg=AOvVaw0T1_1NuFRGDMwKrUlh28Or)\] Add strict Enumerable#single (shyouhei)
 
-- ## \[Misc [#13704](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13704&sa=D&source=editors&ust=1686087248460392&usg=AOvVaw1_bw6VlP6eSwoiz6gRkMdK)\] Exclude Changelog files from documentation. (shyouhei)
+## \[Misc [#13704](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13704&sa=D&source=editors&ust=1686087248460392&usg=AOvVaw1_bw6VlP6eSwoiz6gRkMdK)\] Exclude Changelog files from documentation. (shyouhei)
 
-- ## \[Feature [#13713](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13713&sa=D&source=editors&ust=1686087248460872&usg=AOvVaw1Bg8vHmN_Ps0m-YjQ2b87L)\] socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
+## \[Feature [#13713](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13713&sa=D&source=editors&ust=1686087248460872&usg=AOvVaw1Bg8vHmN_Ps0m-YjQ2b87L)\] socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
 
-- ## \[Feature [#13715](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13715&sa=D&source=editors&ust=1686087248461383&usg=AOvVaw2zD9Hkk_ExwqZ39JkVdwh8)\] \[PATCH\] avoid garbage from Symbol#to\_s in interpolation (shyouhei)
+## \[Feature [#13715](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13715&sa=D&source=editors&ust=1686087248461383&usg=AOvVaw2zD9Hkk_ExwqZ39JkVdwh8)\] \[PATCH\] avoid garbage from Symbol#to\_s in interpolation (shyouhei)
 
-- ## \[Feature [#13719](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13719&sa=D&source=editors&ust=1686087248461977&usg=AOvVaw3T94NXC_LGbgSazYFYYe5q)\] \[PATCH\] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
+## \[Feature [#13719](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13719&sa=D&source=editors&ust=1686087248461977&usg=AOvVaw3T94NXC_LGbgSazYFYYe5q)\] \[PATCH\] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
 
-- ## \[Feature [#13732](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13732&sa=D&source=editors&ust=1686087248462605&usg=AOvVaw19P4qJ37ksdyVBk2wc2uCL)\] Precise Time.now on Windows (shyouhei)
+## \[Feature [#13732](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13732&sa=D&source=editors&ust=1686087248462605&usg=AOvVaw19P4qJ37ksdyVBk2wc2uCL)\] Precise Time.now on Windows (shyouhei)
 
-- ## \[Feature [#13733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13733&sa=D&source=editors&ust=1686087248463256&usg=AOvVaw2I94z2H9iIK3UwbEFe4Ulg)\] Dump the delegator instead of the delegated object (shyouhei)
+## \[Feature [#13733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13733&sa=D&source=editors&ust=1686087248463256&usg=AOvVaw2I94z2H9iIK3UwbEFe4Ulg)\] Dump the delegator instead of the delegated object (shyouhei)
 
-- ## \[Feature [#13625](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13625&sa=D&source=editors&ust=1686087248463854&usg=AOvVaw01NpLQVd_SHjJdVQ8qIlI3)\] BigDecimal short form / shorthand (shyouhei)
+## \[Feature [#13625](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13625&sa=D&source=editors&ust=1686087248463854&usg=AOvVaw01NpLQVd_SHjJdVQ8qIlI3)\] BigDecimal short form / shorthand (shyouhei)
 
-- ## \[Feature [#13712](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13712&sa=D&source=editors&ust=1686087248464453&usg=AOvVaw1X9g__KMZyyjC17wu-eRvC)\] String#start\_with? with regexp (shyouhei)
+## \[Feature [#13712](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13712&sa=D&source=editors&ust=1686087248464453&usg=AOvVaw1X9g__KMZyyjC17wu-eRvC)\] String#start\_with? with regexp (shyouhei)
 
-- ## bugs that are not assigned (shyouhei)
+- bugs that are not assigned (shyouhei)
 
 
-- ## \[Bug [#13674](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13674&sa=D&source=editors&ust=1686087248465292&usg=AOvVaw1e3UizuNMl9z-Ecsz4vepS)\] BigDecimal comparison with Float::INFINITY is erroneous in 2.2.x and 2.3.x
+## \[Bug [#13674](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13674&sa=D&source=editors&ust=1686087248465292&usg=AOvVaw1e3UizuNMl9z-Ecsz4vepS)\] BigDecimal comparison with Float::INFINITY is erroneous in 2.2.x and 2.3.x
 
-- ## \[Bug [#13675](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13675&sa=D&source=editors&ust=1686087248465905&usg=AOvVaw3l31bLW3V0d7DPrHsmq5Bu)\] Should Zlib::GzipReader#ungetc accept nil?
+## \[Bug [#13675](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13675&sa=D&source=editors&ust=1686087248465905&usg=AOvVaw3l31bLW3V0d7DPrHsmq5Bu)\] Should Zlib::GzipReader#ungetc accept nil?
 
-- ## \[Bug [#13700](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13700&sa=D&source=editors&ust=1686087248466526&usg=AOvVaw0XJWj6L0k0SeC0ogHdB6CX)\] Enumerable#sum may not work for Ranges subclasses due to optimization (mrkn)
+## \[Bug [#13700](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13700&sa=D&source=editors&ust=1686087248466526&usg=AOvVaw0XJWj6L0k0SeC0ogHdB6CX)\] Enumerable#sum may not work for Ranges subclasses due to optimization (mrkn)
 
-- ## \[Bug [#13705](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13705&sa=D&source=editors&ust=1686087248467126&usg=AOvVaw3qm_Qux1FBAzlnaUrlEYmB)\] \[PATCH\] \`cfp consistency error' occurs when raising exception in bmethod call event
+## \[Bug [#13705](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13705&sa=D&source=editors&ust=1686087248467126&usg=AOvVaw3qm_Qux1FBAzlnaUrlEYmB)\] \[PATCH\] \`cfp consistency error' occurs when raising exception in bmethod call event
 
-- ## \[Bug [#13716](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13716&sa=D&source=editors&ust=1686087248467657&usg=AOvVaw31NFqFUW6liDUolVOdIe09)\] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+## \[Bug [#13716](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13716&sa=D&source=editors&ust=1686087248467657&usg=AOvVaw31NFqFUW6liDUolVOdIe09)\] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
 
-- ## \[Bug [#13670](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13670&sa=D&source=editors&ust=1686087248468237&usg=AOvVaw0SNkXcwOTwt1x6TvmypAIf)\] \[BUG\] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
+## \[Bug [#13670](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13670&sa=D&source=editors&ust=1686087248468237&usg=AOvVaw0SNkXcwOTwt1x6TvmypAIf)\] \[BUG\] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
 
 
 ## From attendees
 
-- ## \[Feature [#13780](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13780&sa=D&source=editors&ust=1686087248468997&usg=AOvVaw2deS9Zb2oSnBS_xAz7Me0s)\] String#each\_grapheme (naruse)
+## \[Feature [#13780](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13780&sa=D&source=editors&ust=1686087248468997&usg=AOvVaw2deS9Zb2oSnBS_xAz7Me0s)\] String#each\_grapheme (naruse)
 
 
-- ## matz: the unit is grapheme cluster. so the name should be each\_grapheme\_cluster.
+- matz: the unit is grapheme cluster. so the name should be each\_grapheme\_cluster.
 
 
-- ## \[Misc [#13704](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13704&sa=D&source=editors&ust=1686087248469840&usg=AOvVaw2GG95VopuQ9MYRGBvNeKzB)\] \[PATCH\] Exclude Changelog files from documentation. (hsbt)
+## \[Misc [#13704](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13704&sa=D&source=editors&ust=1686087248469840&usg=AOvVaw2GG95VopuQ9MYRGBvNeKzB)\] \[PATCH\] Exclude Changelog files from documentation. (hsbt)
 
-- ## \[Feature [#12733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12733&sa=D&source=editors&ust=1686087248470451&usg=AOvVaw2rOgti2OpgNg5JU10MPHCx)\] Bundle bundler to ruby core (hsbt)
+## \[Feature [#12733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12733&sa=D&source=editors&ust=1686087248470451&usg=AOvVaw2rOgti2OpgNg5JU10MPHCx)\] Bundle bundler to ruby core (hsbt)
 
-- ## \[Feature [#13847](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13847&sa=D&source=editors&ust=1686087248470938&usg=AOvVaw0jwreXuPZnL_F4ZAU0a9_q)\] Gem activated problem for default gems (hsbt)
-
-
-- ## [https://gist.github.com/hsbt/968fcbb7acfa9405d82040a3c219f43a](https://www.google.com/url?q=https://gist.github.com/hsbt/968fcbb7acfa9405d82040a3c219f43a&sa=D&source=editors&ust=1686087248471518&usg=AOvVaw0pw8poXncxT_FiymVKbY8h) (ja)
-
-- ## Related with [https://bugs.ruby-lang.org/issues/10320](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10320&sa=D&source=editors&ust=1686087248472114&usg=AOvVaw0Gce_ebZC_JoNnL94M5z_4)
+## \[Feature [#13847](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13847&sa=D&source=editors&ust=1686087248470938&usg=AOvVaw0jwreXuPZnL_F4ZAU0a9_q)\] Gem activated problem for default gems (hsbt)
 
 
-- ## \[Misc [#13747](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13747&sa=D&source=editors&ust=1686087248472663&usg=AOvVaw0Qq--l11He0lq5Z8e-A61S)\] MinGW trunk build available on Appveyor (shyouhei)
+## [https://gist.github.com/hsbt/968fcbb7acfa9405d82040a3c219f43a](https://www.google.com/url?q=https://gist.github.com/hsbt/968fcbb7acfa9405d82040a3c219f43a&sa=D&source=editors&ust=1686087248471518&usg=AOvVaw0pw8poXncxT_FiymVKbY8h) (ja)
 
-- ## \[Feature [#13751](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13751&sa=D&source=editors&ust=1686087248473254&usg=AOvVaw1MGp-hjIkoMp-463ALS69o)\] Suppert SSHFP resource records in rubysl-resolv (shyouhei)
+- Related with [https://bugs.ruby-lang.org/issues/10320](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10320&sa=D&source=editors&ust=1686087248472114&usg=AOvVaw0Gce_ebZC_JoNnL94M5z_4)
 
-- ## \[Bug [#13752](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13752&sa=D&source=editors&ust=1686087248473899&usg=AOvVaw0lSZECyxz3PPPdDiimvA_1)\] Can't observe sibling refinements (shyouhei)
 
-- ## \[Feature [#13683](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13683&sa=D&source=editors&ust=1686087248474471&usg=AOvVaw2eaIn2rbL3FARturD5-FV4)\] Add strict Enumerable#single (shyouhei)
+## \[Misc [#13747](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13747&sa=D&source=editors&ust=1686087248472663&usg=AOvVaw0Qq--l11He0lq5Z8e-A61S)\] MinGW trunk build available on Appveyor (shyouhei)
 
-- ## \[Feature [#13763](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13763&sa=D&source=editors&ust=1686087248475051&usg=AOvVaw0jyuMUQ08wNN9TVbkZ_E3H)\] Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
+## \[Feature [#13751](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13751&sa=D&source=editors&ust=1686087248473254&usg=AOvVaw1MGp-hjIkoMp-463ALS69o)\] Suppert SSHFP resource records in rubysl-resolv (shyouhei)
 
-- ## \[Feature [#13765](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13765&sa=D&source=editors&ust=1686087248475708&usg=AOvVaw1qaicvgPxCeP7NyVRGv-tU)\] Add Proc#bind (shyouhei)
+## \[Bug [#13752](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13752&sa=D&source=editors&ust=1686087248473899&usg=AOvVaw0lSZECyxz3PPPdDiimvA_1)\] Can't observe sibling refinements (shyouhei)
 
-- ## \[Feature [#13767](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13767&sa=D&source=editors&ust=1686087248476306&usg=AOvVaw1d2Ytv2BczJOTf_9nhtO8a)\] add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
+## \[Feature [#13683](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13683&sa=D&source=editors&ust=1686087248474471&usg=AOvVaw2eaIn2rbL3FARturD5-FV4)\] Add strict Enumerable#single (shyouhei)
 
-- ## \[Feature [#13777](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13777&sa=D&source=editors&ust=1686087248476948&usg=AOvVaw2dMUpqlvCbuOo4rtiGumM5)\] Array#delete\_all (shyouhei)
+## \[Feature [#13763](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13763&sa=D&source=editors&ust=1686087248475051&usg=AOvVaw0jyuMUQ08wNN9TVbkZ_E3H)\] Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
 
-- ## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087248477644&usg=AOvVaw0nVQybSwJjE6TU0I696Uml)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## \[Feature [#13765](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13765&sa=D&source=editors&ust=1686087248475708&usg=AOvVaw1qaicvgPxCeP7NyVRGv-tU)\] Add Proc#bind (shyouhei)
 
-- ## \[Feature [#13784](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13784&sa=D&source=editors&ust=1686087248478317&usg=AOvVaw1qGIizSgeVwz5KzKN-5-gh)\] Add Enumerable#filter as an alias of Enumerable#select (shyouhei)
+## \[Feature [#13767](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13767&sa=D&source=editors&ust=1686087248476306&usg=AOvVaw1d2Ytv2BczJOTf_9nhtO8a)\] add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
 
-- ## \[Misc [#13804](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13804&sa=D&source=editors&ust=1686087248478958&usg=AOvVaw3_MMeFelbCNGje1glRKPeH)\] Protected methods cannot be overridden (shyouhei)
+## \[Feature [#13777](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13777&sa=D&source=editors&ust=1686087248476948&usg=AOvVaw2dMUpqlvCbuOo4rtiGumM5)\] Array#delete\_all (shyouhei)
 
-- ## \[Feature [#13803](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13803&sa=D&source=editors&ust=1686087248479602&usg=AOvVaw0zWA_FGwHoQCoFZe3unsk4)\] Add Socket::Ifaddr.vhid on supported platforms (shyouhei)
+## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087248477644&usg=AOvVaw0nVQybSwJjE6TU0I696Uml)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
 
-- ## \[Feature [#13807](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13807&sa=D&source=editors&ust=1686087248480274&usg=AOvVaw1-UIDFjcuO0EVFZKJr3F3N)\] A method to filter the receiver against some condition (shyouhei)
+## \[Feature [#13784](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13784&sa=D&source=editors&ust=1686087248478317&usg=AOvVaw1qGIizSgeVwz5KzKN-5-gh)\] Add Enumerable#filter as an alias of Enumerable#select (shyouhei)
 
-- ## \[Feature [#13805](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13805&sa=D&source=editors&ust=1686087248480892&usg=AOvVaw1lWumto5jqVgfYuQ7NwizI)\] Make refinement scoping to be like that of constants (shyouhei)
+## \[Misc [#13804](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13804&sa=D&source=editors&ust=1686087248478958&usg=AOvVaw3_MMeFelbCNGje1glRKPeH)\] Protected methods cannot be overridden (shyouhei)
 
-- ## \[Feature [#13789](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13789&sa=D&source=editors&ust=1686087248481463&usg=AOvVaw1wI8HXjLqFj8PYVxChA4hm)\] Dir - methods (shyouhei)
+## \[Feature [#13803](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13803&sa=D&source=editors&ust=1686087248479602&usg=AOvVaw0zWA_FGwHoQCoFZe3unsk4)\] Add Socket::Ifaddr.vhid on supported platforms (shyouhei)
 
-- ## \[Misc [#13810](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13810&sa=D&source=editors&ust=1686087248482017&usg=AOvVaw0rLW2CGEyeDp8c47C6JHWn)\] Inconsistency between Date and Time.strftime("%v") (shyouhei)
+## \[Feature [#13807](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13807&sa=D&source=editors&ust=1686087248480274&usg=AOvVaw1-UIDFjcuO0EVFZKJr3F3N)\] A method to filter the receiver against some condition (shyouhei)
 
-- ## \[Feature [#12282](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12282&sa=D&source=editors&ust=1686087248482584&usg=AOvVaw0P_1qTyAboqZ1Jezu4ajrQ)\] Hash#dig! for repeated applications of Hash#fetch (shyouhei)
+## \[Feature [#13805](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13805&sa=D&source=editors&ust=1686087248480892&usg=AOvVaw1lWumto5jqVgfYuQ7NwizI)\] Make refinement scoping to be like that of constants (shyouhei)
 
-- ## \[Feature [#13821](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13821&sa=D&source=editors&ust=1686087248483204&usg=AOvVaw2A4BS3bKp92Qb4g7tgeluR)\] Allow fibers to be resumed across threads (shyouhei)
+## \[Feature [#13789](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13789&sa=D&source=editors&ust=1686087248481463&usg=AOvVaw1wI8HXjLqFj8PYVxChA4hm)\] Dir - methods (shyouhei)
 
-- ## \[Feature [#9450](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9450&sa=D&source=editors&ust=1686087248483844&usg=AOvVaw3p4UknTP8HSVS9Pur4JGxE)\] Allow overriding SSLContext options in Net::HTTP (shyouhei)
+## \[Misc [#13810](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13810&sa=D&source=editors&ust=1686087248482017&usg=AOvVaw0rLW2CGEyeDp8c47C6JHWn)\] Inconsistency between Date and Time.strftime("%v") (shyouhei)
 
-- ## \[Feature [#13820](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13820&sa=D&source=editors&ust=1686087248484447&usg=AOvVaw2gQU0HypT_cYCn_jjd7Mqa)\] Add a nill coalescing operator (shyouhei)
+## \[Feature [#12282](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12282&sa=D&source=editors&ust=1686087248482584&usg=AOvVaw0P_1qTyAboqZ1Jezu4ajrQ)\] Hash#dig! for repeated applications of Hash#fetch (shyouhei)
 
-- ## \[Feature [#13770](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13770&sa=D&source=editors&ust=1686087248485050&usg=AOvVaw0HlZHJKJhk0mHt1wWGtAU-)\] Can't create valid Cyrillic-named class/module (shyouhei, duerst)
+## \[Feature [#13821](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13821&sa=D&source=editors&ust=1686087248483204&usg=AOvVaw2A4BS3bKp92Qb4g7tgeluR)\] Allow fibers to be resumed across threads (shyouhei)
 
-- ## \[Feature [#13839](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13839&sa=D&source=editors&ust=1686087248485702&usg=AOvVaw2ZZRaxGPuW1bXridk8duat)\] String Interpolation Statements (shyouhei)
+## \[Feature [#9450](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9450&sa=D&source=editors&ust=1686087248483844&usg=AOvVaw3p4UknTP8HSVS9Pur4JGxE)\] Allow overriding SSLContext options in Net::HTTP (shyouhei)
 
-- ## \[Misc [#13840](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13840&sa=D&source=editors&ust=1686087248486253&usg=AOvVaw2F4vjCppZO6_6qo6CflSsQ)\] Collection methods - stability (shyouhei, duerst (propose to reject))
+## \[Feature [#13820](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13820&sa=D&source=editors&ust=1686087248484447&usg=AOvVaw2gQU0HypT_cYCn_jjd7Mqa)\] Add a nill coalescing operator (shyouhei)
+
+## \[Feature [#13770](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13770&sa=D&source=editors&ust=1686087248485050&usg=AOvVaw0HlZHJKJhk0mHt1wWGtAU-)\] Can't create valid Cyrillic-named class/module (shyouhei, duerst)
+
+## \[Feature [#13839](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13839&sa=D&source=editors&ust=1686087248485702&usg=AOvVaw2ZZRaxGPuW1bXridk8duat)\] String Interpolation Statements (shyouhei)
+
+## \[Misc [#13840](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13840&sa=D&source=editors&ust=1686087248486253&usg=AOvVaw2F4vjCppZO6_6qo6CflSsQ)\] Collection methods - stability (shyouhei, duerst (propose to reject))
 
 - \[Feature [#13801](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13801&sa=D&source=editors&ust=1686087248486834&usg=AOvVaw0Xe_uLGLwT5JJPRduy2Do_)\] Implement case equality test for Set#=== (duerst)
-- ## bugs that are not assigned (shyouhei)
+- bugs that are not assigned (shyouhei)
 
 
-- ## \[Bug [#13549](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13549&sa=D&source=editors&ust=1686087248487663&usg=AOvVaw2xAe1ZAbjxcwZ8ZJFwQVTV)\] MinGW / Windows encoding - Two issues
+## \[Bug [#13549](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13549&sa=D&source=editors&ust=1686087248487663&usg=AOvVaw2xAe1ZAbjxcwZ8ZJFwQVTV)\] MinGW / Windows encoding - Two issues
 
-- ## \[Bug [#13754](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13754&sa=D&source=editors&ust=1686087248488261&usg=AOvVaw05cVy5vMt5QJT27I3sSvJi)\] bigdecimal with lower precision that Float
+## \[Bug [#13754](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13754&sa=D&source=editors&ust=1686087248488261&usg=AOvVaw05cVy5vMt5QJT27I3sSvJi)\] bigdecimal with lower precision that Float
 
-- ## \[Bug [#13746](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13746&sa=D&source=editors&ust=1686087248488851&usg=AOvVaw2nGMCubqOowsFgpS0fFark)\] windows-pr gemのRuby 2.4 32bit版でのSEGV
+## \[Bug [#13746](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13746&sa=D&source=editors&ust=1686087248488851&usg=AOvVaw2nGMCubqOowsFgpS0fFark)\] windows-pr gemのRuby 2.4 32bit版でのSEGV
 
-- ## \[Bug [#13758](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13758&sa=D&source=editors&ust=1686087248489320&usg=AOvVaw1mbLq6mOojMydjKuuhvr7y)\] TestRubyOptions#test\_segv\_setproctitle segfaults on AARCH64
+## \[Bug [#13758](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13758&sa=D&source=editors&ust=1686087248489320&usg=AOvVaw1mbLq6mOojMydjKuuhvr7y)\] TestRubyOptions#test\_segv\_setproctitle segfaults on AARCH64
 
-- ## \[Bug [#13716](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13716&sa=D&source=editors&ust=1686087248489747&usg=AOvVaw0CODpdXTSimLfM4I0Qam_b)\] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+## \[Bug [#13716](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13716&sa=D&source=editors&ust=1686087248489747&usg=AOvVaw0CODpdXTSimLfM4I0Qam_b)\] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
 
-- ## \[Bug [#13691](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13691&sa=D&source=editors&ust=1686087248490254&usg=AOvVaw1lzFaHXSU2e2fO-vx31LWH)\] Word- and symbol array literals not valid where regular array is
+## \[Bug [#13691](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13691&sa=D&source=editors&ust=1686087248490254&usg=AOvVaw1lzFaHXSU2e2fO-vx31LWH)\] Word- and symbol array literals not valid where regular array is
 
-- ## \[Bug [#13769](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13769&sa=D&source=editors&ust=1686087248490720&usg=AOvVaw1H8XlbE-FKW965siy4GSeF)\] IPAddr#ipv4\_compat incorrect behavior
+## \[Bug [#13769](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13769&sa=D&source=editors&ust=1686087248490720&usg=AOvVaw1H8XlbE-FKW965siy4GSeF)\] IPAddr#ipv4\_compat incorrect behavior
 
-- ## \[Bug [#13768](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13768&sa=D&source=editors&ust=1686087248491171&usg=AOvVaw1whAN143uBgX2l5fKgGH5F)\] SIGCHLD and Thread dead-lock problem
+## \[Bug [#13768](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13768&sa=D&source=editors&ust=1686087248491171&usg=AOvVaw1whAN143uBgX2l5fKgGH5F)\] SIGCHLD and Thread dead-lock problem
 
-- ## \[Bug [#13773](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13773&sa=D&source=editors&ust=1686087248491766&usg=AOvVaw0N9LDgsEEbM_DdAgKDUn1i)\] Improve String#prepend performance if only one argument is given
+## \[Bug [#13773](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13773&sa=D&source=editors&ust=1686087248491766&usg=AOvVaw0N9LDgsEEbM_DdAgKDUn1i)\] Improve String#prepend performance if only one argument is given
 
-- ## \[Bug [#13774](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13774&sa=D&source=editors&ust=1686087248492348&usg=AOvVaw2v1WqoBrGzj56HIBx8ryby)\] for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
+## \[Bug [#13774](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13774&sa=D&source=editors&ust=1686087248492348&usg=AOvVaw2v1WqoBrGzj56HIBx8ryby)\] for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
 
-- ## \[Bug [#13748](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13748&sa=D&source=editors&ust=1686087248492943&usg=AOvVaw1m_EqVkrVESIxNBWLg9rM7)\] \[PATCH\] Fix mul overflow detection for LLP64 arch.
+## \[Bug [#13748](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13748&sa=D&source=editors&ust=1686087248492943&usg=AOvVaw1m_EqVkrVESIxNBWLg9rM7)\] \[PATCH\] Fix mul overflow detection for LLP64 arch.
 
-- ## \[Bug [#13781](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13781&sa=D&source=editors&ust=1686087248493514&usg=AOvVaw0rN3pwh4XrH_yPsQK6vLSb)\] Should the safe navigation operator invoke nil?
+## \[Bug [#13781](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13781&sa=D&source=editors&ust=1686087248493514&usg=AOvVaw0rN3pwh4XrH_yPsQK6vLSb)\] Should the safe navigation operator invoke nil?
 
-- ## \[Bug [#13795](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13795&sa=D&source=editors&ust=1686087248494150&usg=AOvVaw1WRiCLjKKmTS1XkvXAaUoP)\] Hash#select return type does not match Hash#find\_all
+## \[Bug [#13795](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13795&sa=D&source=editors&ust=1686087248494150&usg=AOvVaw1WRiCLjKKmTS1XkvXAaUoP)\] Hash#select return type does not match Hash#find\_all
 
-- ## \[Bug [#13811](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13811&sa=D&source=editors&ust=1686087248494717&usg=AOvVaw1vX83eOfh89adYUhVBV12F)\] Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
+## \[Bug [#13811](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13811&sa=D&source=editors&ust=1686087248494717&usg=AOvVaw1vX83eOfh89adYUhVBV12F)\] Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
 
 
 We couldn’t investigate it because there is not enough reproduction instruction..
 
-- ## \[Bug [#13818](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13818&sa=D&source=editors&ust=1686087248495448&usg=AOvVaw3NtVG1B_sh4z7Qf4Mm13tv)\] Licence issue with use of Onigmo rather than Oniguruma library files
+## \[Bug [#13818](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13818&sa=D&source=editors&ust=1686087248495448&usg=AOvVaw3NtVG1B_sh4z7Qf4Mm13tv)\] Licence issue with use of Onigmo rather than Oniguruma library files
 
-- ## \[Bug [#13827](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13827&sa=D&source=editors&ust=1686087248496109&usg=AOvVaw2lI4oij8nHP6enF5y9YrMT)\] Improve performance of Base64.urlsafe\_encode64
+## \[Bug [#13827](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13827&sa=D&source=editors&ust=1686087248496109&usg=AOvVaw2lI4oij8nHP6enF5y9YrMT)\] Improve performance of Base64.urlsafe\_encode64
 
-- ## \[Bug [#13829](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13829&sa=D&source=editors&ust=1686087248496810&usg=AOvVaw1ivZ0aG5GPe53RBUXP20BA)\] NUL char in $0
+## \[Bug [#13829](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13829&sa=D&source=editors&ust=1686087248496810&usg=AOvVaw1ivZ0aG5GPe53RBUXP20BA)\] NUL char in $0
 
-- ## \[Bug [#13833](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13833&sa=D&source=editors&ust=1686087248497418&usg=AOvVaw1sD9eIzOvqS6taMRcUKEQF)\] String#scanf("%a") incorrectly requires a sign on the (binary) exponent
+## \[Bug [#13833](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13833&sa=D&source=editors&ust=1686087248497418&usg=AOvVaw1sD9eIzOvqS6taMRcUKEQF)\] String#scanf("%a") incorrectly requires a sign on the (binary) exponent
 
-- ## \[Bug [#13835](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13835&sa=D&source=editors&ust=1686087248498063&usg=AOvVaw1ZTqzvYF2ymsNiMLiG8JFL)\] Using 'open-uri' with 'tempfile' causes an exception
+## \[Bug [#13835](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13835&sa=D&source=editors&ust=1686087248498063&usg=AOvVaw1ZTqzvYF2ymsNiMLiG8JFL)\] Using 'open-uri' with 'tempfile' causes an exception
 
-- ## \[Bug [#13757](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13757&sa=D&source=editors&ust=1686087248498655&usg=AOvVaw2ubAeH0s-MyTCSDqCZYRlS)\] TestBacktrace#test\_caller\_lev segaults on PPC
+## \[Bug [#13757](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13757&sa=D&source=editors&ust=1686087248498655&usg=AOvVaw2ubAeH0s-MyTCSDqCZYRlS)\] TestBacktrace#test\_caller\_lev segaults on PPC
 
-- ## \[Bug [#13167](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13167&sa=D&source=editors&ust=1686087248499272&usg=AOvVaw09EjI9NbJ2DtSjdg0jQBRU)\] Dir.glob is 25x slower since Ruby 2.2
+## \[Bug [#13167](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13167&sa=D&source=editors&ust=1686087248499272&usg=AOvVaw09EjI9NbJ2DtSjdg0jQBRU)\] Dir.glob is 25x slower since Ruby 2.2
 
-- ## \[Bug [#13844](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13844&sa=D&source=editors&ust=1686087248499866&usg=AOvVaw3lKIDh9x6Rtb8PvidTGtEL)\] Toplevel returns should fire ensures
+## \[Bug [#13844](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13844&sa=D&source=editors&ust=1686087248499866&usg=AOvVaw3lKIDh9x6Rtb8PvidTGtEL)\] Toplevel returns should fire ensures
 
 
 ## From non-attendees
 
-- ## \[Feature [#13686](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13686&sa=D&source=editors&ust=1686087248500655&usg=AOvVaw0y0uxR7qjEbjWE4viyrmKt)\] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (aycabta)
+## \[Feature [#13686](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13686&sa=D&source=editors&ust=1686087248500655&usg=AOvVaw0y0uxR7qjEbjWE4viyrmKt)\] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (aycabta)
 
 
 ## Write your name and your interest (what do you want to ask and to whom?) please.

--- a/2017/DevMeeting-2017-09-25.md
+++ b/2017/DevMeeting-2017-09-25.md
@@ -171,19 +171,19 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## next
 
-- ## 10/12, 10/13, 10/17, 10/19, or …?
+- 10/12, 10/13, 10/17, 10/19, or …?
 
-- ## Fixed: 10/19
+- Fixed: 10/19
 
-- ## at?
+- at?
 
 
-- ## Speee, Inc. at Roppongi.
+- Speee, Inc. at Roppongi.
 
 
 ## About 2.5 timeframe
 
-- ## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087280533030&usg=AOvVaw0W4B5MfU7_hqlhOkj85JrJ)
+## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087280533030&usg=AOvVaw0W4B5MfU7_hqlhOkj85JrJ)
 
 
 - shyouhei: no blocker now.
@@ -191,12 +191,12 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-- ## \[Feature [#13396](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13396&sa=D&source=editors&ust=1686087280534228&usg=AOvVaw33J_B18QtOe6KykD_Nxxxe)\] Net::HTTP has no write timeout (shyouhei) Sorry, what was the conclusion of it?
+## \[Feature [#13396](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13396&sa=D&source=editors&ust=1686087280534228&usg=AOvVaw33J_B18QtOe6KykD_Nxxxe)\] Net::HTTP has no write timeout (shyouhei) Sorry, what was the conclusion of it?
 
 
 - naruse: I’ll implement this.
 
-- ## \[Bug [#13438](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13438&sa=D&source=editors&ust=1686087280534889&usg=AOvVaw0maGzvrSQUnoz3SFc1Bpyl)\] Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei) Sorry, what was the conclusion of it?
+## \[Bug [#13438](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13438&sa=D&source=editors&ust=1686087280534889&usg=AOvVaw0maGzvrSQUnoz3SFc1Bpyl)\] Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei) Sorry, what was the conclusion of it?
 
 
 - mrkn: I remember we should not support old OpenBSD.
@@ -204,32 +204,32 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - shyouhei: then should we accept this?
 - nobu: yes.
 
-- ## \[Feature [#13608](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13608&sa=D&source=editors&ust=1686087280535880&usg=AOvVaw3u8j7ONvSZr2h8phJdb5N5)\] Add TracePoint#thread (shyouhei)
+## \[Feature [#13608](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13608&sa=D&source=editors&ust=1686087280535880&usg=AOvVaw3u8j7ONvSZr2h8phJdb5N5)\] Add TracePoint#thread (shyouhei)
 
 
 - ko1: I think we don’t need this.
 - naruse: I wanted this when I created a tracer.
 - ko1: the tracer shall run on the thread. Thread.current should suffice
 
-- ## \[Feature [#13602](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13602&sa=D&source=editors&ust=1686087280536664&usg=AOvVaw088YT2SCkTD5DOb2ANzSfv)\] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
+## \[Feature [#13602](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13602&sa=D&source=editors&ust=1686087280536664&usg=AOvVaw088YT2SCkTD5DOb2ANzSfv)\] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
 
 
 - ko1: is it worth for a 5-6% speedup?
 - mame: this should affect optcarrot...
 
-- ## \[Feature [#13613](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13613&sa=D&source=editors&ust=1686087280537347&usg=AOvVaw1qm5R91gtCQizT0WWLP-nQ)\] Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
+## \[Feature [#13613](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13613&sa=D&source=editors&ust=1686087280537347&usg=AOvVaw1qm5R91gtCQizT0WWLP-nQ)\] Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
 
 
 - akr: we should define errors that are “fatal” and those aren’t.  For instance, ENOENT is not fatal but EPERM is.
 - shyouhei: it sounds reasonable for someone want to know when there \_are\_ some nasty files.
 - mame: should we raise exceptions for errors other than ENOENT? or to warn only?
 
-- ## \[Feature [#13620](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13620&sa=D&source=editors&ust=1686087280538106&usg=AOvVaw1fPJWxGVwZnEg4YOfWA8Qe)\] Simplifying MRI's build system: always install (shyouhei)
+## \[Feature [#13620](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13620&sa=D&source=editors&ust=1686087280538106&usg=AOvVaw1fPJWxGVwZnEg4YOfWA8Qe)\] Simplifying MRI's build system: always install (shyouhei)
 
 
 - the thread is going on.
 
-- ## \[Feature [#13630](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13630&sa=D&source=editors&ust=1686087280538651&usg=AOvVaw0rb-Vtx5f6Q53bJzq1cqdD)\] :\[\] method should accept block in nice syntax (shyouhei) OK to close?
+## \[Feature [#13630](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13630&sa=D&source=editors&ust=1686087280538651&usg=AOvVaw0rb-Vtx5f6Q53bJzq1cqdD)\] :\[\] method should accept block in nice syntax (shyouhei) OK to close?
 
 
 - matz: I think it should be accepted.
@@ -245,14 +245,14 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - nobu: what about buffer\_offset?
 - knu: seems IO.write has optional 3rd argument, offset, which is used to seek the file.
 
-- ## \[Feature [#9001](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9001&sa=D&source=editors&ust=1686087280540497&usg=AOvVaw0Xhok2krZGSbbQc7ZEcwnk)\] Please package better standard library (shyouhe)
+## \[Feature [#9001](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9001&sa=D&source=editors&ust=1686087280540497&usg=AOvVaw0Xhok2krZGSbbQc7ZEcwnk)\] Please package better standard library (shyouhe)
 
 
 - duerst: This particular ticket seems no feature but for long term, what should we do for standard libraries?
 - mrkn: I think current goal is to bundle things that are only needed for installing rubygems
 - akira: close this and let people individually name replacemets.
 
-- ## \[Feature [#12533](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12533&sa=D&source=editors&ust=1686087280541062&usg=AOvVaw2kutIF7DGy929CUeVyTQKP)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
+## \[Feature [#12533](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12533&sa=D&source=editors&ust=1686087280541062&usg=AOvVaw2kutIF7DGy929CUeVyTQKP)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
 
 
 - matz: this sounds like a bug instead of local rebinding?
@@ -289,24 +289,24 @@ end
 
 puts "tomatoe".vegetables
 
-- ## \[Feature [#13653](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13653&sa=D&source=editors&ust=1686087280543152&usg=AOvVaw3kNrSzYZt1wWiYNEKEl416)\] Bundled zlib helper (shyouhei)
+## \[Feature [#13653](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13653&sa=D&source=editors&ust=1686087280543152&usg=AOvVaw3kNrSzYZt1wWiYNEKEl416)\] Bundled zlib helper (shyouhei)
 
 
 - shyouhei: postpone because hsbt is absent.
 
-- ## \[Feature [#13626](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13626&sa=D&source=editors&ust=1686087280543840&usg=AOvVaw0znFKkf_dH25kJXzODgTpK)\] Add String#byteslice! (shyouhei)
+## \[Feature [#13626](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13626&sa=D&source=editors&ust=1686087280543840&usg=AOvVaw0znFKkf_dH25kJXzODgTpK)\] Add String#byteslice! (shyouhei)
 
 
 - mame: sounds reasonable because we have both slice and slice!
 - matz: agreed.
 
-- ## \[Feature [#13551](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13551&sa=D&source=editors&ust=1686087280544575&usg=AOvVaw3aoPOj81lUi1OkxopfJ7cp)\] Add a method to alias class methods (shyouhei)
+## \[Feature [#13551](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13551&sa=D&source=editors&ust=1686087280544575&usg=AOvVaw3aoPOj81lUi1OkxopfJ7cp)\] Add a method to alias class methods (shyouhei)
 
 
 - shyouhei: ah, I want this feature.
 - matz: I prefer opening singleton class.
 
-- ## \[Feature [#13332](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13332&sa=D&source=editors&ust=1686087280545273&usg=AOvVaw1kw4565_1X6rjaYAUQdJqV)\] Forwardable#def\_instance\_delegator nil (shyouhei)
+## \[Feature [#13332](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13332&sa=D&source=editors&ust=1686087280545273&usg=AOvVaw1kw4565_1X6rjaYAUQdJqV)\] Forwardable#def\_instance\_delegator nil (shyouhei)
 
 
 - nobu: I don’t think this is much meaningful.
@@ -314,30 +314,30 @@ puts "tomatoe".vegetables
 - knu: ActiveSupport::Delegate also doesn’t support this comples feature (but only allow\_nil)
 - matz: I’d like to hear use cases.
 
-- ## \[Feature [#13378](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13378&sa=D&source=editors&ust=1686087280545959&usg=AOvVaw2kfMzLXObkr-9QSuXzvSS0)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+## \[Feature [#13378](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13378&sa=D&source=editors&ust=1686087280545959&usg=AOvVaw2kfMzLXObkr-9QSuXzvSS0)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
 
 
 - nobu: I’m handlig this. WIP.
 
-- ## \[Feature [#13381](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13381&sa=D&source=editors&ust=1686087280546453&usg=AOvVaw0JRLdy99IkuWXDSgRGFWlf)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## \[Feature [#13381](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13381&sa=D&source=editors&ust=1686087280546453&usg=AOvVaw0JRLdy99IkuWXDSgRGFWlf)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
 
 
 - matz: postpone because ko1 is absent.
 
-- ## \[Feature [#13677](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13677&sa=D&source=editors&ust=1686087280547021&usg=AOvVaw3q2B0XFOQ0KK0gIlS8RPTK)\] Add more details to error "Name or service not known (SocketError)" (shyouhei)
+## \[Feature [#13677](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13677&sa=D&source=editors&ust=1686087280547021&usg=AOvVaw3q2B0XFOQ0KK0gIlS8RPTK)\] Add more details to error "Name or service not known (SocketError)" (shyouhei)
 
 
 - akr: we currenly only show the return value of gai\_strerror(). Seems OK to extend though.
 - akr: patch is welcomed.
 
-- ## \[Feature [#9323](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9323&sa=D&source=editors&ust=1686087280547573&usg=AOvVaw0_AsdqTk98KVnKB529OBSI)\] IO#writev (shyouhei)
+## \[Feature [#9323](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9323&sa=D&source=editors&ust=1686087280547573&usg=AOvVaw0_AsdqTk98KVnKB529OBSI)\] IO#writev (shyouhei)
 
 
 - akr: do we call syscalls many times, or should we buffer?
 - mame: I want to know how this speeds things up.
 - knu: maybe atomic write is the point.
 
-- ## \[Feature [#13693](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13693&sa=D&source=editors&ust=1686087280548098&usg=AOvVaw3anf_hNNXQu48ruBqi8w-M)\] Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
+## \[Feature [#13693](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13693&sa=D&source=editors&ust=1686087280548098&usg=AOvVaw3anf_hNNXQu48ruBqi8w-M)\] Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
 
 
 - mame: haha
@@ -349,18 +349,18 @@ puts "tomatoe".vegetables
 - mrkn: yes.
 - mrkn: it seems the behaviour of #to\_i comes with atoi().
 
-- ## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087280549113&usg=AOvVaw2cxOT0ni4UA8D1u1wU6xjw)\] better method definition in C API (shyouhei)
+## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087280549113&usg=AOvVaw2cxOT0ni4UA8D1u1wU6xjw)\] better method definition in C API (shyouhei)
 
 
 - shyouhei: postpone because ko1 is absent now.
 
-- ## \[Feature [#13696](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13696&sa=D&source=editors&ust=1686087280549582&usg=AOvVaw0u2vgwWSMqrRZWPRziV6KE)\] Add exchange and noreplace options to File.rename (shyouhei)
+## \[Feature [#13696](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13696&sa=D&source=editors&ust=1686087280549582&usg=AOvVaw0u2vgwWSMqrRZWPRziV6KE)\] Add exchange and noreplace options to File.rename (shyouhei)
 
 
 - akr: This should definitely not be an extension to #rename.
 - nobu: It’s hard to introduce in-core.
 
-- ## \[Feature [#13683](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13683&sa=D&source=editors&ust=1686087280550109&usg=AOvVaw2ScW1cnL3mfvvflZxyz0LT)\] Add strict Enumerable#single (shyouhei)
+## \[Feature [#13683](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13683&sa=D&source=editors&ust=1686087280550109&usg=AOvVaw2ScW1cnL3mfvvflZxyz0LT)\] Add strict Enumerable#single (shyouhei)
 
 
 - shyouhei: わかる
@@ -371,7 +371,7 @@ puts "tomatoe".vegetables
 - mame: what about the feature itself?
 - matz: think we need more use case.
 
-- ## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087280551188&usg=AOvVaw05fsyaWbHAKnxDoHuiw7vw)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087280551188&usg=AOvVaw05fsyaWbHAKnxDoHuiw7vw)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
 
 
 - matz: async { File.read }
@@ -380,17 +380,17 @@ puts "tomatoe".vegetables
 - ko1: what if a library author did this, its user can never be aware of this async call.
 - ko1: If a Fiber body is small, it may have no problem.  However when someone write a framework that wraps existing external library, that should result in a problematic situation.
 
-- ## \[Feature [#13821](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13821&sa=D&source=editors&ust=1686087280552245&usg=AOvVaw08bg-bz9yjadzgB6bUwVjW)\] Allow fibers to be resumed across threads (shyouhei)
+## \[Feature [#13821](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13821&sa=D&source=editors&ust=1686087280552245&usg=AOvVaw08bg-bz9yjadzgB6bUwVjW)\] Allow fibers to be resumed across threads (shyouhei)
 
 
 - ko1: it’s technically impossible.
 
-- ## \[Bug [#13931](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13931&sa=D&source=editors&ust=1686087280552799&usg=AOvVaw2OF0PRpGjlLUOZTb7qZtnb)\] correct install\_name of libruby on macOS (libruby.2.5.0.dylib -> libruby.2.5.dylib) (naruse)
+## \[Bug [#13931](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13931&sa=D&source=editors&ust=1686087280552799&usg=AOvVaw2OF0PRpGjlLUOZTb7qZtnb)\] correct install\_name of libruby on macOS (libruby.2.5.0.dylib -> libruby.2.5.dylib) (naruse)
 
 
-- ## nobu: compatibility version shall be, and is, “2.4.0” ATM.  But we had bugs before.  I don’t want to change the AS-IS behaviour.
+- nobu: compatibility version shall be, and is, “2.4.0” ATM.  But we had bugs before.  I don’t want to change the AS-IS behaviour.
 
-- ## naruse: compatibility version shall be “2.4.0” or “2.4”, and linked libray should be libruby.2.4.dylib
+- naruse: compatibility version shall be “2.4.0” or “2.4”, and linked libray should be libruby.2.4.dylib
 
 
 - \[Bug [#13917](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13917&sa=D&source=editors&ust=1686087280553388&usg=AOvVaw3xTSpLxfdUUE4F31z_AeWj)\] Comparable#clamp is slower than using Array#min,max. (naruse)
@@ -399,18 +399,18 @@ puts "tomatoe".vegetables
 - mame: we don’t optimize Comparable#clamp for literals, because no practical usage can be thought for such thing. NEWS shall be consulted.
 - naruse: I’ll respond as such. nobu will merge the pull request.
 
-- ## \[Feature [#13893](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13893&sa=D&source=editors&ust=1686087280554009&usg=AOvVaw1th4kPmvwr7OzkfjoXqk5Y)\] Add Fiber#\[\] and Fiber#\[\]= and restore Thread#\[\] and Thread#\[\]= to their original behavior (shyouhei)
+## \[Feature [#13893](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13893&sa=D&source=editors&ust=1686087280554009&usg=AOvVaw1th4kPmvwr7OzkfjoXqk5Y)\] Add Fiber#\[\] and Fiber#\[\]= and restore Thread#\[\] and Thread#\[\]= to their original behavior (shyouhei)
 
 
 - akr: This is clear, but too late.
 
-- ## \[Feature [#10344](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10344&sa=D&source=editors&ust=1686087280554554&usg=AOvVaw33DADjQ83tpRt-HH9nB32p)\] \[PATCH\] Implement Fiber#raise (shyouhei)
+## \[Feature [#10344](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10344&sa=D&source=editors&ust=1686087280554554&usg=AOvVaw33DADjQ83tpRt-HH9nB32p)\] \[PATCH\] Implement Fiber#raise (shyouhei)
 
 
 - ko1: if we allow Fiber#raise, auto fiber shall introduce weired behaviour.
 - akr: I don’t think auto fiber should transfar exceptions.
 
-- ## \[Feature [#13923](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13923&sa=D&source=editors&ust=1686087280555160&usg=AOvVaw2aoTYfXoD7tVDS_mkTGqiH)\] Idiom to release resources safely, with less indentations (shyouhei)
+## \[Feature [#13923](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13923&sa=D&source=editors&ust=1686087280555160&usg=AOvVaw2aoTYfXoD7tVDS_mkTGqiH)\] Idiom to release resources safely, with less indentations (shyouhei)
 
 
 - shyouhei: This is what C++ resolves using RAII
@@ -441,7 +441,7 @@ puts "tomatoe".vegetables
 - matz: returning to the issue, let’s hear what the OP thinks about the nobu’s library.
 
 
-- ## \[Feature [#13919](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13919&sa=D&source=editors&ust=1686087280557224&usg=AOvVaw2sXUu_YLSxvW4f2OUGS7fw)\] Add a new method to create Time instances from unix time and nsec (shyouhei)
+## \[Feature [#13919](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13919&sa=D&source=editors&ust=1686087280557224&usg=AOvVaw2sXUu_YLSxvW4f2OUGS7fw)\] Add a new method to create Time instances from unix time and nsec (shyouhei)
 
 
 - naruse: I want it.
@@ -459,7 +459,7 @@ puts "tomatoe".vegetables
 - naruse: I think no practical usage are there for specifying both msec and nsec.
 - matz: OK, accepted.  But specifying nil shall raise exceptions.
 
-- ## \[Bug [#13887](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13887&sa=D&source=editors&ust=1686087280559317&usg=AOvVaw1Y6JrF6D3Ltd1KjmqbC9Il)\] test/ruby/test\_io.rb may get stuck with FIBER\_USE\_NATIVE=0 on Linux
+## \[Bug [#13887](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13887&sa=D&source=editors&ust=1686087280559317&usg=AOvVaw1Y6JrF6D3Ltd1KjmqbC9Il)\] test/ruby/test\_io.rb may get stuck with FIBER\_USE\_NATIVE=0 on Linux
 
 
 - ko1: this is a bug that should be fixed. I’ll do.

--- a/2018/DevMeeting-2018-01-24.md
+++ b/2018/DevMeeting-2018-01-24.md
@@ -150,24 +150,24 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 
 ## Revisions r61785, r61786, r61787 were introduced by the request from @naruse. However [shyouhei](https://www.google.com/url?q=https://bugs.ruby-lang.org/users/10&sa=D&source=editors&ust=1686087512360881&usg=AOvVaw0ePcJzCf5XdJSgCLsuD24q) thinks the request was somewhat vague.
 
-- ## Do we have to support such old toolchains? (shyouhei)
+- Do we have to support such old toolchains? (shyouhei)
 
-- ## Things we discussed:
+- Things we discussed:
 
 
-- ## Let’s make configure show the version of BASERUBY
+- Let’s make configure show the version of BASERUBY
 
-- ## That way we can detect failures on the CI matrix.
+- That way we can detect failures on the CI matrix.
 
 
 ## From attendees
 
-- ## \[Feature [#14223](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14223&sa=D&source=editors&ust=1686087512361697&usg=AOvVaw2qoIVwRQ21jZGfCNmt4Avp)\] Enable #to\_proc by Refinements at &hoge (nobu)
+## \[Feature [#14223](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14223&sa=D&source=editors&ust=1686087512361697&usg=AOvVaw2qoIVwRQ21jZGfCNmt4Avp)\] Enable #to\_proc by Refinements at &hoge (nobu)
 
 
 - Matz: LGTM.
 
-- ## \[Feature [#14371](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14371&sa=D&source=editors&ust=1686087512362186&usg=AOvVaw3C2jlghrPiW2dGUkolCj4y)\] New option "recursive: true" for Hash#transform\_keys! (nobu)
+## \[Feature [#14371](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14371&sa=D&source=editors&ust=1686087512362186&usg=AOvVaw3C2jlghrPiW2dGUkolCj4y)\] New option "recursive: true" for Hash#transform\_keys! (nobu)
 
 
 - Mrkn: This is deep\_stringify\_keys!
@@ -177,43 +177,43 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Knu: This method changes values as well as keys, which seems wrong.
 - Matz: This particular API seems NG to me.
 
-- ## \[Bug #14380\] Expected transform\_keys! to work just as transform\_keys, but it doesn't (mame)
+## \[Bug #14380\] Expected transform\_keys! to work just as transform\_keys, but it doesn't (mame)
 
 
 - Shyouhei: This behaviour was inherited from ActiveSupport.
 - Mrkn: we can fix it by preserving entries that conflict.
 - Matz: I have strong opinion on this.  Isn’t the current behaviour acceptable in sake of space efficiency?
 
-- ## \[Bug [#14374](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14374&sa=D&source=editors&ust=1686087512363214&usg=AOvVaw2B1puv_rNMyUOXl6K4ljSU)\] for does not splat elements (nobu)
+## \[Bug [#14374](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14374&sa=D&source=editors&ust=1686087512363214&usg=AOvVaw2B1puv_rNMyUOXl6K4ljSU)\] for does not splat elements (nobu)
 
 
 - Ko1: is it me?
 - Nobu: because it’s since 1.9
 - Matz: please fix.
 
-- ## \[Feature [#14313](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14313&sa=D&source=editors&ust=1686087512363750&usg=AOvVaw2KpS-czrNodNpwLcBg2XDl)\] Support creating KeyError with receiver and key from Ruby (mrkn/kou)
+## \[Feature [#14313](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14313&sa=D&source=editors&ust=1686087512363750&usg=AOvVaw2KpS-czrNodNpwLcBg2XDl)\] Support creating KeyError with receiver and key from Ruby (mrkn/kou)
 
 
 - Mrkn: I was asked to bring this.
 - Matz: Understand the needs.
 - Shyouhei: Should it be keyword arguments?
 
-- ## Maintainers of csv (mrkn/kou)
+- Maintainers of csv (mrkn/kou)
 
 
 - Mame: JEG2.
 - Mrkn: But he doesn’t have the repo access bit, nor gem release right.
 - Mame: He’s active on twitter etc.  You should ask his current status.
 
-- ## \[Feature [#4831](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4831&sa=D&source=editors&ust=1686087512364553&usg=AOvVaw2NGtLMxfwqnTu1GnsVIkwn)\] Integer#prime\_factors (mrkn)
+## \[Feature [#4831](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4831&sa=D&source=editors&ust=1686087512364553&usg=AOvVaw2NGtLMxfwqnTu1GnsVIkwn)\] Integer#prime\_factors (mrkn)
 
 
 - Mrkn: name?
 - Shyouhei: yugui is on the ticket.
 
-- ## \[Feature [#14235](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14235&sa=D&source=editors&ust=1686087512365105&usg=AOvVaw3eDxHEK0-D0acn16JHMRMx)\] Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
+## \[Feature [#14235](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14235&sa=D&source=editors&ust=1686087512365105&usg=AOvVaw3eDxHEK0-D0acn16JHMRMx)\] Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
 
-- ## \[Feature [#14386](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14386&sa=D&source=editors&ust=1686087512365387&usg=AOvVaw2AN5f2c2f_uvaRIS83hIRi)\] Add option to let Kernel.#system raise error instead of returning false (k0kubun)
+## \[Feature [#14386](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14386&sa=D&source=editors&ust=1686087512365387&usg=AOvVaw2AN5f2c2f_uvaRIS83hIRi)\] Add option to let Kernel.#system raise error instead of returning false (k0kubun)
 
 
 - Nobu: is this request to raise error when spawn fails, or when the spawned process fails?
@@ -222,7 +222,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Mrkn: I see similarity for discussion on Integer(). \[ruby-core:77171\] \[Feature#12732\]
 - Akr: There are \`exception: true\`
 
-- ## \[Bug [#14353](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14353&sa=D&source=editors&ust=1686087512365973&usg=AOvVaw1oixIdf58UwAT9WWQAxiYg)\] $SAFE should stay at least thread-local for compatibility (ko1)
+## \[Bug [#14353](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14353&sa=D&source=editors&ust=1686087512365973&usg=AOvVaw1oixIdf58UwAT9WWQAxiYg)\] $SAFE should stay at least thread-local for compatibility (ko1)
 
 
 - Matz: This feature is something to extinct in future.
@@ -248,7 +248,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 
 ## From non-attendees
 
-- ## \[Feature [#14382](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14382&sa=D&source=editors&ust=1686087512367039&usg=AOvVaw3gFB_Lay0sGojfbewW7Sa7)\] Make public access of a private constant call const\_missing (jeremyevans0)
+## \[Feature [#14382](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14382&sa=D&source=editors&ust=1686087512367039&usg=AOvVaw3gFB_Lay0sGojfbewW7Sa7)\] Make public access of a private constant call const\_missing (jeremyevans0)
 
 
 - Nobu: sounds like a bug to me
@@ -256,7 +256,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Matz: Let’s try.
 - Nobu: I’d like to review the patch.
 
-- ## \[Feature [#14385](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14385&sa=D&source=editors&ust=1686087512367688&usg=AOvVaw0eQ3yNpD38-9kMww4Bo970)\] Deprecate back-tick for Ruby 3 (hsbt)
+## \[Feature [#14385](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14385&sa=D&source=editors&ust=1686087512367688&usg=AOvVaw0eQ3yNpD38-9kMww4Bo970)\] Deprecate back-tick for Ruby 3 (hsbt)
 
 
 - Matz: I see several objections are there.
@@ -268,7 +268,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Mame: should we also deprecate def \`; end; self.\` ? If so, warning on parsing is dangerous.
 - Matz: I think we don’t necessarily warn this as soon as 2.6.
 
-- ## \[Feature [#13969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13969&sa=D&source=editors&ust=1686087512368511&usg=AOvVaw3WyXrLdBrk8ACvBw3WmPmA)\] Dir#each\_child (znz)
+## \[Feature [#13969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13969&sa=D&source=editors&ust=1686087512368511&usg=AOvVaw3WyXrLdBrk8ACvBw3WmPmA)\] Dir#each\_child (znz)
 
 
 - Matz: OK.

--- a/2018/DevMeeting-2018-02-20.md
+++ b/2018/DevMeeting-2018-02-20.md
@@ -151,24 +151,24 @@ Next Developper Meetings
 
 ## Revisions r61785, r61786, r61787 were introduced by the request from @naruse. However [shyouhei](https://www.google.com/url?q=https://bugs.ruby-lang.org/users/10&sa=D&source=editors&ust=1686087534729949&usg=AOvVaw0zCOxnLHfD-SAJpu3U4FWv) thinks the request was somewhat vague.
 
-- ## Do we have to support such old toolchains? (shyouhei)
+- Do we have to support such old toolchains? (shyouhei)
 
-- ## Things we discussed:
+- Things we discussed:
 
 
-- ## Let’s make configure show the version of BASERUBY
+- Let’s make configure show the version of BASERUBY
 
-- ## That way we can detect failures on the CI matrix.
+- That way we can detect failures on the CI matrix.
 
 
 ## From attendees
 
-- ## \[Feature [#14223](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14223&sa=D&source=editors&ust=1686087534730902&usg=AOvVaw0hKDkPhy2smcNbHV7h3t95)\] Enable #to\_proc by Refinements at &hoge (nobu)
+## \[Feature [#14223](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14223&sa=D&source=editors&ust=1686087534730902&usg=AOvVaw0hKDkPhy2smcNbHV7h3t95)\] Enable #to\_proc by Refinements at &hoge (nobu)
 
 
 - Matz: LGTM.
 
-- ## \[Feature [#14371](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14371&sa=D&source=editors&ust=1686087534731456&usg=AOvVaw0138Z7WbBbP8sVNjKJtboU)\] New option "recursive: true" for Hash#transform\_keys! (nobu)
+## \[Feature [#14371](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14371&sa=D&source=editors&ust=1686087534731456&usg=AOvVaw0138Z7WbBbP8sVNjKJtboU)\] New option "recursive: true" for Hash#transform\_keys! (nobu)
 
 
 - Mrkn: This is deep\_stringify\_keys!
@@ -178,43 +178,43 @@ Next Developper Meetings
 - Knu: This method changes values as well as keys, which seems wrong.
 - Matz: This particular API seems NG to me.
 
-- ## \[Bug #14380\] Expected transform\_keys! to work just as transform\_keys, but it doesn't (mame)
+## \[Bug #14380\] Expected transform\_keys! to work just as transform\_keys, but it doesn't (mame)
 
 
 - Shyouhei: This behaviour was inherited from ActiveSupport.
 - Mrkn: we can fix it by preserving entries that conflict.
 - Matz: I have strong opinion on this.  Isn’t the current behaviour acceptable in sake of space efficiency?
 
-- ## \[Bug [#14374](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14374&sa=D&source=editors&ust=1686087534732782&usg=AOvVaw23Evsh07gKVvWVGJqwzzPf)\] for does not splat elements (nobu)
+## \[Bug [#14374](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14374&sa=D&source=editors&ust=1686087534732782&usg=AOvVaw23Evsh07gKVvWVGJqwzzPf)\] for does not splat elements (nobu)
 
 
 - Ko1: is it me?
 - Nobu: because it’s since 1.9
 - Matz: please fix.
 
-- ## \[Feature [#14313](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14313&sa=D&source=editors&ust=1686087534733360&usg=AOvVaw01wZt0etef0uPW3YdiOET2)\] Support creating KeyError with receiver and key from Ruby (mrkn/kou)
+## \[Feature [#14313](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14313&sa=D&source=editors&ust=1686087534733360&usg=AOvVaw01wZt0etef0uPW3YdiOET2)\] Support creating KeyError with receiver and key from Ruby (mrkn/kou)
 
 
 - Mrkn: I was asked to bring this.
 - Matz: Understand the needs.
 - Shyouhei: Should it be keyword arguments?
 
-- ## Maintainers of csv (mrkn/kou)
+- Maintainers of csv (mrkn/kou)
 
 
 - Mame: JEG2.
 - Mrkn: But he doesn’t have the repo access bit, nor gem release right.
 - Mame: He’s active on twitter etc.  You should ask his current status.
 
-- ## \[Feature [#4831](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4831&sa=D&source=editors&ust=1686087534734216&usg=AOvVaw000s7NUFCbXTK8QZm0leib)\] Integer#prime\_factors (mrkn)
+## \[Feature [#4831](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4831&sa=D&source=editors&ust=1686087534734216&usg=AOvVaw000s7NUFCbXTK8QZm0leib)\] Integer#prime\_factors (mrkn)
 
 
 - Mrkn: name?
 - Shyouhei: yugui is on the ticket.
 
-- ## \[Feature [#14235](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14235&sa=D&source=editors&ust=1686087534734701&usg=AOvVaw3sHZaMuYBRg9KZEliD_l-L)\] Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
+## \[Feature [#14235](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14235&sa=D&source=editors&ust=1686087534734701&usg=AOvVaw3sHZaMuYBRg9KZEliD_l-L)\] Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
 
-- ## \[Feature [#14386](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14386&sa=D&source=editors&ust=1686087534735005&usg=AOvVaw0rq2r3IXro64FgAE0y6TSU)\] Add option to let Kernel.#system raise error instead of returning false (k0kubun)
+## \[Feature [#14386](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14386&sa=D&source=editors&ust=1686087534735005&usg=AOvVaw0rq2r3IXro64FgAE0y6TSU)\] Add option to let Kernel.#system raise error instead of returning false (k0kubun)
 
 
 - Nobu: is this request to raise error when spawn fails, or when the spawned process fails?
@@ -223,7 +223,7 @@ Next Developper Meetings
 - Mrkn: I see similarity for discussion on Integer(). \[ruby-core:77171\] \[Feature#12732\]
 - Akr: There are \`exception: true\`
 
-- ## \[Bug [#14353](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14353&sa=D&source=editors&ust=1686087534735695&usg=AOvVaw3VLRR_Wp944LrfkBaowubO)\] $SAFE should stay at least thread-local for compatibility (ko1)
+## \[Bug [#14353](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14353&sa=D&source=editors&ust=1686087534735695&usg=AOvVaw3VLRR_Wp944LrfkBaowubO)\] $SAFE should stay at least thread-local for compatibility (ko1)
 
 
 - Matz: This feature is something to extinct in future.
@@ -249,7 +249,7 @@ Next Developper Meetings
 
 ## From non-attendees
 
-- ## \[Feature [#14382](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14382&sa=D&source=editors&ust=1686087534736923&usg=AOvVaw1k6X3Y-H2yxkyqjbUiHTjO)\] Make public access of a private constant call const\_missing (jeremyevans0)
+## \[Feature [#14382](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14382&sa=D&source=editors&ust=1686087534736923&usg=AOvVaw1k6X3Y-H2yxkyqjbUiHTjO)\] Make public access of a private constant call const\_missing (jeremyevans0)
 
 
 - Nobu: sounds like a bug to me
@@ -257,7 +257,7 @@ Next Developper Meetings
 - Matz: Let’s try.
 - Nobu: I’d like to review the patch.
 
-- ## \[Feature [#14385](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14385&sa=D&source=editors&ust=1686087534737578&usg=AOvVaw1e4UbeKafR4WFVvojciJ0F)\] Deprecate back-tick for Ruby 3 (hsbt)
+## \[Feature [#14385](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14385&sa=D&source=editors&ust=1686087534737578&usg=AOvVaw1e4UbeKafR4WFVvojciJ0F)\] Deprecate back-tick for Ruby 3 (hsbt)
 
 
 - Matz: I see several objections are there.
@@ -269,7 +269,7 @@ Next Developper Meetings
 - Mame: should we also deprecate def \`; end; self.\` ? If so, warning on parsing is dangerous.
 - Matz: I think we don’t necessarily warn this as soon as 2.6.
 
-- ## \[Feature [#13969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13969&sa=D&source=editors&ust=1686087534738407&usg=AOvVaw08WBvi8j7alCbpQ1j1kSuU)\] Dir#each\_child (znz)
+## \[Feature [#13969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13969&sa=D&source=editors&ust=1686087534738407&usg=AOvVaw08WBvi8j7alCbpQ1j1kSuU)\] Dir#each\_child (znz)
 
 
 - Matz: OK.

--- a/2018/DevMeeting-2018-10-10.md
+++ b/2018/DevMeeting-2018-10-10.md
@@ -104,18 +104,18 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From Attendees
 
-- ## \[Feature [#14839](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14839&sa=D&source=editors&ust=1686088679122674&usg=AOvVaw2bQQy5J7FdfrrgTG3UxxMO)\] How to deal with capitalizing Georgian in Unicode 11.0.0 (duerst)
+## \[Feature [#14839](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14839&sa=D&source=editors&ust=1686088679122674&usg=AOvVaw2bQQy5J7FdfrrgTG3UxxMO)\] How to deal with capitalizing Georgian in Unicode 11.0.0 (duerst)
 
 
-- ## I need feedback on this to be able to implement in in time for the Ruby 2.6 release.
+- I need feedback on this to be able to implement in in time for the Ruby 2.6 release.
 
 - usa: What about keep things as is, to make Georgian people aware of the issue
 - duerst: Georgian characters can be detectable so theoretically it’s possible to have complete mapping of characters.
 
-- ## \[Feature [#15195](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15195&sa=D&source=editors&ust=1686088679123584&usg=AOvVaw1K4og-kfBz0kHzDNaeBvDc)\] How to deal with new Japanese era (duerst)
+## \[Feature [#15195](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15195&sa=D&source=editors&ust=1686088679123584&usg=AOvVaw1K4og-kfBz0kHzDNaeBvDc)\] How to deal with new Japanese era (duerst)
 
 
-- ## We should prepare early (even if it's just to check that we need to do nothing)
+- We should prepare early (even if it's just to check that we need to do nothing)
 
 - duerst: When I experienced Showa -> Heisei transition, I started using AD.
 - duerst: the new character itself can be handled without problem.  The problem, if any, is the decomposition of the character.  Also regexp.
@@ -124,10 +124,10 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - duerst: What about older versions? Backport?
 - naruse: If Unicode 12 could be released until 2.6.1, I think I can release 2.6.1 with Unicode 12.
 
-- ## How to address increasing spam to the bug tracker. (duerst)
+- How to address increasing spam to the bug tracker. (duerst)
 
 
-- ## #15212/#15213 are just two examples. They get removed (return a 404), which is good. But they reach the mailing list and its subscribers, which is a problem. Prefiltering bugs with URIs in titles seems to be a good start.
+- #15212/#15213 are just two examples. They get removed (return a 404), which is good. But they reach the mailing list and its subscribers, which is a problem. Prefiltering bugs with URIs in titles seems to be a good start.
 
 - hsbt: Efforts ongoing.
 - (details omitted from the log)
@@ -175,19 +175,19 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From non-attendees
 
-- ## \[Feature [#15123](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15123&sa=D&source=editors&ust=1686088679128709&usg=AOvVaw2cTGv7ZudKnUpc3XJNQyEP)\] Enumerable#compact proposal (greggzst)
+## \[Feature [#15123](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15123&sa=D&source=editors&ust=1686088679128709&usg=AOvVaw2cTGv7ZudKnUpc3XJNQyEP)\] Enumerable#compact proposal (greggzst)
 
 
-- ## It simplifies working with large and small collections so one doesn't have to remember that can't use #compact when enumerator is returned and have to fall back to #reject(:nil?).
+- It simplifies working with large and small collections so one doesn't have to remember that can't use #compact when enumerator is returned and have to fall back to #reject(:nil?).
 
 - usa: What does it return?
 - mrkn: Returns another enumerator.
 - matz: Use case not very clear to me.
 
-- ## \[Feature [#15112](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15112&sa=D&source=editors&ust=1686088679129838&usg=AOvVaw3knTOOjSSYwngR-x4IBwz-)\] Introduce the new singleton method STDERR.p (shevegen)
+## \[Feature [#15112](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15112&sa=D&source=editors&ust=1686088679129838&usg=AOvVaw3knTOOjSSYwngR-x4IBwz-)\] Introduce the new singleton method STDERR.p (shevegen)
 
 
-- ## I am mostly curious what the ruby core team thinks about Kenta Murata's proposal; it probably will not take too much time away discussing it briefly, since the scope is small.
+- I am mostly curious what the ruby core team thinks about Kenta Murata's proposal; it probably will not take too much time away discussing it briefly, since the scope is small.
 
 - shyouhei: This one conflicts with [#14609](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14609&sa=D&source=editors&ust=1686088679130477&usg=AOvVaw1ndxk_xT0ZOVkbwtggTqEg)
 - mame: Does it really conflict with that? Does anyone bother inspecting STDERR?
@@ -204,10 +204,10 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - akr: I think STDERR.p is acceptable but IO#p is too short.
 - mame: same feeling.
 
-- ## \[Feature [#11505](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11505&sa=D&source=editors&ust=1686088679131882&usg=AOvVaw0DJxaVuFWbTMyBIFg3ylDm)\] Module#=== should call #kind\_of? on the object rather than rb\_obj\_is\_kind\_of which only searches the ancestor hierarchy (rafaelfranca)
+## \[Feature [#11505](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11505&sa=D&source=editors&ust=1686088679131882&usg=AOvVaw0DJxaVuFWbTMyBIFg3ylDm)\] Module#=== should call #kind\_of? on the object rather than rb\_obj\_is\_kind\_of which only searches the ancestor hierarchy (rafaelfranca)
 
 
-- ## This would allow patterns as Decorator and Proxy to work with case statements.
+- This would allow patterns as Decorator and Proxy to work with case statements.
 
 - mame: I don’t understand the use case shown in the issue.
 - matz: I don’t think it works because the receiver of === is the class, not the object.
@@ -250,15 +250,15 @@ when Array
 
 end
 
-- ## \[Feature [#14912](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14912&sa=D&source=editors&ust=1686088679134393&usg=AOvVaw144dZgFkft9EebgHKGHjsJ)\] Introduce pattern matching syntax (greggzst)
+## \[Feature [#14912](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14912&sa=D&source=editors&ust=1686088679134393&usg=AOvVaw144dZgFkft9EebgHKGHjsJ)\] Introduce pattern matching syntax (greggzst)
 
 
-- ## Many modern languages have introduced pattern matching. I used it in scala and found it very easy to utilize and understand especially in recursion. It makes extracting data easier as well.
+- Many modern languages have introduced pattern matching. I used it in scala and found it very easy to utilize and understand especially in recursion. It makes extracting data easier as well.
 
 - shyouhei: Any updates?
 - mame: We should ask the status for @k-tsj
 
-- ## \[Feature [#15144](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15144&sa=D&source=editors&ust=1686088679135194&usg=AOvVaw2AnwhuYwKQuW-K-aX_mUEJ)\] Enumerator#chain (zverok)
+## \[Feature [#15144](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15144&sa=D&source=editors&ust=1686088679135194&usg=AOvVaw2AnwhuYwKQuW-K-aX_mUEJ)\] Enumerator#chain (zverok)
 
 
 - knu: Understand the needs. Name?
@@ -278,7 +278,7 @@ end
 
 ## I am not sure if it is appropriate, but I'd also be very glad to hear about some "stale" discussions. They were typically reacted on developer meetings as "in general, good proposal (but not sure when it would be implemented/not sure about the name)", or something like that, and I'd like to know maybe we should do something to push them further? List of tickets:
 
-- ## \[Feature [#14799](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14799&sa=D&source=editors&ust=1686088679137240&usg=AOvVaw1BSPXlfNqL-ZwF_1tL8V4b)\] Startless range: usefulness discussed, patch provided by mame (Yusuke Endoh), waits for Matz's decision (?)
+## \[Feature [#14799](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14799&sa=D&source=editors&ust=1686088679137240&usg=AOvVaw1BSPXlfNqL-ZwF_1tL8V4b)\] Startless range: usefulness discussed, patch provided by mame (Yusuke Endoh), waits for Matz's decision (?)
 
 
 - mame: I can have 2.5 without it.
@@ -286,18 +286,18 @@ end
 - mame: What about right after when?
 - matz: Mmm…. That’s difficult.
 
-- ## \[Feature [#14784](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14784&sa=D&source=editors&ust=1686088679138176&usg=AOvVaw0EQnfP5CGnYujJS11wowWM)\] Comparable#clamp accepting range: comment for akr (Akira Tanaka) about "needlessly big" proposal, I answered it, is it makes the proposal more likely to be accepted?
+## \[Feature [#14784](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14784&sa=D&source=editors&ust=1686088679138176&usg=AOvVaw0EQnfP5CGnYujJS11wowWM)\] Comparable#clamp accepting range: comment for akr (Akira Tanaka) about "needlessly big" proposal, I answered it, is it makes the proposal more likely to be accepted?
 
 
 - Nobody is against #clamp accepting ranges.  The issue did not seem requesting that, rather it was for one-sided clamp.
 
-- ## \[Feature [#6284](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6284&sa=D&source=editors&ust=1686088679138785&usg=AOvVaw30xn7FVqiBRSttTaThEcXt)\] Composition for procs: the last thing Matz has said is the operators are chosen (<< and \>>), and "We need more discussion if we would add combination methods to the Symbol class." Is there a chance proc composition would make it way in the 2.6?
+## \[Feature [#6284](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6284&sa=D&source=editors&ust=1686088679138785&usg=AOvVaw30xn7FVqiBRSttTaThEcXt)\] Composition for procs: the last thing Matz has said is the operators are chosen (<< and \>>), and "We need more discussion if we would add combination methods to the Symbol class." Is there a chance proc composition would make it way in the 2.6?
 
 
 - usa: This has been accepted. (at [https://bugs.ruby-lang.org/issues/6284#note-55](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6284%23note-55&sa=D&source=editors&ust=1686088679139291&usg=AOvVaw3uKEYU9R4IM6vkIsf9ZVKF))
 - ko1: @nobu is assigned.  Waiting for him to implement.
 
-- ## \[Feature [#13581](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13581&sa=D&source=editors&ust=1686088679139760&usg=AOvVaw3NViQCG-e7amXwSzn_h54b)\] Syntax sugar for method reference. The last thing Matz have said is: ".: looks best to me (followed by :::). Let me consider it for a while." Are there any choices made? Could we expect this for 2.6?
+## \[Feature [#13581](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13581&sa=D&source=editors&ust=1686088679139760&usg=AOvVaw3NViQCG-e7amXwSzn_h54b)\] Syntax sugar for method reference. The last thing Matz have said is: ".: looks best to me (followed by :::). Let me consider it for a while." Are there any choices made? Could we expect this for 2.6?
 
 
 - matz: Honestly I still don’t find the right name.
@@ -308,7 +308,7 @@ end
 - ko1: It might matter you, but not for the OP.
 - shyouhei: Maybe.
 
-- ## \[Feature [#14781](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14781&sa=D&source=editors&ust=1686088679140744&usg=AOvVaw3CDIYP3AMZiqrMegQgYH80)\] Enumerator#generate It seems like people feel cautious enthusiasm about it, but not sure about the name. What should be done here? Voting on the name? Providing the patch with some name, and then voting for the name?
+## \[Feature [#14781](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14781&sa=D&source=editors&ust=1686088679140744&usg=AOvVaw3CDIYP3AMZiqrMegQgYH80)\] Enumerator#generate It seems like people feel cautious enthusiasm about it, but not sure about the name. What should be done here? Voting on the name? Providing the patch with some name, and then voting for the name?
 
 
 - Everybody is against #generate.

--- a/2018/DevMeeting-2018-11-22.md
+++ b/2018/DevMeeting-2018-11-22.md
@@ -120,25 +120,25 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From Attendees
 
-- ## Mame: How about changing the meeting time? 14:00-18:00 → 13:00-17:00
+- Mame: How about changing the meeting time? 14:00-18:00 → 13:00-17:00
 
 
 - OK but 12/12 is 13:30-.
 
-- ## \[Feature [#15144](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15144&sa=D&source=editors&ust=1686088712085884&usg=AOvVaw224TkP6VNsxLlh6RTQcaae)\] Enumerator#chain (zverok)
+## \[Feature [#15144](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15144&sa=D&source=editors&ust=1686088712085884&usg=AOvVaw224TkP6VNsxLlh6RTQcaae)\] Enumerator#chain (zverok)
 
 
-- ## A.k.a. Enumerator#+
+- A.k.a. Enumerator#+
 
-- ## knu posted an implementation
+- knu posted an implementation
 
 - Matz: why not Enumerable#chain ?
 - Knu: definitely agreed!
 
-- ## \[[Bug #14127](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14127&sa=D&source=editors&ust=1686088712086925&usg=AOvVaw2Z35sH67fhIcvo-nrSZt2y)\] generating UTF-16LE encoded file without BOM (nobu)
+## \[[Bug #14127](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14127&sa=D&source=editors&ust=1686088712086925&usg=AOvVaw2Z35sH67fhIcvo-nrSZt2y)\] generating UTF-16LE encoded file without BOM (nobu)
 
 
-- ## Although this is not a bug of csv.rb, I'd suggest to enable "bom|" flag when writing instead. [https://github.com/nobu/ruby/tree/bug/14127-bom-header](https://www.google.com/url?q=https://github.com/nobu/ruby/tree/bug/14127-bom-header&sa=D&source=editors&ust=1686088712087403&usg=AOvVaw07eDDCfswI7U6fwA0R3jBj)
+- Although this is not a bug of csv.rb, I'd suggest to enable "bom|" flag when writing instead. [https://github.com/nobu/ruby/tree/bug/14127-bom-header](https://www.google.com/url?q=https://github.com/nobu/ruby/tree/bug/14127-bom-header&sa=D&source=editors&ust=1686088712087403&usg=AOvVaw07eDDCfswI7U6fwA0R3jBj)
 
 - Usa: can this be made for “r+” and / or “a”?
 - Nobu: the proposed patch writes bom only when the pos is zero.
@@ -147,10 +147,10 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Knu: We need a concrete specification first as to when a BOM is written.
 - Ko1: file a new ticket for this.
 
-- ## \[Feature [#15230](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15230&sa=D&source=editors&ust=1686088712088348&usg=AOvVaw3deEsz-Hf8yfQK_tb_PV3_)\] RubyVM.resolve\_feature\_path (mame)
+## \[Feature [#15230](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15230&sa=D&source=editors&ust=1686088712088348&usg=AOvVaw3deEsz-Hf8yfQK_tb_PV3_)\] RubyVM.resolve\_feature\_path (mame)
 
 
-- ## I'd like this feature to investigate what will be loaded by require(feature).
+- I'd like this feature to investigate what will be loaded by require(feature).
 
 - Mame: I want it because I am writing a static analyzer and that wants this kind of thing.
 - Shyouhei: I have concerns that this method can be absued.
@@ -159,10 +159,10 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Usa: I think it’s a good feature in general; the proposal seems like a rough cut though.
 - Matz: I have no strong objection.
 
-- ## \[Feature [#15231](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15231&sa=D&source=editors&ust=1686088712089554&usg=AOvVaw3_0vwrX-wvbeDBvo8epvhX)\] Remove Object#=~ (mame)
+## \[Feature [#15231](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15231&sa=D&source=editors&ust=1686088712089554&usg=AOvVaw3_0vwrX-wvbeDBvo8epvhX)\] Remove Object#=~ (mame)
 
 
-- ## The method looks useless, and made a trouble at least for me. I'd like to hear opinions from other committers.
+- The method looks useless, and made a trouble at least for me. I'd like to hear opinions from other committers.
 
 - (nobody is against removal)
 - Ko1: NilClass#=~ should remain.
@@ -172,14 +172,14 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Knu: people might have their own =~, so deleting !~ affect them.
 - Akira: it seems sequel defines =~ and not for !~
 
-- ## \[Feature [#11689](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11689&sa=D&source=editors&ust=1686088712090731&usg=AOvVaw1QbOo0e_-o7CbtOKGiGO_b)\] Add methods allow us to get visibility from Method and UnboundMethod object. (yui-knk)
+## \[Feature [#11689](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11689&sa=D&source=editors&ust=1686088712090731&usg=AOvVaw1QbOo0e_-o7CbtOKGiGO_b)\] Add methods allow us to get visibility from Method and UnboundMethod object. (yui-knk)
 
 
-- ## I want to introduce this feature to help meta programming. I'd like to hear opinions from other committers.
+- I want to introduce this feature to help meta programming. I'd like to hear opinions from other committers.
 
 - Matz: the concept is not if a method is “visible” or not, but if a method is “callable” or not.  So I feel a bit NG to call it visibility.
 
-- ## \[Feature [#15286](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15286&sa=D&source=editors&ust=1686088712091500&usg=AOvVaw1TAEJbmyxvEayuVDw3aTvF)\] Proposal: Add Kernel.#expand(\*args) (aycabta)
+## \[Feature [#15286](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15286&sa=D&source=editors&ust=1686088712091500&usg=AOvVaw1TAEJbmyxvEayuVDw3aTvF)\] Proposal: Add Kernel.#expand(\*args) (aycabta)
 
 
 - Matz: I don’t like the name.
@@ -190,71 +190,71 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Mrkn: { a: a } is much shorter than binding.expand(a) …
 - Naruse: tell us a more realistic use-case.
 
-- ## \[Bug [#15285](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15285&sa=D&source=editors&ust=1686088712092361&usg=AOvVaw24KvmZ8QvBPdvTjFxTY_pR)\] lambda return behavior regression from [#14639](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14639&sa=D&source=editors&ust=1686088712092576&usg=AOvVaw33j50fJzH80cNRKsmeVlf5) (nobu)
+## \[Bug [#15285](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15285&sa=D&source=editors&ust=1686088712092361&usg=AOvVaw24KvmZ8QvBPdvTjFxTY_pR)\] lambda return behavior regression from [#14639](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14639&sa=D&source=editors&ust=1686088712092576&usg=AOvVaw33j50fJzH80cNRKsmeVlf5) (nobu)
 
-- ## \[Feature [#15289](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15289&sa=D&source=editors&ust=1686088712092980&usg=AOvVaw0unzlueUD80UBrUMffkaf5)\] Accept "target" keyword on TracePoint#enable (ko1)
+## \[Feature [#15289](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15289&sa=D&source=editors&ust=1686088712092980&usg=AOvVaw0unzlueUD80UBrUMffkaf5)\] Accept "target" keyword on TracePoint#enable (ko1)
 
 
 - Matz: OK, do it yourself.
 
-- ## \[Feature [#15287](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15287&sa=D&source=editors&ust=1686088712093478&usg=AOvVaw2QaM8Jxu1jN7Vj2dhgdT5w)\] New TracePoint events to support loading features (ko1)
+## \[Feature [#15287](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15287&sa=D&source=editors&ust=1686088712093478&usg=AOvVaw2QaM8Jxu1jN7Vj2dhgdT5w)\] New TracePoint events to support loading features (ko1)
 
 
 - Matz: Ok except naming “loaded”. Koichi should name good name.
 
-- ## \[Bug [#6087](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6087&sa=D&source=editors&ust=1686088712093961&usg=AOvVaw0Zl5DkaYXuC2iRWWZJONkJ)\] How should inherited methods deal with return values of their own subclass? (mame)
+## \[Bug [#6087](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6087&sa=D&source=editors&ust=1686088712093961&usg=AOvVaw0Zl5DkaYXuC2iRWWZJONkJ)\] How should inherited methods deal with return values of their own subclass? (mame)
 
 
-- ## 6 years ago, matz decided that class A < Array; end; A.new.flatten.class #=> A in 2.X, Array in 3.0. Just confirm: has the decision been still unchanged?
+- 6 years ago, matz decided that class A < Array; end; A.new.flatten.class #=> A in 2.X, Array in 3.0. Just confirm: has the decision been still unchanged?
 
 - Matz: It is not obvious in each case if the operation is collecting elements (i.e. making an Array object) or making an altered version of the container object.
 - Knu: select() is a good example.  It may be considered a method for obtaining a subset or a method that collects matching elements into an array.  Hash#select() changed to return a Hash because it seemed more useful than returning an alist.
 - Nobu: Methods defined by Enumerable all return an array.
 - Knu: Making all Array methods return an Array object would make it harder to define your own array-like container by subclassing Array.
 
-- ## \[Feature [#15317](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15317&sa=D&source=editors&ust=1686088712094822&usg=AOvVaw0BWiht9rsVqDDWwtE_dkZ5)\] How to deal with obsolete property values in Unicode 11.0.0 (duerst)
+## \[Feature [#15317](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15317&sa=D&source=editors&ust=1686088712094822&usg=AOvVaw0BWiht9rsVqDDWwtE_dkZ5)\] How to deal with obsolete property values in Unicode 11.0.0 (duerst)
 
 
-- ## A clear idea on this is needed to upgrade to Unicode 11.0.0.
+- A clear idea on this is needed to upgrade to Unicode 11.0.0.
 
 - Martin: one property value has disappeared.
 - Naruse: program error is preferred here because we can be aware of such breakage before actually deploying the code.
 - Mame: what about issuing a warning instead?
 
-- ## \[Feature [#13890](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13890&sa=D&source=editors&ust=1686088712095732&usg=AOvVaw03cQlKTH78s-fYWBUNZdV2)\] Allow a regexp as an argument to 'count', to count more interesting things than single characters (duerst)
+## \[Feature [#13890](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13890&sa=D&source=editors&ust=1686088712095732&usg=AOvVaw03cQlKTH78s-fYWBUNZdV2)\] Allow a regexp as an argument to 'count', to count more interesting things than single characters (duerst)
 
 
-- ## I find this missing regularly, and writing it by hand in Ruby is clumsy, so addition would be valuable.
+- I find this missing regularly, and writing it by hand in Ruby is clumsy, so addition would be valuable.
 
 
-- ## \[Feature [#12698](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12698&sa=D&source=editors&ust=1686088712096354&usg=AOvVaw0ErVMZ3NLQBNWZMFHyq0tF)\] Method to delete a substring by regex match (duerst)
+## \[Feature [#12698](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12698&sa=D&source=editors&ust=1686088712096354&usg=AOvVaw0ErVMZ3NLQBNWZMFHyq0tF)\] Method to delete a substring by regex match (duerst)
 
 
 ## From non-attendees
 
-- ## \[Feature [#15220](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15220&sa=D&source=editors&ust=1686088712096857&usg=AOvVaw3orANVpeO1wzaiWnTRYl5P)\] Adding OpenSSL 1.1.1 on Travis CI gcc-8 case (jaruga)
+## \[Feature [#15220](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15220&sa=D&source=editors&ust=1686088712096857&usg=AOvVaw3orANVpeO1wzaiWnTRYl5P)\] Adding OpenSSL 1.1.1 on Travis CI gcc-8 case (jaruga)
 
 
-- ## To detect an issue for the latest OpenSSL early and guarantee a Ruby version supporting a OpenSSL version.
+- To detect an issue for the latest OpenSSL early and guarantee a Ruby version supporting a OpenSSL version.
 
 - Shyouhei: I had already added one.
 
-- ## \[Feature [#15301](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15301&sa=D&source=editors&ust=1686088712097438&usg=AOvVaw08rZdhyo_hoxgXp0lUAcmI)\] Symbol#call, returning method bound with arguments (zverok)
+## \[Feature [#15301](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15301&sa=D&source=editors&ust=1686088712097438&usg=AOvVaw08rZdhyo_hoxgXp0lUAcmI)\] Symbol#call, returning method bound with arguments (zverok)
 
 
 - Matz: I’m very faintly against it.
 
-- ## \[Feature [#15302](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15302&sa=D&source=editors&ust=1686088712097954&usg=AOvVaw37vDYz8udDMp2y5h2bPMyY)\] Proc#with and Proc#by, for partial function application and currying (Ritchie Buitre)
+## \[Feature [#15302](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15302&sa=D&source=editors&ust=1686088712097954&usg=AOvVaw37vDYz8udDMp2y5h2bPMyY)\] Proc#with and Proc#by, for partial function application and currying (Ritchie Buitre)
 
 
-- ## Convenient methods for functional programming.
+- Convenient methods for functional programming.
 
 - Matz: which is which? (looks confused at the first glance)
 - Matz: I don’t like the name.
 - Ko1: Is the naming only concern?
 - Matz: Not against the feature but I feel the notation is not right.
 
-- ## \[Bug [#14968](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14968&sa=D&source=editors&ust=1686088712099037&usg=AOvVaw1kbmTiRYvunskq26MzAlrW)\] make all pipes and sockets non-blocking by default (normalperson)
+## \[Bug [#14968](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14968&sa=D&source=editors&ust=1686088712099037&usg=AOvVaw1kbmTiRYvunskq26MzAlrW)\] make all pipes and sockets non-blocking by default (normalperson)
 
 
 - Shyouhei: AFAIK there is a problem on Windows.
@@ -269,15 +269,15 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Matz: maybe we should try it and fix or back out as necessary?
 - Naruse: so Eric should commit it today.
 
-- ## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686088712100090&usg=AOvVaw2Yz0V2EUrQG2cH57pWgdm3)\] Thread::Light for 2.6 [ruby-core:89900](https://www.google.com/url?q=http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/89900&sa=D&source=editors&ust=1686088712100336&usg=AOvVaw2E2xLnXfEImCceXhiNoWCQ)
+## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686088712100090&usg=AOvVaw2Yz0V2EUrQG2cH57pWgdm3)\] Thread::Light for 2.6 [ruby-core:89900](https://www.google.com/url?q=http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/89900&sa=D&source=editors&ust=1686088712100336&usg=AOvVaw2E2xLnXfEImCceXhiNoWCQ)
 
 
 - Matz: will respond.
 
-- ## \[Feature [#10548](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10548&sa=D&source=editors&ust=1686088712100796&usg=AOvVaw0zEsCysogJ_umPhZc6Zb2g)\] remove callcc (Callcc is now going obsolete. Please use Fiber.) (ioquatix)
+## \[Feature [#10548](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10548&sa=D&source=editors&ust=1686088712100796&usg=AOvVaw0zEsCysogJ_umPhZc6Zb2g)\] remove callcc (Callcc is now going obsolete. Please use Fiber.) (ioquatix)
 
 
-- ## It's unofficially deprecated, unsupported in most implementations of Ruby, and not used very much. Do you think it's a good idea to drop support by 3.0?
+- It's unofficially deprecated, unsupported in most implementations of Ruby, and not used very much. Do you think it's a good idea to drop support by 3.0?
 
 - Ko1: callcc has many issues.  We have some workarounds, but that must be insufficient.
 - Mame: I don’t think it’s worth deleting because nobody actually uses this feature in production, thus deletion has no practical benefit.
@@ -285,7 +285,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Usa: for 3x3?
 - Matz: may not make it 3x faster.
 
-- ## \[Feature [#15327](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15327&sa=D&source=editors&ust=1686088712101815&usg=AOvVaw0DyqtlUC70v-eY9yFbFhNa)\] Proposal: Enable refinements to #respond\_to? (osyo)
+## \[Feature [#15327](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15327&sa=D&source=editors&ust=1686088712101815&usg=AOvVaw0DyqtlUC70v-eY9yFbFhNa)\] Proposal: Enable refinements to #respond\_to? (osyo)
 
 
 - Matz: Mmm.
@@ -300,23 +300,23 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - (everybody started thinking...)
 - Ko1: OK, let’s not think about it for a while.
 
-- ## \[Feature [#15326](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15326&sa=D&source=editors&ust=1686088712103265&usg=AOvVaw3AC8Vwzk343AgoNcmaXwTZ)\] Proposal: Enable refinements to #public\_send (osyo)
+## \[Feature [#15326](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15326&sa=D&source=editors&ust=1686088712103265&usg=AOvVaw3AC8Vwzk343AgoNcmaXwTZ)\] Proposal: Enable refinements to #public\_send (osyo)
 
 
 - Matz: this one makes sense. Accepted.
 
-- ## \[Feature [#15114](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15114&sa=D&source=editors&ust=1686088712103966&usg=AOvVaw1MAJ1l4hfeQN7N5jetOuxt)\] Symbol#to\_proc does not work with refinements? (osyo)
+## \[Feature [#15114](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15114&sa=D&source=editors&ust=1686088712103966&usg=AOvVaw1MAJ1l4hfeQN7N5jetOuxt)\] Symbol#to\_proc does not work with refinements? (osyo)
 
 
-- ## I want to more refinements!
+- I want to more refinements!
 
 - Matz: sounds like a bug?
 - assign nobu
 
-- ## \[Feature [#15330](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15330&sa=D&source=editors&ust=1686088712104834&usg=AOvVaw2Cjz0EDUw_mngr-bISmGIQ)\] Proposal: autoload\_relative (marcandre)
+## \[Feature [#15330](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15330&sa=D&source=editors&ust=1686088712104834&usg=AOvVaw2Cjz0EDUw_mngr-bISmGIQ)\] Proposal: autoload\_relative (marcandre)
 
 
-- ## This feature is actually more useful than autoload and should be added to 2.6
+- This feature is actually more useful than autoload and should be added to 2.6
 
 - Matz: why people love autoload, why…?
 - Naruse: What is new in this issue is not why, but how much people love autoloads.


### PR DESCRIPTION
## Summary

Meeting logs from 2017-2018 that were exported from Google Docs have ticket headings incorrectly nested inside list items, e.g.:

```markdown
- ## \[Feature #14844\] Some title
```

This causes them to render as list items instead of standalone section headings.

## Changes

**Ticket headings** like `- ## \[Feature #NNNNN\]` and `- ## https://...` are promoted to standalone H2 headings by stripping the `- ` prefix:

```diff
-- ## \[Feature #14844\] Some title
+## \[Feature #14844\] Some title
```

**Discussion text** like `- ## I need feedback on this` is converted to plain list items by removing the erroneous `## ` markup:

```diff
-- ## I need feedback on this
+- I need feedback on this
```

## Affected files

12 files across 2017-2018:

- `2017/DevMeeting-2017-01-19.md`
- `2017/DevMeeting-2017-03-13.md`
- `2017/DevMeeting-2017-04-17.md`
- `2017/DevMeeting-2017-05-19.md`
- `2017/DevMeeting-2017-06-16.md`
- `2017/DevMeeting-2017-07-14.md`
- `2017/DevMeeting-2017-08-31.md`
- `2017/DevMeeting-2017-09-25.md`
- `2018/DevMeeting-2018-01-24.md`
- `2018/DevMeeting-2018-02-20.md`
- `2018/DevMeeting-2018-10-10.md`
- `2018/DevMeeting-2018-11-22.md`