### PR TITLE
Convert metadata headings to plain text in 2017 meeting logs

### DIFF
--- a/2017/DevMeeting-2017-01-19.md
+++ b/2017/DevMeeting-2017-01-19.md
@@ -116,17 +116,17 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 # Log
 
-## Date: 2017/01/19 (Wed)
+Date: 2017/01/19 (Wed)
 
-## Time: 14:00- 19:00 (JST)
+Time: 14:00- 19:00 (JST)
 
-## Place: Money Forward inc. Headquarter
+Place: Money Forward inc. Headquarter
 
-## Sign-up: [https://ruby.connpass.com/event/47745/](https://www.google.com/url?q=https://ruby.connpass.com/event/47745/&sa=D&source=editors&ust=1686087044830088&usg=AOvVaw2B0DL05cV44uXU8QKfN8mH)
+Sign-up: [https://ruby.connpass.com/event/47745/](https://www.google.com/url?q=https://ruby.connpass.com/event/47745/&sa=D&source=editors&ust=1686087044830088&usg=AOvVaw2B0DL05cV44uXU8QKfN8mH)
 
-## log edit: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/edit&sa=D&source=editors&ust=1686087044830657&usg=AOvVaw298Tt8wyJIEKNVp5Uggbco)
+log edit: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/edit&sa=D&source=editors&ust=1686087044830657&usg=AOvVaw298Tt8wyJIEKNVp5Uggbco)
 
-## log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/pub](https://www.google.com/url?q=https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/pub&sa=D&source=editors&ust=1686087044830974&usg=AOvVaw1cb_v2sBjaj9Kfi8Bkk_SM)
+log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/pub](https://www.google.com/url?q=https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/pub&sa=D&source=editors&ust=1686087044830974&usg=AOvVaw1cb_v2sBjaj9Kfi8Bkk_SM)
 
 ## Next meeting
 

--- a/2017/DevMeeting-2017-03-13.md
+++ b/2017/DevMeeting-2017-03-13.md
@@ -103,17 +103,17 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 # Log
 
-## Date: 2017/03/13 (Mon)
+Date: 2017/03/13 (Mon)
 
-## Time: 14:00- 19:00 (JST)
+Time: 14:00- 19:00 (JST)
 
-## Place: Money Forward inc. Headquarter
+Place: Money Forward inc. Headquarter
 
-## Sign-up: [https://ruby.connpass.com/event/47745/](https://www.google.com/url?q=https://ruby.connpass.com/event/47745/&sa=D&source=editors&ust=1686087099212572&usg=AOvVaw2H69ZGcgNYVH87pcL_SNae)
+Sign-up: [https://ruby.connpass.com/event/47745/](https://www.google.com/url?q=https://ruby.connpass.com/event/47745/&sa=D&source=editors&ust=1686087099212572&usg=AOvVaw2H69ZGcgNYVH87pcL_SNae)
 
-## log edit: [https://docs.google.com/document/d/1fZPbRMn2zjVAflvLz1IFWs3Kdijnm2Um4uNLammqURE/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1fZPbRMn2zjVAflvLz1IFWs3Kdijnm2Um4uNLammqURE/edit&sa=D&source=editors&ust=1686087099212956&usg=AOvVaw252KatT_TiaZG1EV8OMs74)
+log edit: [https://docs.google.com/document/d/1fZPbRMn2zjVAflvLz1IFWs3Kdijnm2Um4uNLammqURE/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1fZPbRMn2zjVAflvLz1IFWs3Kdijnm2Um4uNLammqURE/edit&sa=D&source=editors&ust=1686087099212956&usg=AOvVaw252KatT_TiaZG1EV8OMs74)
 
-## log: TBD
+log: TBD
 
 ## Next meeting
 

--- a/2017/DevMeeting-2017-04-17.md
+++ b/2017/DevMeeting-2017-04-17.md
@@ -122,17 +122,17 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 # Log
 
-## Date: 2017/04/17 (Mon)
+Date: 2017/04/17 (Mon)
 
-## Time: 14:00- 19:00 (JST)
+Time: 14:00- 19:00 (JST)
 
-## Place: Cookpad Inc. Headquarter
+Place: Cookpad Inc. Headquarter
 
-## Sign-up: [https://ruby.connpass.com/event/53124/](https://www.google.com/url?q=https://ruby.connpass.com/event/53124/&sa=D&source=editors&ust=1686087122714817&usg=AOvVaw3a19jCb1ija_qokyu5Q5Tj)
+Sign-up: [https://ruby.connpass.com/event/53124/](https://www.google.com/url?q=https://ruby.connpass.com/event/53124/&sa=D&source=editors&ust=1686087122714817&usg=AOvVaw3a19jCb1ija_qokyu5Q5Tj)
 
-## log edit: [https://docs.google.com/document/d/1\_tWfg7\_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1_tWfg7_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit&sa=D&source=editors&ust=1686087122715256&usg=AOvVaw3HWhoiEjigR-s344HlZvby)
+log edit: [https://docs.google.com/document/d/1\_tWfg7\_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1_tWfg7_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit&sa=D&source=editors&ust=1686087122715256&usg=AOvVaw3HWhoiEjigR-s344HlZvby)
 
-## log: TBD
+log: TBD
 
 ## Next meeting
 

--- a/2017/DevMeeting-2017-05-19.md
+++ b/2017/DevMeeting-2017-05-19.md
@@ -132,17 +132,17 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 
 # Log
 
-## Date: 2017/05/19 (Mon)
+Date: 2017/05/19 (Mon)
 
-## Time: 14:00- 19:00 (JST)
+Time: 14:00- 19:00 (JST)
 
-## Place: Speee Inc. Headquarter
+Place: Speee Inc. Headquarter
 
-## Sign-up: https://ruby.connpass.com/event/55487/
+Sign-up: https://ruby.connpass.com/event/55487/
 
-## log edit: [https://docs.google.com/document/d/1XolSYFFvBOj\_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1XolSYFFvBOj_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit&sa=D&source=editors&ust=1686087156478680&usg=AOvVaw3OMGEHJuo3NAojETLp_5NU)
+log edit: [https://docs.google.com/document/d/1XolSYFFvBOj\_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1XolSYFFvBOj_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit&sa=D&source=editors&ust=1686087156478680&usg=AOvVaw3OMGEHJuo3NAojETLp_5NU)
 
-## log: TBD
+log: TBD
 
 ## Next meeting
 


### PR DESCRIPTION
## Summary

Four meeting logs from early 2017 have metadata lines (Date, Time, Place, etc.) incorrectly formatted as H2 headings due to Google Docs export artifacts:

```markdown
## Date: 2017/01/19 (Wed)
## Time: 14:00- 19:00 (JST)
## Place: Money Forward inc. Headquarter
```

These are not section headings — they're plain metadata that should render as regular text.

## Changes

Strip the `## ` prefix from metadata lines:

```diff
-## Date: 2017/01/19 (Wed)
+Date: 2017/01/19 (Wed)
```

Affected patterns: `Date:`, `Time:`, `Place:`, `Sign-up:`, `log edit:`, `log:`.

## Affected files

4 files in 2017:

- `2017/DevMeeting-2017-01-19.md`
- `2017/DevMeeting-2017-03-13.md`
- `2017/DevMeeting-2017-04-17.md`
- `2017/DevMeeting-2017-05-19.md`

---

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.