### PR TITLE
Demote H1 ticket headings to H2 in Log sections (2015-2016)

### DIFF
--- a/2015/DevMeeting-2015-04-08.md
+++ b/2015/DevMeeting-2015-04-08.md
@@ -166,4 +166,4 @@ matz, akr, hsbt, nurse, nobu, ayumin, sora, ko1
 
 (matz) reject.
 
-# Next meeting -> 2015/05/14 (Thu) 14:00- (JST)
+## Next meeting -> 2015/05/14 (Thu) 14:00- (JST)

--- a/2015/DevMeeting-2015-05-14.md
+++ b/2015/DevMeeting-2015-05-14.md
@@ -49,7 +49,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 Attendee: ko1,ayumin,akr,hsbt,naruse; matz,sora\_h
 
-# \[Feature [#11084](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11084&sa=D&source=editors&ust=1686086372471249&usg=AOvVaw1AUX-rPJiMbGnUU6Uy2K8P)\] Use rb-readline instead of ext/readline
+## \[Feature [#11084](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11084&sa=D&source=editors&ust=1686086372471249&usg=AOvVaw1AUX-rPJiMbGnUU6Uy2K8P)\] Use rb-readline instead of ext/readline
 
 hsbt: Ruby needs readline. openssl, zlib to build. rb-readline is a pure Ruby library. Replacing current readline with rb-readline (as a bundled gem) helps build problems. Current readline will be a gem. Now windows ruby installer already use rb-readline.
 
@@ -87,7 +87,7 @@ Next action:
 
 hsbt: I continue to use rb-readline and try it.
 
-# \[Feature [#11083](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11083&sa=D&source=editors&ust=1686086372474766&usg=AOvVaw1fsqftrcsDUHDGZ8iwYzHx)\] Gemify net-telnet
+## \[Feature [#11083](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11083&sa=D&source=editors&ust=1686086372474766&usg=AOvVaw1fsqftrcsDUHDGZ8iwYzHx)\] Gemify net-telnet
 
 hsbt: no maintainer so it should be gemify.
 
@@ -97,7 +97,7 @@ hsbt: Not sure.
 
 Matz: I accept bundled gem.
 
-# \[Feature [#11082](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11082&sa=D&source=editors&ust=1686086372475773&usg=AOvVaw1It0FTzDf5YEnqD85dlndN)\] Remove condition of RUBY\_VERSION < 1.9 (hsbt)
+## \[Feature [#11082](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11082&sa=D&source=editors&ust=1686086372475773&usg=AOvVaw1It0FTzDf5YEnqD85dlndN)\] Remove condition of RUBY\_VERSION < 1.9 (hsbt)
 
 hsbt: Title is wrong. Not < 1.9, but <= 1.9.
 
@@ -123,7 +123,7 @@ ayumin: Positive because using newer features helps to evaluate such features.
 
 ko1: Use newer features with keeping compatibility.
 
-# \[Feature [#11049](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11049&sa=D&source=editors&ust=1686086372477343&usg=AOvVaw3ZF7dRSTNliaZ_h1qb9ybU)\] Enumerable#grep\_v (inversed grep) (sorah)
+## \[Feature [#11049](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11049&sa=D&source=editors&ust=1686086372477343&usg=AOvVaw3ZF7dRSTNliaZ_h1qb9ybU)\] Enumerable#grep\_v (inversed grep) (sorah)
 
 matz: are you okay to use the name “grep\_v”
 
@@ -141,7 +141,7 @@ matz: but grep\_v() is okay. -> accept on ticket.
 
 naruse: How about reject(pattern) ?
 
-# \[Bug [#10967](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10967&sa=D&source=editors&ust=1686086372478539&usg=AOvVaw2yV2ubsSc32pjwiv479d8v)\] Remove "private attribute?" warning (zzak)
+## \[Bug [#10967](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10967&sa=D&source=editors&ust=1686086372478539&usg=AOvVaw2yV2ubsSc32pjwiv479d8v)\] Remove "private attribute?" warning (zzak)
 
 akr: self.private\_something\_method is accepted recently.
 
@@ -149,7 +149,7 @@ naruse: test can find problem, so warning is not needed.
 
 matz: accept .
 
-# \[Feature [#10984](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10984&sa=D&source=editors&ust=1686086372479409&usg=AOvVaw1aj9mfL62pDDl_MsKtey31)\] Hash#contain? (zzak)
+## \[Feature [#10984](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10984&sa=D&source=editors&ust=1686086372479409&usg=AOvVaw1aj9mfL62pDDl_MsKtey31)\] Hash#contain? (zzak)
 
 akr: “contain” is too general. “subhash”?
 
@@ -157,7 +157,7 @@ n0kada: “contain?” seems similiar to “include?”
 
 akr: do we really use? we need concrete examples.
 
-# \[Bug [#10856](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10856&sa=D&source=editors&ust=1686086372480104&usg=AOvVaw1SZKB2wQZXPLpvAn1DfTLl)\] Splat with empty keyword args
+## \[Bug [#10856](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10856&sa=D&source=editors&ust=1686086372480104&usg=AOvVaw1SZKB2wQZXPLpvAn1DfTLl)\] Splat with empty keyword args
 
 def foo
 
@@ -185,13 +185,13 @@ foo(\*\*{}) #=> okay
 
 The first one seems wrong code, so an error is reasonable.
 
-# \[Feature [#11140](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11140&sa=D&source=editors&ust=1686086372482440&usg=AOvVaw3tq9ifZ7KxS9gLVIZDFF1h)\] autoload should call Kernel.require to give rubygems a chance to handle loading (tenderlove)
+## \[Feature [#11140](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11140&sa=D&source=editors&ust=1686086372482440&usg=AOvVaw3tq9ifZ7KxS9gLVIZDFF1h)\] autoload should call Kernel.require to give rubygems a chance to handle loading (tenderlove)
 
 nobu: no problem. -r already calls replaced require().
 
 matz: accept.
 
-# \[Feature [#11151](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11151&sa=D&source=editors&ust=1686086372483286&usg=AOvVaw1CSypUyGvqTK8mEViTqT2M)\] Numeric#positive? and Numeric#negative?
+## \[Feature [#11151](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11151&sa=D&source=editors&ust=1686086372483286&usg=AOvVaw1CSypUyGvqTK8mEViTqT2M)\] Numeric#positive? and Numeric#negative?
 
 akr: well usecase.
 
@@ -305,6 +305,6 @@ Binding#local\_variable\_set(:a, 1)
 
 binding.local\_variables(%i(a b c))
 
-# Next meeting
+## Next meeting
 
 2015/06/12 14:00-18:30 @ SFDC JP

--- a/2015/DevMeeting-2015-06-12.md
+++ b/2015/DevMeeting-2015-06-12.md
@@ -55,7 +55,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 Attendee: akr, hsbt, ko1, matz, naruse, nobu
 
-# \[Feature [#7148](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7148&sa=D&source=editors&ust=1686086420316632&usg=AOvVaw04IpXnttiOw_m9h0ZX0k21)\] Improved Tempfile w/o DelegateClass (glass\_saga)
+## \[Feature [#7148](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7148&sa=D&source=editors&ust=1686086420316632&usg=AOvVaw04IpXnttiOw_m9h0ZX0k21)\] Improved Tempfile w/o DelegateClass (glass\_saga)
 
 matz: I have some issue on this proposal. Tempfile should not be a subclass of File. It is different concept from File. I’m okay to implement Tempfile without delegator. However, I’m not sure it implemeted with subclass of File.
 
@@ -63,7 +63,7 @@ File is a wrapper of fd. Tempfile is not only a wrapper but handle other informa
 
 Action: Matz will reply this issue.
 
-# \[Feature [#11218](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11218&sa=D&source=editors&ust=1686086420317787&usg=AOvVaw0KSke3_MK8esxsZUYJqlZy)\] File.open FILE\_SHARE\_DELETE (naruse)
+## \[Feature [#11218](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11218&sa=D&source=editors&ust=1686086420317787&usg=AOvVaw0KSke3_MK8esxsZUYJqlZy)\] File.open FILE\_SHARE\_DELETE (naruse)
 
 naruse: (explain about this proposal). This proposal is only for Windows.
 
@@ -85,7 +85,7 @@ naruse: I need modestr2modeint for add the new integer flag (rb\_io\_modestr\_of
 
 Action: Discuss on ticket
 
-# \[Feature [#11251](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11251&sa=D&source=editors&ust=1686086420320036&usg=AOvVaw2BT9ptJ9dw8OOgeTtfybkc)\] pthread\_set\_name\_np (naruse)
+## \[Feature [#11251](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11251&sa=D&source=editors&ust=1686086420320036&usg=AOvVaw2BT9ptJ9dw8OOgeTtfybkc)\] pthread\_set\_name\_np (naruse)
 
 ko1: Interface?
 
@@ -103,25 +103,25 @@ Action: naruse will implement it
 
 Action: reply on issue.
 
-# \[Feature [#5455](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5455&sa=D&source=editors&ust=1686086420322762&usg=AOvVaw39dNDxfnYfswP6nGQe0Ebv)\] $SAFE should be removed(hsbt)
+## \[Feature [#5455](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5455&sa=D&source=editors&ust=1686086420322762&usg=AOvVaw39dNDxfnYfswP6nGQe0Ebv)\] $SAFE should be removed(hsbt)
 
 matz: $2 and $3 can be removed.
 
 Action: Matz will reply on ticket. hsbt-san will try implent.
 
-# \[Feature [#10730](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10730&sa=D&source=editors&ust=1686086420324242&usg=AOvVaw31hryX1D9DbpuqAsLl_eN1)\] Implement Array#bsearch\_index(hsbt)
+## \[Feature [#10730](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10730&sa=D&source=editors&ust=1686086420324242&usg=AOvVaw31hryX1D9DbpuqAsLl_eN1)\] Implement Array#bsearch\_index(hsbt)
 
 matz: go ahead.
 
 Action: Matz will reply. nobu will merge.
 
-# \[Feature [#10017](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10017&sa=D&source=editors&ust=1686086420325348&usg=AOvVaw1yJRgzUVP2Sj7Vqk0jO5tq)\] Add Hash#values\_at!(hsbt)
+## \[Feature [#10017](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10017&sa=D&source=editors&ust=1686086420325348&usg=AOvVaw1yJRgzUVP2Sj7Vqk0jO5tq)\] Add Hash#values\_at!(hsbt)
 
 matz: approved (Hash#fetch\_values).
 
 Action: Matz will reply. Nobu will merge it.
 
-# \[Feature #9108\] Hash sub-selections
+## \[Feature #9108\] Hash sub-selections
 
 Action: Matz will reply.
 
@@ -129,13 +129,13 @@ Action: Matz will reply.
 
 Action: continue to discuss how to implement (nobu)
 
-# \[Feature #11215\] pack/unpack for (u)intptr\_t
+## \[Feature #11215\] pack/unpack for (u)intptr\_t
 
 Action: Matz will approve it.
 
-# \[Feature #10769\] Negative counterpart to Enumerable#slice\_when
+## \[Feature #10769\] Negative counterpart to Enumerable#slice\_when
 
-# \[Feature #11253\] rb\_io\_modestr\_oflags for Ruby API
+## \[Feature #11253\] rb\_io\_modestr\_oflags for Ruby API
 
 matz: add keyword argument “flags”, which is OR-ed with 2nd argument mode.
 
@@ -145,6 +145,6 @@ naruse: If they use this for metrics, it should show 3 different count for each 
 
 akr: the number of existing symbols is implementation specific information. which should be in ObjectSpace.
 
-# Next meeting:
+## Next meeting:
 
 Date: 7/28 14:00- (JST)

--- a/2015/DevMeeting-2015-07-28.md
+++ b/2015/DevMeeting-2015-07-28.md
@@ -65,7 +65,7 @@ matz: ok
 
 matz: ok
 
-# [https://bugs.ruby-lang.org/issues/11339](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11339&sa=D&source=editors&ust=1686086447558338&usg=AOvVaw2vgkHD9pqJjDzGHhqvEaG1)
+## [https://bugs.ruby-lang.org/issues/11339](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11339&sa=D&source=editors&ust=1686086447558338&usg=AOvVaw2vgkHD9pqJjDzGHhqvEaG1)
 
 Introducing IDL will
 
@@ -97,11 +97,11 @@ Also, additional TracePoint will be introduced.
 - we will replace following azure backends to s3.
 - [https://github.com/akr/chkbuild/blob/master/chkbuild/upload.rb#L75](https://www.google.com/url?q=https://github.com/akr/chkbuild/blob/master/chkbuild/upload.rb%23L75&sa=D&source=editors&ust=1686086447560583&usg=AOvVaw1Y-fiqFqbpP-ZlbBuzn_Uu)
 
-# about the necessity of r51384 (it takes toooooo looooong time to run test-all) (usa)
+## about the necessity of r51384 (it takes toooooo looooong time to run test-all) (usa)
 
 Resolved.
 
-# \[Feature [#8919](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8919&sa=D&source=editors&ust=1686086447561376&usg=AOvVaw1GpriQ8IBecqjlUXWryVI9)\] Queue as embedded class: please determine whether or not it should be introduced. (glass\_saga)
+## \[Feature [#8919](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8919&sa=D&source=editors&ust=1686086447561376&usg=AOvVaw1GpriQ8IBecqjlUXWryVI9)\] Queue as embedded class: please determine whether or not it should be introduced. (glass\_saga)
 
 Matz: seems good.
 
@@ -117,6 +117,6 @@ akr: What happens on pushing/popping closed Queue?
 
 ko1: there are discussions on ticket. I’ll take it.
 
-# \[Feature [#11297](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11297&sa=D&source=editors&ust=1686086447562734&usg=AOvVaw2n78P0SgnFCpyVhlq5wN_v)\] Allow private method of self to be called (a\_matsuda)
+## \[Feature [#11297](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11297&sa=D&source=editors&ust=1686086447562734&usg=AOvVaw2n78P0SgnFCpyVhlq5wN_v)\] Allow private method of self to be called (a\_matsuda)
 
 Matz: seems good

--- a/2015/DevMeeting-2015-11-09.md
+++ b/2015/DevMeeting-2015-11-09.md
@@ -40,11 +40,11 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 Attendees: matz, nobu, hsbt, akr, naruse, sorah, yuki, ko1
 
-# Next meeting
+## Next meeting
 
 2015/12/07 Mon 14:00 JST at SFDC
 
-# \[Feature [#8976](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8976&sa=D&source=editors&ust=1686086629237034&usg=AOvVaw305ggw0LyuhLDsm00vbufd)\] file-scope freeze\_string directive
+## \[Feature [#8976](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8976&sa=D&source=editors&ust=1686086629237034&usg=AOvVaw305ggw0LyuhLDsm00vbufd)\] file-scope freeze\_string directive
 
 ## freeze dynamic string literal or not?
 
@@ -91,7 +91,7 @@ Attendees: matz, nobu, hsbt, akr, naruse, sorah, yuki, ko1
 
 - We don’t need an option name if it is always enabled.
 
-# \[Feature [#4840](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4840&sa=D&source=editors&ust=1686086629240030&usg=AOvVaw2uPK_OKxtBrOwaRgGbruU6)\] Allow returning from require
+## \[Feature [#4840](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4840&sa=D&source=editors&ust=1686086629240030&usg=AOvVaw2uPK_OKxtBrOwaRgGbruU6)\] Allow returning from require
 
 \### Before
 
@@ -204,7 +204,7 @@ def foo
 
 end
 
-# \[Feature [#9098](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9098&sa=D&source=editors&ust=1686086629246775&usg=AOvVaw2jAu9y3Ym2D62Ll4HI044G)\] Indent heredoc against the left margin by default when "indented closing identifier" is turned on.
+## \[Feature [#9098](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9098&sa=D&source=editors&ust=1686086629246775&usg=AOvVaw2jAu9y3Ym2D62Ll4HI044G)\] Indent heredoc against the left margin by default when "indented closing identifier" is turned on.
 
 \# 2 spaces
 
@@ -237,7 +237,7 @@ Matz: acecptable, but there could be a problem if hard tabs and spaces are both 
 
 Nishijima-san suggested another way to write strings like DATA for each files. It will be proposed as another ticket.
 
-# \[Feature [#11643](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11643&sa=D&source=editors&ust=1686086629249954&usg=AOvVaw3bgMFujgdEH0PWLs9Slb_P)\] A new method on Hash to grab values out of nested hashes, failing gracefully
+## \[Feature [#11643](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11643&sa=D&source=editors&ust=1686086629249954&usg=AOvVaw3bgMFujgdEH0PWLs9Slb_P)\] A new method on Hash to grab values out of nested hashes, failing gracefully
 
 Matz: acceptable, but name is problem.
 
@@ -278,7 +278,7 @@ Nishijima-san mentioned past rejected proposals in Rails [\[1\]](https://www.goo
 
 - e.g. {a: {b: {c: 1}}}.dig(:a, :b, :x) == nil (not {c: 1})
 
-# \[Feature [#11665](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11665&sa=D&source=editors&ust=1686086629253785&usg=AOvVaw2-Hkf1kjJuY73Ta3ftAWCB)\] Support nested functions for better code organization
+## \[Feature [#11665](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11665&sa=D&source=editors&ust=1686086629253785&usg=AOvVaw2-Hkf1kjJuY73Ta3ftAWCB)\] Support nested functions for better code organization
 
 class C
 
@@ -320,11 +320,11 @@ end
 
 - matz: commented at [https://bugs.ruby-lang.org/issues/11665#note-3](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11665%23note-3&sa=D&source=editors&ust=1686086629256181&usg=AOvVaw3M-5Ke8tsnKa9JoTAVJIh5)
 
-# \[Feature [#11666](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11666&sa=D&source=editors&ust=1686086629256639&usg=AOvVaw2aoPqU-rovW6shbNPYSZ9C)\] IPAddr#private?
+## \[Feature [#11666](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11666&sa=D&source=editors&ust=1686086629256639&usg=AOvVaw2aoPqU-rovW6shbNPYSZ9C)\] IPAddr#private?
 
 Matz accepted this feature. Pass to knu -san (maintainer).
 
-# \[Feature [#11588](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11588&sa=D&source=editors&ust=1686086629257153&usg=AOvVaw0Je12v8DTmmbG_r7AMBnre)\] Implement structured warnings
+## \[Feature [#11588](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11588&sa=D&source=editors&ust=1686086629257153&usg=AOvVaw0Je12v8DTmmbG_r7AMBnre)\] Implement structured warnings
 
 - pros
 
@@ -344,7 +344,7 @@ Matz accepted this feature. Pass to knu -san (maintainer).
 
 - no conclusion.
 
-# \[Feature [#11653](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11653&sa=D&source=editors&ust=1686086629258468&usg=AOvVaw3ybz4P1lTPCMyh8SRIdR2v)\] Add to\_proc on Hash
+## \[Feature [#11653](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11653&sa=D&source=editors&ust=1686086629258468&usg=AOvVaw3ybz4P1lTPCMyh8SRIdR2v)\] Add to\_proc on Hash
 
 class Hash
 
@@ -368,7 +368,7 @@ Matz: acceptable
 
 Matz: to\_proc is intended for & argument operator. So it is reasonable to add.
 
-# \[Feature [#10984](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10984&sa=D&source=editors&ust=1686086629260420&usg=AOvVaw3Dtz_rIysRVt2ZLvU56NzV)\] Hash#contain? to check whether hash contains other hash
+## \[Feature [#10984](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10984&sa=D&source=editors&ust=1686086629260420&usg=AOvVaw3Dtz_rIysRVt2ZLvU56NzV)\] Hash#contain? to check whether hash contains other hash
 
 Matz: Feature is acceptable. But naming issue;
 
@@ -391,7 +391,7 @@ Method name candidates:
 
 Matz: I vote for “<”, “>”, “<=” and “>=” (no “<=>” and “===”).
 
-# \[Feature [#9108](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9108&sa=D&source=editors&ust=1686086629262227&usg=AOvVaw0yao0ymha7fNRMDhrXv3Nm)\]\[Feature [#8499](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8499&sa=D&source=editors&ust=1686086629262509&usg=AOvVaw27B-oerOWdzRueNvZA7oKx)\] Importing Hash#slice, Hash#slice!, Hash#except, and Hash#except! from ActiveSupport
+## \[Feature [#9108](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9108&sa=D&source=editors&ust=1686086629262227&usg=AOvVaw0yao0ymha7fNRMDhrXv3Nm)\]\[Feature [#8499](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8499&sa=D&source=editors&ust=1686086629262509&usg=AOvVaw27B-oerOWdzRueNvZA7oKx)\] Importing Hash#slice, Hash#slice!, Hash#except, and Hash#except! from ActiveSupport
 
 Current status: naming issue, select and reject are acceptable for Matz.
 

--- a/2016/DevMeeting-2016-01-18.md
+++ b/2016/DevMeeting-2016-01-18.md
@@ -68,7 +68,7 @@ Attendees: unak, mrkn, naruse, ayumin, ko1, sorah, zack, martin
 - Shibata-san
 - Usa-san
 
-# \[Feature [#11949](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11949&sa=D&source=editors&ust=1686086669304153&usg=AOvVaw2yGAdfbMDsH3mYZjJlB9mt)\] Allow @/$ prefix in Regexp's named captures (naruse)
+## \[Feature [#11949](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11949&sa=D&source=editors&ust=1686086669304153&usg=AOvVaw2yGAdfbMDsH3mYZjJlB9mt)\] Allow @/$ prefix in Regexp's named captures (naruse)
 
 /(?<[@timestamp](https://www.google.com/url?q=https://github.com/timestamp&sa=D&source=editors&ust=1686086669304610&usg=AOvVaw28N6Kq4TmNVpiRZst-nyet)\>\[^ \]\*): / =~
 
@@ -114,7 +114,7 @@ valid: > /(?<a@-あfoo>a)/.match("a")
 
 Conclusion: acceptable confusion or not. Matz is positive to accept this feature
 
-# \[Feature [#11987](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11987&sa=D&source=editors&ust=1686086669307460&usg=AOvVaw2PuKCWfc_szpekM7TIHEK1)\] daemons can't show the backtrace of rb\_bug
+## \[Feature [#11987](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11987&sa=D&source=editors&ust=1686086669307460&usg=AOvVaw2PuKCWfc_szpekM7TIHEK1)\] daemons can't show the backtrace of rb\_bug
 
 Process.daemon closes STDERR (or redirect to /dev/null).
 
@@ -189,7 +189,7 @@ Conclusion: Use wrapper process to intercept stderr.
 
 [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/CallForFeatureProposalTemplate](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/CallForFeatureProposalTemplate&sa=D&source=editors&ust=1686086669314387&usg=AOvVaw2_xKpFGpK5ToUyH3Mk1bHJ)
 
-# Announcement channel
+## Announcement channel
 
 We have only mailing lists and [www.ruby-lang.org](https://www.google.com/url?q=http://www.ruby-lang.org&sa=D&source=editors&ust=1686086669314808&usg=AOvVaw2jIwC6FxxSu2ArZR9sN6NM) to annouce news. However, it is difficult to catch up latest news by such channels. Any other ideas?
 

--- a/2016/DevMeeting-2016-03-16.md
+++ b/2016/DevMeeting-2016-03-16.md
@@ -74,7 +74,7 @@ Date: 2016/03/16 14:00- JST
 
 Attendees: Matz, ko1, nobu, akr, naruse, mrkn, shyouhei, sorah, martin, hsbt
 
-# Next meeting
+## Next meeting
 
 2016/04/13 13:00 @ Money Forward
 

--- a/2016/DevMeeting-2016-04-13.md
+++ b/2016/DevMeeting-2016-04-13.md
@@ -68,13 +68,13 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 Attendees: matz, sorah, naruse, ko1, mame, kosaki, hsbt, nobu, tarui, akr, shyouhei, mrkn
 
-# Next meeting
+## Next meeting
 
 5/17/2016 (Tue) JST
 
 venue: TBD
 
-# \[Feature [#9969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9969&sa=D&source=editors&ust=1686086778188607&usg=AOvVaw1r1Ex8lWi1rHAWqywICQXs)\] Add File.empty? as alias to File.zero? (shyouhei)
+## \[Feature [#9969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9969&sa=D&source=editors&ust=1686086778188607&usg=AOvVaw1r1Ex8lWi1rHAWqywICQXs)\] Add File.empty? as alias to File.zero? (shyouhei)
 
 (discussing about current behavior of related methods)
 
@@ -83,7 +83,7 @@ venue: TBD
 - matz: ok
 - kosaki: do you say “zero sized file”?
 
-# \[Feature [#10617](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10617&sa=D&source=editors&ust=1686086778189557&usg=AOvVaw3n9pUWMsFxA5DDKNUZfPip)\] Change multiple assignment in conditional from parse error to warning (shyouhei)
+## \[Feature [#10617](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10617&sa=D&source=editors&ust=1686086778189557&usg=AOvVaw3n9pUWMsFxA5DDKNUZfPip)\] Change multiple assignment in conditional from parse error to warning (shyouhei)
 
 - ko1: counter proposal. returning array can affect performance. how about to make mltiple assignment as a void expression?
 
@@ -103,70 +103,70 @@ venue: TBD
 - ko1: i can’t understand what happen on it.
 - matz: I want to use it. accept.
 
-# \[Feature [#11547](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11547&sa=D&source=editors&ust=1686086778190922&usg=AOvVaw23JOvjx6EpwV97PrLIDc_j)\] remove top-level constant lookup (shyouhei)
+## \[Feature [#11547](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11547&sa=D&source=editors&ust=1686086778190922&usg=AOvVaw23JOvjx6EpwV97PrLIDc_j)\] remove top-level constant lookup (shyouhei)
 
 - matz: lets try this to see how much codes break with it.
 
-# \[Feature [#12020](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12020&sa=D&source=editors&ust=1686086778191350&usg=AOvVaw3sgp2Ic24E2wWTSRAkYH5E)\] Documenting Ruby memory model (shyouhei)
+## \[Feature [#12020](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12020&sa=D&source=editors&ust=1686086778191350&usg=AOvVaw3sgp2Ic24E2wWTSRAkYH5E)\] Documenting Ruby memory model (shyouhei)
 
-# \[Feature [#11210](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11210&sa=D&source=editors&ust=1686086778191764&usg=AOvVaw0PZ2mNK6EHchSdiUrieGvj)\] IPAddr has no public method to get the current subnet mask (eregon) Who can review this?
+## \[Feature [#11210](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11210&sa=D&source=editors&ust=1686086778191764&usg=AOvVaw0PZ2mNK6EHchSdiUrieGvj)\] IPAddr has no public method to get the current subnet mask (eregon) Who can review this?
 
 - assign to knu-san
 - naruse: mentioned to knu
 
-# \[Feature [#6647](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6647&sa=D&source=editors&ust=1686086778192280&usg=AOvVaw2LyPWo0K3jf04EyBzOokuo)\] Exceptions raised in threads should be logged, Thread#report\_on\_exception= (eregon) Can we agree on the feature?
+## \[Feature [#6647](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6647&sa=D&source=editors&ust=1686086778192280&usg=AOvVaw2LyPWo0K3jf04EyBzOokuo)\] Exceptions raised in threads should be logged, Thread#report\_on\_exception= (eregon) Can we agree on the feature?
 
 Matz is positive to provide Thread#report\_on\_exception, but negative to turning it on by default.
 
-# \[Feature [#12026](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12026&sa=D&source=editors&ust=1686086778192918&usg=AOvVaw3YACU_CmKEFp9xMz9UatbE)\] Support warning processor
+## \[Feature [#12026](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12026&sa=D&source=editors&ust=1686086778192918&usg=AOvVaw3YACU_CmKEFp9xMz9UatbE)\] Support warning processor
 
 - matz: agree with customizable warning
 
 - should not use global variables
 - there are many design choise. continue to discuss
 
-# \[Feature [#12092](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12092&sa=D&source=editors&ust=1686086778193591&usg=AOvVaw362zFI9yX5FLMBV39DlGEa)\] Allow Object#clone to yield cloned object before freezing (jeremyevans0)
+## \[Feature [#12092](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12092&sa=D&source=editors&ust=1686086778193591&usg=AOvVaw362zFI9yX5FLMBV39DlGEa)\] Allow Object#clone to yield cloned object before freezing (jeremyevans0)
 
-# \[Feature #[12217](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12217&sa=D&source=editors&ust=1686086778193978&usg=AOvVaw3vSDoLPRbhD2p4nLs74xyZ)\] Introducing Enumerable#sum for precision compensated summation and revert r54237 (mrkn)
+## \[Feature #[12217](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12217&sa=D&source=editors&ust=1686086778193978&usg=AOvVaw3vSDoLPRbhD2p4nLs74xyZ)\] Introducing Enumerable#sum for precision compensated summation and revert r54237 (mrkn)
 
 - matz: Adding Array#sum is ok
 - Revert r54237 and optimization for Float
 
-# \[Bug [#12271](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12271&sa=D&source=editors&ust=1686086778194538&usg=AOvVaw14yLnN2YsYcx4sZVUj1FC2)\] Time#to\_time removes timezone information
+## \[Bug [#12271](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12271&sa=D&source=editors&ust=1686086778194538&usg=AOvVaw14yLnN2YsYcx4sZVUj1FC2)\] Time#to\_time removes timezone information
 
 - nobu: It is a bug, so I commited
 - yui\_knk: ActiveSupport was testing this behavior (FYI)
 
-# \[Feature [#12157](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12157&sa=D&source=editors&ust=1686086778195148&usg=AOvVaw1dkXIbSX_4tem_kgHpAXSQ)\] Is the option hash necessary for future Rubys?
+## \[Feature [#12157](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12157&sa=D&source=editors&ust=1686086778195148&usg=AOvVaw1dkXIbSX_4tem_kgHpAXSQ)\] Is the option hash necessary for future Rubys?
 
 - We have no matz for time when discussed this issue, so pend until next meeting.
 
-# \[Bug [#12181](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12181&sa=D&source=editors&ust=1686086778195586&usg=AOvVaw1BeuIWyT45sBg25ws4uD3S)\] ブロックがたくさんあるファイルを編集するとruby-modeが重い
+## \[Bug [#12181](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12181&sa=D&source=editors&ust=1686086778195586&usg=AOvVaw1BeuIWyT45sBg25ws4uD3S)\] ブロックがたくさんあるファイルを編集するとruby-modeが重い
 
 - Who can look this issue? Nobu?
 - nobu will investigate and make some action.
 
-# \[Bug [#12179](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12179&sa=D&source=editors&ust=1686086778196151&usg=AOvVaw08pK7nXdMKrpaJuSTVU5AL)\] Build failure due to VPATH expansion
+## \[Bug [#12179](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12179&sa=D&source=editors&ust=1686086778196151&usg=AOvVaw08pK7nXdMKrpaJuSTVU5AL)\] Build failure due to VPATH expansion
 
 - Weird. Nobu will investigate.
 
-# \[Bug [#12183](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12183&sa=D&source=editors&ust=1686086778196632&usg=AOvVaw1ZRuU3ajsZH3ZM6ge0ztga)\] require "win32ole" すると終了ステータスが必ず 0 になる
+## \[Bug [#12183](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12183&sa=D&source=editors&ust=1686086778196632&usg=AOvVaw1ZRuU3ajsZH3ZM6ge0ztga)\] require "win32ole" すると終了ステータスが必ず 0 になる
 
 - Assigned to appropriate maintainer.
 
-# \[Bug [#12184](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12184&sa=D&source=editors&ust=1686086778197108&usg=AOvVaw2ki9AJmCdWLvAWlPcQIXih)\] Cygwin LANG=ja\_JP.SJIS 環境でコマンドライン引数に日本語が渡せない
+## \[Bug [#12184](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12184&sa=D&source=editors&ust=1686086778197108&usg=AOvVaw2ki9AJmCdWLvAWlPcQIXih)\] Cygwin LANG=ja\_JP.SJIS 環境でコマンドライン引数に日本語が渡せない
 
 - nobu: Cygwin only supports UTF-8
 - nobu(?) will reply something
 
-# \[Feature [#7361](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7361&sa=D&source=editors&ust=1686086778197739&usg=AOvVaw1lOc3i9xapIXK_UJqVFcTX)\] Adding Pathname#touch
+## \[Feature [#7361](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7361&sa=D&source=editors&ust=1686086778197739&usg=AOvVaw1lOc3i9xapIXK_UJqVFcTX)\] Adding Pathname#touch
 
 - actually touch(1) does lot of thing. What ticket author wanted?
 - Encourage author to make feature request more solid.
 
-# \[Feature [#12236](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12236&sa=D&source=editors&ust=1686086778198454&usg=AOvVaw2_LsdmZvTnMTxkHk7wry8o)\] Introduce mmap managed heap (ko1)
+## \[Feature [#12236](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12236&sa=D&source=editors&ust=1686086778198454&usg=AOvVaw2_LsdmZvTnMTxkHk7wry8o)\] Introduce mmap managed heap (ko1)
 
-# \[Feature [#11925](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11925&sa=D&source=editors&ust=1686086778199160&usg=AOvVaw1AZQHGNpNQdwtjEo11lP0o)\] Struct construction with kwargs (ko1)
+## \[Feature [#11925](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11925&sa=D&source=editors&ust=1686086778199160&usg=AOvVaw1AZQHGNpNQdwtjEo11lP0o)\] Struct construction with kwargs (ko1)
 
 - Understood and +1 for this feature, but maybe naming is a problem
 - We also have to wait a Matz.

--- a/2016/DevMeeting-2016-06-13.md
+++ b/2016/DevMeeting-2016-06-13.md
@@ -82,9 +82,9 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 Attendees: Matz (remote), Koichi Sasada, Nobu(yoshi) Nakada, Shyouhei Urabe (host), Hiroshi Shibata, Akira Tanaka, Yui Naruse, Kenta Murata, Satoru Horie (guest), Martin Dürst, sorah (from 15:00), Shugo  Maeda (remote)
 
-# Next meeting: 7/19 (Tue) 14:00-@Pivotal Lab.
+## Next meeting: 7/19 (Tue) 14:00-@Pivotal Lab.
 
-# GSoC achievements report (ko1, Horie-san)
+## GSoC achievements report (ko1, Horie-san)
 
 Link to [project description](https://www.google.com/url?q=https://summerofcode.withgoogle.com/organizations/5749695703941120/%234576418910437376&sa=D&source=editors&ust=1686086826654098&usg=AOvVaw0g14O4pYXW3Xk7FNOD5oEI) ([Automatic-selection mechanism for data structures in MRI](https://www.google.com/url?q=https://summerofcode.withgoogle.com/projects/%234576418910437376&sa=D&source=editors&ust=1686086826654469&usg=AOvVaw3wp5-EcpoTD01XEoRYe2hc)). Koichi is a mentor. Report: Started to implement String using Rope. Showing some performance results of initial experiments.
 
@@ -106,7 +106,7 @@ This release doesn’t prevent further big changes for Ruby 2.4.
 
 (This release is different from an usual preview1 (even more ‘previewy’))
 
-# \[Misc [#12283](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12283&sa=D&source=editors&ust=1686086826655925&usg=AOvVaw1V_E-bm4yWtswMJZVEpfua)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
+## \[Misc [#12283](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12283&sa=D&source=editors&ust=1686086826655925&usg=AOvVaw1V_E-bm4yWtswMJZVEpfua)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 
 Any progress? → Nothing
 
@@ -129,7 +129,7 @@ A: Use empty commit.
 - Try this service.
 - Should we decide whether reports are eligible for bounty?
 
-# \[Feature [#12333](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12333&sa=D&source=editors&ust=1686086826657701&usg=AOvVaw1FvhwrnKWfgcUzKqYPJjgs)\] String#concat, Array#concat, String#prepend to take multiple arguments (shyouhei)
+## \[Feature [#12333](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12333&sa=D&source=editors&ust=1686086826657701&usg=AOvVaw1FvhwrnKWfgcUzKqYPJjgs)\] String#concat, Array#concat, String#prepend to take multiple arguments (shyouhei)
 
 matz: acceptable
 
@@ -142,7 +142,7 @@ nobu: this patch requires some tests, and fixes.
 
 - see https://bugs.ruby-lang.org/projects/ruby/wiki/DeveloperHowto
 
-# \[Feature #12247\] accept multiple arguments at Array#delete
+## \[Feature #12247\] accept multiple arguments at Array#delete
 
 What’s happen?
 
@@ -160,20 +160,20 @@ ary.delete(:a, :f, :c) #=> ???
 - x, y, z = ary.delete(:a, :f, :c)
 - Especially for Hash#delete (this is out of scope, but we should consier consistency)
 
-# \[Bug [#12295](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12295&sa=D&source=editors&ust=1686086826660239&usg=AOvVaw0hwar7O_qyBzkPdBFgwA9x)\] Ripper not emitting on\_parse\_error for global variable name syntax errors (shyouhei) is this the right design?
+## \[Bug [#12295](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12295&sa=D&source=editors&ust=1686086826660239&usg=AOvVaw0hwar7O_qyBzkPdBFgwA9x)\] Ripper not emitting on\_parse\_error for global variable name syntax errors (shyouhei) is this the right design?
 
 Assigned to Minero Aoki.
 
-# \[Feature [#12484](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12484&sa=D&source=editors&ust=1686086826660784&usg=AOvVaw1uo8Lg46TRKmVwMIusOdkT)\] Optimizing Rational (hsbt, mrkn)
+## \[Feature [#12484](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12484&sa=D&source=editors&ust=1686086826660784&usg=AOvVaw1uo8Lg46TRKmVwMIusOdkT)\] Optimizing Rational (hsbt, mrkn)
 
 - matz approved to add commit permission to Tadashi-san.
 - mrkn will reivew the proposed patch
 
-# \[Feature [#12281](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12281&sa=D&source=editors&ust=1686086826661465&usg=AOvVaw2dEZ2PXv_iAmh6mgKgRRd5)\] Allow lexically scoped use of refinements with using {} block syntax (shyouhei)
+## \[Feature [#12281](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12281&sa=D&source=editors&ust=1686086826661465&usg=AOvVaw2dEZ2PXv_iAmh6mgKgRRd5)\] Allow lexically scoped use of refinements with using {} block syntax (shyouhei)
 
 Assigned to shugo.
 
-# \[Feature #12086\] using: option for instance\_eval etc.
+## \[Feature #12086\] using: option for instance\_eval etc.
 
 Motivation is replace self and using context.
 
@@ -181,7 +181,7 @@ Motivation is replace self and using context.
 
 Matz will comment it.
 
-# \[Feature [#12447](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12447&sa=D&source=editors&ust=1686086826662909&usg=AOvVaw2ZpI0-lpWz4qDN0qZ74i3a)\] Integer#digits for extracting digits of place-value notation in any base (mrkn)
+## \[Feature [#12447](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12447&sa=D&source=editors&ust=1686086826662909&usg=AOvVaw2ZpI0-lpWz4qDN0qZ74i3a)\] Integer#digits for extracting digits of place-value notation in any base (mrkn)
 
 - Q. Endian? #=> Little endian
 - Q. how about negative integers? #=> Math::DomainError
@@ -189,7 +189,7 @@ Matz will comment it.
 
 matz: i’m not sure how it is convinience. but ok.
 
-# \[Feature [#12299](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12299&sa=D&source=editors&ust=1686086826664297&usg=AOvVaw313x6w3Lpw3IeQbvNFuWT4)\] Add Warning module for customized warning handling (jeremyevans)
+## \[Feature [#12299](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12299&sa=D&source=editors&ust=1686086826664297&usg=AOvVaw313x6w3Lpw3IeQbvNFuWT4)\] Add Warning module for customized warning handling (jeremyevans)
 
 naruse: it sounds useful with Gem.loaded\_specs\[ gem\_name \].full\_gem\_path.
 
@@ -199,7 +199,7 @@ matz: ok (except naming).
 
 h[ttps://bugs.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms&sa=D&source=editors&ust=1686086826666672&usg=AOvVaw3V0qvcsp0fuYrQ2ZFHMHks) says it’s for Ruby 1.9; needs some updating.
 
-# \[Feature [#12460](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12460&sa=D&source=editors&ust=1686086826667695&usg=AOvVaw2o73k2frUa5OTnCGcJT7Oa)\] Make Unicode Version directly available in Ruby (duerst)
+## \[Feature [#12460](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12460&sa=D&source=editors&ust=1686086826667695&usg=AOvVaw2o73k2frUa5OTnCGcJT7Oa)\] Make Unicode Version directly available in Ruby (duerst)
 
 Approved; name as proposed by Nobu: RbConfig::CONFIG\['UNICODE\_VERSION'\]; implementation: Nobu or Martin.
 
@@ -207,7 +207,7 @@ Approved; name as proposed by Nobu: RbConfig::CONFIG\['UNICODE\_VERSION'\]; impl
 
 See [https://github.com/rdoc/rdoc/issues/409](https://www.google.com/url?q=https://github.com/rdoc/rdoc/issues/409&sa=D&source=editors&ust=1686086826669415&usg=AOvVaw2EhluWwZ8TBFyBzz6e43aB). Intent is understandable. May work by just using &#(x)... HTML/XML convention; needs to be checked further.
 
-# \[Bug [#12427](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12427&sa=D&source=editors&ust=1686086826670082&usg=AOvVaw1Vu8MUVbVbsHHXmO7xY7ib)\] the way that extension libraries know if Integer is integrated (nobu)
+## \[Bug [#12427](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12427&sa=D&source=editors&ust=1686086826670082&usg=AOvVaw1Vu8MUVbVbsHHXmO7xY7ib)\] the way that extension libraries know if Integer is integrated (nobu)
 
 Nobu prepared a patch to show warning for rb\_cFixnum and rb\_cBignum, so developers can recognize this change. However, there are risks to compile broken code (assume passed parameters are Fixnum, but passed BIgnums. In this case, it is difficult to check Fixnum asusmed methods because Bignum may be rare to use, in general).
 

--- a/2016/DevMeeting-2016-07-19.md
+++ b/2016/DevMeeting-2016-07-19.md
@@ -110,7 +110,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 
-# Next meeting:
+## Next meeting:
 
 - 8/9 (Tue)
 - At MoneyForward, Inc.

--- a/2016/DevMeeting-2016-08-09.md
+++ b/2016/DevMeeting-2016-08-09.md
@@ -95,7 +95,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 * [Feature #10594] `Comparable#clamp` (nerdinand)
 
 # Log
-# Next meeting:
+## Next meeting:
 
 - when 7 Sept., 14:00 〜
 - At @tagomoris house?

--- a/2016/DevMeeting-2016-09-07.md
+++ b/2016/DevMeeting-2016-09-07.md
@@ -89,7 +89,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 
 [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20160907Japan](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20160907Japan&sa=D&source=editors&ust=1686086903371750&usg=AOvVaw3h-Ezlz0Vufuf0h-KtQA84)
 
-# Next meeting:
+## Next meeting:
 
 - when: Oct 11th, 14:00-
 - venue: TBA

--- a/2016/DevMeeting-2016-10-11.md
+++ b/2016/DevMeeting-2016-10-11.md
@@ -112,7 +112,7 @@ Attendees/参加者: ko1, naruse, akr, amatsuda, sorah, nakada, duerst (Martin D
 
 Language: mostly Japanese (sorry for non native Japanese speakers)
 
-# Agenda
+## Agenda
 
 - next meeting?
 


### PR DESCRIPTION
## Summary

Meeting logs from 2015-2016 that were exported from Google Docs use H1 (`#`) for ticket headings inside the Log section, e.g.:

```markdown
# \[Feature #9969\] Add File.empty? as alias to File.zero?
```

This makes every ticket heading the same level as the document title, breaking heading hierarchy. This PR demotes them to H2 (`##`).

## Changes

**Ticket headings** inside Log sections are demoted from H1 to H2:

```diff
-# \[Feature #9969\] Add File.empty? as alias to File.zero?
+## \[Feature #9969\] Add File.empty? as alias to File.zero?
```

**Non-ticket section headers** inside Log sections (e.g. `# Next meeting`, `# Announcement`) are also demoted:

```diff
-# Next meeting
+## Next meeting
```

Only headings after the `# Log` marker are affected. Document titles and agenda sections are left unchanged.

## Affected files

13 files across 2015-2016:

- `2015/DevMeeting-2015-04-08.md`
- `2015/DevMeeting-2015-05-14.md`
- `2015/DevMeeting-2015-06-12.md`
- `2015/DevMeeting-2015-07-28.md`
- `2015/DevMeeting-2015-11-09.md`
- `2016/DevMeeting-2016-01-18.md`
- `2016/DevMeeting-2016-03-16.md`
- `2016/DevMeeting-2016-04-13.md`
- `2016/DevMeeting-2016-06-13.md`
- `2016/DevMeeting-2016-07-19.md`
- `2016/DevMeeting-2016-08-09.md`
- `2016/DevMeeting-2016-09-07.md`
- `2016/DevMeeting-2016-10-11.md`

---

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.