### PR TITLE
Replace &nbsp; HTML entities with regular spaces in 2016-2018 meeting logs

### DIFF
--- a/2016/DevMeeting-2016-11-25.md
+++ b/2016/DevMeeting-2016-11-25.md
@@ -72,7 +72,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 * [Feature #12802] Add BLAKE2 support to Digest (nobu)
 * [Feature #12861] Lexically scoped super (nobu)
 * [Bug #12952] Incompatibility of a method signature between `Float#round` and `BigDecimal#round` (yui-knk)
-* [Feature #12953]&nbsp;(Float, Integer, Rational)#round(half: :down) (shyouhei)
+* [Feature #12953] (Float, Integer, Rational)#round(half: :down) (shyouhei)
 * [Bug #12666] Fatal error: glibc detected an invalid stdio handle (shyouhei)
 * [Bug #12945] Use-after-free in vm_trace.c (shyouhei)
 * [Bug #12961] Bad value for range using infinity for Date or Time (shyouhei)

--- a/2017/DevMeeting-2017-07-14.md
+++ b/2017/DevMeeting-2017-07-14.md
@@ -58,75 +58,75 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 ## From attendees
 
-- [Feature #13618]&nbsp;[PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (shyouhei)
-- [Feature #13581]&nbsp;Syntax sugar for method reference (shyouhei)
-- [Feature #13583]&nbsp;Adding `Hash#transform_keys` method (shyouhei)
-- [Feature #13396]&nbsp;Net::HTTP has no write timeout (shyouhei)
-- [Feature #13587]&nbsp;Improve performance of string interpolation (shyouhei)
-- [Bug #13438]&nbsp;Fix heap overflow due to configure.in not being updated for HEAP_* -> HEAP_PAGE_* variable renaming (shyouhei)
-- [Misc #12529]&nbsp;LEGAL file covering all the license information within Ruby (shyouhei)
-- [Feature #13600]&nbsp;yield_self should be chainable/composable (shyouhei)
-- [Misc #13597]&nbsp;Does read_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
-- [Feature #13606]&nbsp;Enumerator equality and comparison (shyouhei)
-- [Feature #13604]&nbsp;Exposing alternative interface of readline (shyouhei)
-- [Feature #13608]&nbsp;Add TracePoint#thread (shyouhei)
-- [Feature #13602]&nbsp;Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
-- [Feature #13613]&nbsp;Prefer that require/require_relative/load to tell us permission error if the target file is unreadable (shyouhei)
-- [Feature #13620]&nbsp;Simplifying MRI's build system: always install (shyouhei)
-- [Feature #13630]&nbsp;:[] method should accept block in nice syntax (shyouhei)
-- [Feature #13639]&nbsp;Add "RTMIN" and "RTMAX" to Signal.list (shyouhei)
-- [Feature #11484]&nbsp;add output offset for readpartial/read_nonblock/etc (shyouhei)
-- [Feature #9001]&nbsp;Please package better standard library (shyouhei)
-- [Feature #13563]&nbsp;Implement Hash#choice method. (shyouhei)
-- [Feature #12533]&nbsp;Refinements: allow modules inclusion, in which the module can call internal methods which it defines.  (shyouhei)
-- [Feature #13653]&nbsp;Bundled zlib helper (shyouhei)
-- [Feature #12589]&nbsp;VM performance improvement proposal (shyouhei)
-- [Feature #13626]&nbsp;Add String#byteslice! (shyouhei)
-- [Feature #13551]&nbsp;Add a method to alias class methods (shyouhei)
-- [Feature #13332]&nbsp;Forwardable#def_instance_delegator nil (shyouhei)
-- [Feature #13378]&nbsp;Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
-- [Feature #13381]&nbsp;[PATCH] Expose rb_fstring and its family to C extensions (shyouhei)
-- [Feature #13676]&nbsp;to_s method is not overriden for Set (shyouhei)
-- [Feature #13677]&nbsp;Add more details to error "Name or service not known (SocketError)" (shyouhei)
-- [Feature #10771]&nbsp;An easy way to get the source location of a constant (shyouhei)
-- [Feature #13665]&nbsp;String#delete_suffix (shyouhei)
-- [Feature #9323]&nbsp;IO#writev (shyouhei)
-- [Feature #13686]&nbsp;Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on_* (shyouhei)
-- [Feature #13693]&nbsp;Allow String#to_i and / or Kernel::Integer to parse e-notation (shyouhei)
-- [Feature #13434]&nbsp;better method definition in C API (shyouhei)
-- [Feature #13696]&nbsp;Add exchange and noreplace options to File.rename (shyouhei)
-- [Feature #13683]&nbsp;Add strict Enumerable#single (shyouhei)
-- [Misc #13704]&nbsp;Exclude Changelog files from documentation. (shyouhei)
-- [Feature #13666]&nbsp;Development: Writing test code for new features/bug fixes can be done as specs under spec/rubyspec instead of tests under test/ (shyouhei)
-- [Feature #13713]&nbsp;socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
-- [Feature #13715]&nbsp;[PATCH] avoid garbage from Symbol#to_s in interpolation (shyouhei)
-- [Feature #13719]&nbsp;[PATCH] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
-- [Feature #13721]&nbsp;[PATCH] net/imap: dedupe attr keys in Net::IMAP::FetchData (shyouhei)
-- [Feature #13732]&nbsp;Precise Time.now on Windows (shyouhei)
-- [Feature #13733]&nbsp;Dump the delegator instead of the delegated object (shyouhei)
-- [Feature #13625]&nbsp;BigDecimal short form / shorthand (shyouhei)
-- [Feature #13712]&nbsp;String#start_with? with regexp (shyouhei)
+- [Feature #13618] [PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (shyouhei)
+- [Feature #13581] Syntax sugar for method reference (shyouhei)
+- [Feature #13583] Adding `Hash#transform_keys` method (shyouhei)
+- [Feature #13396] Net::HTTP has no write timeout (shyouhei)
+- [Feature #13587] Improve performance of string interpolation (shyouhei)
+- [Bug #13438] Fix heap overflow due to configure.in not being updated for HEAP_* -> HEAP_PAGE_* variable renaming (shyouhei)
+- [Misc #12529] LEGAL file covering all the license information within Ruby (shyouhei)
+- [Feature #13600] yield_self should be chainable/composable (shyouhei)
+- [Misc #13597] Does read_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
+- [Feature #13606] Enumerator equality and comparison (shyouhei)
+- [Feature #13604] Exposing alternative interface of readline (shyouhei)
+- [Feature #13608] Add TracePoint#thread (shyouhei)
+- [Feature #13602] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
+- [Feature #13613] Prefer that require/require_relative/load to tell us permission error if the target file is unreadable (shyouhei)
+- [Feature #13620] Simplifying MRI's build system: always install (shyouhei)
+- [Feature #13630] :[] method should accept block in nice syntax (shyouhei)
+- [Feature #13639] Add "RTMIN" and "RTMAX" to Signal.list (shyouhei)
+- [Feature #11484] add output offset for readpartial/read_nonblock/etc (shyouhei)
+- [Feature #9001] Please package better standard library (shyouhei)
+- [Feature #13563] Implement Hash#choice method. (shyouhei)
+- [Feature #12533] Refinements: allow modules inclusion, in which the module can call internal methods which it defines.  (shyouhei)
+- [Feature #13653] Bundled zlib helper (shyouhei)
+- [Feature #12589] VM performance improvement proposal (shyouhei)
+- [Feature #13626] Add String#byteslice! (shyouhei)
+- [Feature #13551] Add a method to alias class methods (shyouhei)
+- [Feature #13332] Forwardable#def_instance_delegator nil (shyouhei)
+- [Feature #13378] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+- [Feature #13381] [PATCH] Expose rb_fstring and its family to C extensions (shyouhei)
+- [Feature #13676] to_s method is not overriden for Set (shyouhei)
+- [Feature #13677] Add more details to error "Name or service not known (SocketError)" (shyouhei)
+- [Feature #10771] An easy way to get the source location of a constant (shyouhei)
+- [Feature #13665] String#delete_suffix (shyouhei)
+- [Feature #9323] IO#writev (shyouhei)
+- [Feature #13686] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on_* (shyouhei)
+- [Feature #13693] Allow String#to_i and / or Kernel::Integer to parse e-notation (shyouhei)
+- [Feature #13434] better method definition in C API (shyouhei)
+- [Feature #13696] Add exchange and noreplace options to File.rename (shyouhei)
+- [Feature #13683] Add strict Enumerable#single (shyouhei)
+- [Misc #13704] Exclude Changelog files from documentation. (shyouhei)
+- [Feature #13666] Development: Writing test code for new features/bug fixes can be done as specs under spec/rubyspec instead of tests under test/ (shyouhei)
+- [Feature #13713] socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
+- [Feature #13715] [PATCH] avoid garbage from Symbol#to_s in interpolation (shyouhei)
+- [Feature #13719] [PATCH] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
+- [Feature #13721] [PATCH] net/imap: dedupe attr keys in Net::IMAP::FetchData (shyouhei)
+- [Feature #13732] Precise Time.now on Windows (shyouhei)
+- [Feature #13733] Dump the delegator instead of the delegated object (shyouhei)
+- [Feature #13625] BigDecimal short form / shorthand (shyouhei)
+- [Feature #13712] String#start_with? with regexp (shyouhei)
 - bugs that are not assigned (shyouhei)
-    * [Bug #13586]&nbsp;Ruby hangs when accessing array which is modified in instance_eval after Coverage.start
-    * [Bug #13574]&nbsp;Method redefinition warning
-    * [Bug #13616]&nbsp;Zlib::GzipReader#pos underflows after calling #ungetbyte or #ungetc at start of file
-    * [Bug #13593]&nbsp;Addrinfo#== behaves oddly
-    * [Bug #13631]&nbsp;Cannot disable site and vendor directories
-    * [Bug #13647]&nbsp;Some weird behaviour with keyword arguments
-    * [Bug #13649]&nbsp;Net::IMAP doesn't support response from a Microsoft Exchange server (which is not compliant with RFC standards)
-    * [Bug #13654]&nbsp;irb save-history extension is not concurrency-safe
-    * [Bug #13655]&nbsp;external encoding named "-" (doc issue or…?)
-    * [Bug #13660]&nbsp;rb_str_hash_m discards bits from the hash
-    * [Bug #13671]&nbsp;Regexp with lookbehind and case-insensitivity raises RegexpError only on strings with certain characters
-    * [Bug #13674]&nbsp;BigDecimal comparison with Float::INFINITY is erroneous in 2.2.x and 2.3.x
-    * [Bug #13675]&nbsp;Should Zlib::GzipReader#ungetc accept nil?
-    * [Bug #13700]&nbsp;Enumerable#sum may not work for Ranges subclasses due to optimization
-    * [Bug #13350]&nbsp;File.read :newline option not respected on Linux
-    * [Bug #13705]&nbsp;[PATCH] `cfp consistency error' occurs when raising exception in bmethod call event
-    * [Bug #13716]&nbsp;Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
-    * [Bug #13670]&nbsp;[BUG] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
-    * [Bug #13731]&nbsp;inode for Windows on ReFS
-    * [Bug #13735]&nbsp;Initialization-error of sortedset
+    * [Bug #13586] Ruby hangs when accessing array which is modified in instance_eval after Coverage.start
+    * [Bug #13574] Method redefinition warning
+    * [Bug #13616] Zlib::GzipReader#pos underflows after calling #ungetbyte or #ungetc at start of file
+    * [Bug #13593] Addrinfo#== behaves oddly
+    * [Bug #13631] Cannot disable site and vendor directories
+    * [Bug #13647] Some weird behaviour with keyword arguments
+    * [Bug #13649] Net::IMAP doesn't support response from a Microsoft Exchange server (which is not compliant with RFC standards)
+    * [Bug #13654] irb save-history extension is not concurrency-safe
+    * [Bug #13655] external encoding named "-" (doc issue or…?)
+    * [Bug #13660] rb_str_hash_m discards bits from the hash
+    * [Bug #13671] Regexp with lookbehind and case-insensitivity raises RegexpError only on strings with certain characters
+    * [Bug #13674] BigDecimal comparison with Float::INFINITY is erroneous in 2.2.x and 2.3.x
+    * [Bug #13675] Should Zlib::GzipReader#ungetc accept nil?
+    * [Bug #13700] Enumerable#sum may not work for Ranges subclasses due to optimization
+    * [Bug #13350] File.read :newline option not respected on Linux
+    * [Bug #13705] [PATCH] `cfp consistency error' occurs when raising exception in bmethod call event
+    * [Bug #13716] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+    * [Bug #13670] [BUG] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
+    * [Bug #13731] inode for Windows on ReFS
+    * [Bug #13735] Initialization-error of sortedset
 
 ## From non-attendees
 

--- a/2017/DevMeeting-2017-08-31.md
+++ b/2017/DevMeeting-2017-08-31.md
@@ -46,51 +46,51 @@ Please add your favorite ticket numbers you want to ask to discuss.
 - [Bug #13535] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
 - [Feature #13568] File#path for O_TMPFILE fds are unmeaning (sorah)
 - [Feature #13563] Implement Hash#choice method. (shyouhei)
-- [Feature #13581]&nbsp;Syntax sugar for method reference (shyouhei)
-- [Bug #13438]&nbsp;Fix heap overflow due to configure.in not being updated for HEAP_* -> HEAP_PAGE_* variable renaming (shyouhei)
-- [Misc #12529]&nbsp;LEGAL file covering all the license information within Ruby (shyouhei)
-- [Feature #13600]&nbsp;yield_self should be chainable/composable (shyouhei)
-- [Misc #13597]&nbsp;Does read_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
-- [Feature #13606]&nbsp;Enumerator equality and comparison (shyouhei)
-- [Feature #13604]&nbsp;Exposing alternative interface of readline (shyouhei)
-- [Feature #13608]&nbsp;Add TracePoint#thread (shyouhei)
-- [Feature #13602]&nbsp;Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
-- [Feature #13613]&nbsp;Prefer that require/require_relative/load to tell us permission error if the target file is unreadable (shyouhei)
-- [Feature #13620]&nbsp;Simplifying MRI's build system: always install (shyouhei)
-- [Feature #13630]&nbsp;:[] method should accept block in nice syntax (shyouhei)
-- [Feature #13639]&nbsp;Add "RTMIN" and "RTMAX" to Signal.list (shyouhei)
-- [Feature #11484]&nbsp;add output offset for readpartial/read_nonblock/etc (shyouhei)
-- [Feature #9001]&nbsp;Please package better standard library (shyouhei)
-- [Feature #13563]&nbsp;Implement Hash#choice method. (shyouhei)
-- [Feature #12533]&nbsp;Refinements: allow modules inclusion, in which the module can call internal methods which it defines.  (shyouhei)
-- [Feature #13653]&nbsp;Bundled zlib helper (shyouhei)
-- [Feature #13626]&nbsp;Add String#byteslice! (shyouhei)
-- [Feature #13551]&nbsp;Add a method to alias class methods (shyouhei)
-- [Feature #13332]&nbsp;Forwardable#def_instance_delegator nil (shyouhei)
-- [Feature #13378]&nbsp;Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
-- [Feature #13381]&nbsp;[PATCH] Expose rb_fstring and its family to C extensions (shyouhei)
-- [Feature #13677]&nbsp;Add more details to error "Name or service not known (SocketError)" (shyouhei)
-- [Feature #9323]&nbsp;IO#writev (shyouhei)
-- [Feature #13686]&nbsp;Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on_* (shyouhei)
-- [Feature #13693]&nbsp;Allow String#to_i and / or Kernel::Integer to parse e-notation (shyouhei)
-- [Feature #13434]&nbsp;better method definition in C API (shyouhei)
-- [Feature #13696]&nbsp;Add exchange and noreplace options to File.rename (shyouhei)
-- [Feature #13683]&nbsp;Add strict Enumerable#single (shyouhei)
-- [Misc #13704]&nbsp;Exclude Changelog files from documentation. (shyouhei)
-- [Feature #13713]&nbsp;socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
-- [Feature #13715]&nbsp;[PATCH] avoid garbage from Symbol#to_s in interpolation (shyouhei)
-- [Feature #13719]&nbsp;[PATCH] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
-- [Feature #13732]&nbsp;Precise Time.now on Windows (shyouhei)
-- [Feature #13733]&nbsp;Dump the delegator instead of the delegated object (shyouhei)
-- [Feature #13625]&nbsp;BigDecimal short form / shorthand (shyouhei)
-- [Feature #13712]&nbsp;String#start_with? with regexp (shyouhei)
+- [Feature #13581] Syntax sugar for method reference (shyouhei)
+- [Bug #13438] Fix heap overflow due to configure.in not being updated for HEAP_* -> HEAP_PAGE_* variable renaming (shyouhei)
+- [Misc #12529] LEGAL file covering all the license information within Ruby (shyouhei)
+- [Feature #13600] yield_self should be chainable/composable (shyouhei)
+- [Misc #13597] Does read_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
+- [Feature #13606] Enumerator equality and comparison (shyouhei)
+- [Feature #13604] Exposing alternative interface of readline (shyouhei)
+- [Feature #13608] Add TracePoint#thread (shyouhei)
+- [Feature #13602] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
+- [Feature #13613] Prefer that require/require_relative/load to tell us permission error if the target file is unreadable (shyouhei)
+- [Feature #13620] Simplifying MRI's build system: always install (shyouhei)
+- [Feature #13630] :[] method should accept block in nice syntax (shyouhei)
+- [Feature #13639] Add "RTMIN" and "RTMAX" to Signal.list (shyouhei)
+- [Feature #11484] add output offset for readpartial/read_nonblock/etc (shyouhei)
+- [Feature #9001] Please package better standard library (shyouhei)
+- [Feature #13563] Implement Hash#choice method. (shyouhei)
+- [Feature #12533] Refinements: allow modules inclusion, in which the module can call internal methods which it defines.  (shyouhei)
+- [Feature #13653] Bundled zlib helper (shyouhei)
+- [Feature #13626] Add String#byteslice! (shyouhei)
+- [Feature #13551] Add a method to alias class methods (shyouhei)
+- [Feature #13332] Forwardable#def_instance_delegator nil (shyouhei)
+- [Feature #13378] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+- [Feature #13381] [PATCH] Expose rb_fstring and its family to C extensions (shyouhei)
+- [Feature #13677] Add more details to error "Name or service not known (SocketError)" (shyouhei)
+- [Feature #9323] IO#writev (shyouhei)
+- [Feature #13686] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on_* (shyouhei)
+- [Feature #13693] Allow String#to_i and / or Kernel::Integer to parse e-notation (shyouhei)
+- [Feature #13434] better method definition in C API (shyouhei)
+- [Feature #13696] Add exchange and noreplace options to File.rename (shyouhei)
+- [Feature #13683] Add strict Enumerable#single (shyouhei)
+- [Misc #13704] Exclude Changelog files from documentation. (shyouhei)
+- [Feature #13713] socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
+- [Feature #13715] [PATCH] avoid garbage from Symbol#to_s in interpolation (shyouhei)
+- [Feature #13719] [PATCH] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
+- [Feature #13732] Precise Time.now on Windows (shyouhei)
+- [Feature #13733] Dump the delegator instead of the delegated object (shyouhei)
+- [Feature #13625] BigDecimal short form / shorthand (shyouhei)
+- [Feature #13712] String#start_with? with regexp (shyouhei)
 - bugs that are not assigned (shyouhei)
-    * [Bug #13674]&nbsp;BigDecimal comparison with Float::INFINITY is erroneous in 2.2.x and 2.3.x
-    * [Bug #13675]&nbsp;Should Zlib::GzipReader#ungetc accept nil?
-    * [Bug #13700]&nbsp;Enumerable#sum may not work for Ranges subclasses due to optimization (**mrkn**)
-    * [Bug #13705]&nbsp;[PATCH] `cfp consistency error' occurs when raising exception in bmethod call event
-    * [Bug #13716]&nbsp;Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
-    * [Bug #13670]&nbsp;[BUG] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
+    * [Bug #13674] BigDecimal comparison with Float::INFINITY is erroneous in 2.2.x and 2.3.x
+    * [Bug #13675] Should Zlib::GzipReader#ungetc accept nil?
+    * [Bug #13700] Enumerable#sum may not work for Ranges subclasses due to optimization (**mrkn**)
+    * [Bug #13705] [PATCH] `cfp consistency error' occurs when raising exception in bmethod call event
+    * [Bug #13716] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+    * [Bug #13670] [BUG] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
 
 ## From attendees
 
@@ -101,53 +101,53 @@ Please add your favorite ticket numbers you want to ask to discuss.
   * https://gist.github.com/hsbt/968fcbb7acfa9405d82040a3c219f43a (ja)
   * Related with https://bugs.ruby-lang.org/issues/10320
 * [Bug #12159] Thread::Backtrace::Location#path returns absolute path for files loaded by require_relative (a_matsuda)
-- [Misc #13747]&nbsp;MinGW trunk build available on Appveyor (shyouhei)
-- [Feature #13751]&nbsp;Suppert SSHFP resource records in rubysl-resolv (shyouhei)
-- [Bug #13752]&nbsp;Can't observe sibling refinements (shyouhei)
-- [Feature #13683]&nbsp;Add strict Enumerable#single (shyouhei)
-- [Feature #13763]&nbsp;Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
-- [Feature #13765]&nbsp;Add Proc#bind (shyouhei)
-- [Feature #13767]&nbsp;add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
-- [Feature #13777]&nbsp;Array#delete_all (shyouhei)
-- [Feature #13618]&nbsp;[PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (shyouhei)
-- [Feature #13784]&nbsp;Add Enumerable#filter as an alias of Enumerable#select (shyouhei)
-- [Misc #13804]&nbsp;Protected methods cannot be overridden (shyouhei)
-- [Feature #13803]&nbsp;Add Socket::Ifaddr.vhid on supported platforms (shyouhei)
-- [Feature #13807]&nbsp;A method to filter the receiver against some condition (shyouhei)
-- [Feature #13805]&nbsp;Make refinement scoping to be like that of constants (shyouhei)
-- [Feature #13789]&nbsp;Dir - methods (shyouhei)
-- [Misc #13810]&nbsp;Inconsistency between Date and Time.strftime("%v") (shyouhei)
-- [Feature #12282]&nbsp;Hash#dig! for repeated applications of Hash#fetch (shyouhei)
-- [Feature #13821]&nbsp;Allow fibers to be resumed across threads (shyouhei)
-- [Feature #9450]&nbsp;Allow overriding SSLContext options in Net::HTTP (shyouhei)
-- [Feature #13820]&nbsp;Add a nill coalescing operator (shyouhei)
-- [Feature #13770]&nbsp;Can't create valid Cyrillic-named class/module (shyouhei)
-- [Feature #13839]&nbsp;String Interpolation Statements (shyouhei)
-- [Misc #13840]&nbsp;Collection methods - stability (shyouhei, duerst (propose to reject))
+- [Misc #13747] MinGW trunk build available on Appveyor (shyouhei)
+- [Feature #13751] Suppert SSHFP resource records in rubysl-resolv (shyouhei)
+- [Bug #13752] Can't observe sibling refinements (shyouhei)
+- [Feature #13683] Add strict Enumerable#single (shyouhei)
+- [Feature #13763] Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
+- [Feature #13765] Add Proc#bind (shyouhei)
+- [Feature #13767] add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
+- [Feature #13777] Array#delete_all (shyouhei)
+- [Feature #13618] [PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (shyouhei)
+- [Feature #13784] Add Enumerable#filter as an alias of Enumerable#select (shyouhei)
+- [Misc #13804] Protected methods cannot be overridden (shyouhei)
+- [Feature #13803] Add Socket::Ifaddr.vhid on supported platforms (shyouhei)
+- [Feature #13807] A method to filter the receiver against some condition (shyouhei)
+- [Feature #13805] Make refinement scoping to be like that of constants (shyouhei)
+- [Feature #13789] Dir - methods (shyouhei)
+- [Misc #13810] Inconsistency between Date and Time.strftime("%v") (shyouhei)
+- [Feature #12282] Hash#dig! for repeated applications of Hash#fetch (shyouhei)
+- [Feature #13821] Allow fibers to be resumed across threads (shyouhei)
+- [Feature #9450] Allow overriding SSLContext options in Net::HTTP (shyouhei)
+- [Feature #13820] Add a nill coalescing operator (shyouhei)
+- [Feature #13770] Can't create valid Cyrillic-named class/module (shyouhei)
+- [Feature #13839] String Interpolation Statements (shyouhei)
+- [Misc #13840] Collection methods - stability (shyouhei, duerst (propose to reject))
 - [Feature #13801] Implement case equality test for Set#=== (duerst)
 - bugs that are not assigned (shyouhei)
-    * [Bug #13549]&nbsp;MinGW / Windows encoding - Two issues
-    * [Bug #13754]&nbsp;bigdecimal with lower precision that Float
-    * [Bug #13746]&nbsp;windows-pr gemのRuby　2.4 32bit版でのSEGV
-    * [Bug #13758]&nbsp;TestRubyOptions#test_segv_setproctitle segfaults on AARCH64
-    * [Bug #13716]&nbsp;Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
-    * [Bug #13691]&nbsp;Word- and symbol array literals not valid where regular array is
-    * [Bug #13769]&nbsp;IPAddr#ipv4_compat incorrect behavior
-    * [Bug #13768]&nbsp;SIGCHLD and Thread dead-lock problem
-    * [Bug #13773]&nbsp;Improve String#prepend performance if only one argument is given
-    * [Bug #13774]&nbsp;for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
-    * [Bug #13748]&nbsp;[PATCH] Fix mul overflow detection for LLP64 arch.
-    * [Bug #13781]&nbsp;Should the safe navigation operator invoke `nil?`
-    * [Bug #13795]&nbsp;Hash#select return type does not match Hash#find_all
-    * [Bug #13811]&nbsp;Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
-    * [Bug #13818]&nbsp;Licence issue with use of Onigmo rather than Oniguruma library files
-    * [Bug #13827]&nbsp;Improve performance of `Base64.urlsafe_encode64`
-    * [Bug #13829]&nbsp;NUL char in $0
-    * [Bug #13833]&nbsp;String#scanf("%a") incorrectly requires a sign on the (binary) exponent
-    * [Bug #13835]&nbsp;Using 'open-uri' with 'tempfile' causes an exception
-    * [Bug #13757]&nbsp;TestBacktrace#test_caller_lev segaults on PPC
-    * [Bug #13167]&nbsp;Dir.glob is 25x slower since Ruby 2.2
-    * [Bug #13844]&nbsp;Toplevel returns should fire ensures
+    * [Bug #13549] MinGW / Windows encoding - Two issues
+    * [Bug #13754] bigdecimal with lower precision that Float
+    * [Bug #13746] windows-pr gemのRuby　2.4 32bit版でのSEGV
+    * [Bug #13758] TestRubyOptions#test_segv_setproctitle segfaults on AARCH64
+    * [Bug #13716] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+    * [Bug #13691] Word- and symbol array literals not valid where regular array is
+    * [Bug #13769] IPAddr#ipv4_compat incorrect behavior
+    * [Bug #13768] SIGCHLD and Thread dead-lock problem
+    * [Bug #13773] Improve String#prepend performance if only one argument is given
+    * [Bug #13774] for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
+    * [Bug #13748] [PATCH] Fix mul overflow detection for LLP64 arch.
+    * [Bug #13781] Should the safe navigation operator invoke `nil?`
+    * [Bug #13795] Hash#select return type does not match Hash#find_all
+    * [Bug #13811] Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
+    * [Bug #13818] Licence issue with use of Onigmo rather than Oniguruma library files
+    * [Bug #13827] Improve performance of `Base64.urlsafe_encode64`
+    * [Bug #13829] NUL char in $0
+    * [Bug #13833] String#scanf("%a") incorrectly requires a sign on the (binary) exponent
+    * [Bug #13835] Using 'open-uri' with 'tempfile' causes an exception
+    * [Bug #13757] TestBacktrace#test_caller_lev segaults on PPC
+    * [Bug #13167] Dir.glob is 25x slower since Ruby 2.2
+    * [Bug #13844] Toplevel returns should fire ensures
 
 ## From non-attendees
 

--- a/2017/DevMeeting-2017-09-25.md
+++ b/2017/DevMeeting-2017-09-25.md
@@ -32,77 +32,77 @@ Please add your favorite ticket numbers you want to ask to discuss.
 ## Carry-over from previous meeting(s)
 
 - [Feature #13396] Net::HTTP has no write timeout (shyouhei) Sorry, what was the conclusion of it?
-- [Bug #13438]&nbsp;Fix heap overflow due to configure.in not being updated for HEAP_* -> HEAP_PAGE_* variable renaming (shyouhei) Sorry, what was the conclusion of it?
-- [Feature #13608]&nbsp;Add TracePoint#thread (shyouhei)
-- [Feature #13602]&nbsp;Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
-- [Feature #13613]&nbsp;Prefer that require/require_relative/load to tell us permission error if the target file is unreadable (shyouhei)
-- [Feature #13620]&nbsp;Simplifying MRI's build system: always install (shyouhei)
-- [Feature #13630]&nbsp;:[] method should accept block in nice syntax (shyouhei) OK to close?
-- [Feature #11484]&nbsp;add output offset for readpartial/read_nonblock/etc (shyouhei)
-- [Feature #9001]&nbsp;Please package better standard library (shyouhei)
-- [Feature #12533]&nbsp;Refinements: allow modules inclusion, in which the module can call internal methods which it defines.  (shyouhei)
-- [Feature #13653]&nbsp;Bundled zlib helper (shyouhei)
-- [Feature #13626]&nbsp;Add String#byteslice! (shyouhei)
-- [Feature #13551]&nbsp;Add a method to alias class methods (shyouhei)
-- [Feature #13332]&nbsp;Forwardable#def_instance_delegator nil (shyouhei)
-- [Feature #13378]&nbsp;Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
-- [Feature #13381]&nbsp;[PATCH] Expose rb_fstring and its family to C extensions (shyouhei)
-- [Feature #13677]&nbsp;Add more details to error "Name or service not known (SocketError)" (shyouhei)
-- [Feature #9323]&nbsp;IO#writev (shyouhei)
-- [Feature #13693]&nbsp;Allow String#to_i and / or Kernel::Integer to parse e-notation (shyouhei)
-- [Feature #13434]&nbsp;better method definition in C API (shyouhei)
-- [Feature #13696]&nbsp;Add exchange and noreplace options to File.rename (shyouhei)
-- [Feature #13683]&nbsp;Add strict Enumerable#single (shyouhei)
-- [Feature #13713]&nbsp;socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
-- [Feature #13715]&nbsp;[PATCH] avoid garbage from Symbol#to_s in interpolation (shyouhei)
-- [Feature #13719]&nbsp;[PATCH] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
-- [Feature #13732]&nbsp;Precise Time.now on Windows (shyouhei)
-- [Feature #13733]&nbsp;Dump the delegator instead of the delegated object (shyouhei)
-- [Feature #13625]&nbsp;BigDecimal short form / shorthand (shyouhei)
-- [Feature #13712]&nbsp;String#start_with? with regexp (shyouhei)
+- [Bug #13438] Fix heap overflow due to configure.in not being updated for HEAP_* -> HEAP_PAGE_* variable renaming (shyouhei) Sorry, what was the conclusion of it?
+- [Feature #13608] Add TracePoint#thread (shyouhei)
+- [Feature #13602] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
+- [Feature #13613] Prefer that require/require_relative/load to tell us permission error if the target file is unreadable (shyouhei)
+- [Feature #13620] Simplifying MRI's build system: always install (shyouhei)
+- [Feature #13630] :[] method should accept block in nice syntax (shyouhei) OK to close?
+- [Feature #11484] add output offset for readpartial/read_nonblock/etc (shyouhei)
+- [Feature #9001] Please package better standard library (shyouhei)
+- [Feature #12533] Refinements: allow modules inclusion, in which the module can call internal methods which it defines.  (shyouhei)
+- [Feature #13653] Bundled zlib helper (shyouhei)
+- [Feature #13626] Add String#byteslice! (shyouhei)
+- [Feature #13551] Add a method to alias class methods (shyouhei)
+- [Feature #13332] Forwardable#def_instance_delegator nil (shyouhei)
+- [Feature #13378] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+- [Feature #13381] [PATCH] Expose rb_fstring and its family to C extensions (shyouhei)
+- [Feature #13677] Add more details to error "Name or service not known (SocketError)" (shyouhei)
+- [Feature #9323] IO#writev (shyouhei)
+- [Feature #13693] Allow String#to_i and / or Kernel::Integer to parse e-notation (shyouhei)
+- [Feature #13434] better method definition in C API (shyouhei)
+- [Feature #13696] Add exchange and noreplace options to File.rename (shyouhei)
+- [Feature #13683] Add strict Enumerable#single (shyouhei)
+- [Feature #13713] socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
+- [Feature #13715] [PATCH] avoid garbage from Symbol#to_s in interpolation (shyouhei)
+- [Feature #13719] [PATCH] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
+- [Feature #13732] Precise Time.now on Windows (shyouhei)
+- [Feature #13733] Dump the delegator instead of the delegated object (shyouhei)
+- [Feature #13625] BigDecimal short form / shorthand (shyouhei)
+- [Feature #13712] String#start_with? with regexp (shyouhei)
 * [Bug #12159] Thread::Backtrace::Location#path returns absolute path for files loaded by require_relative (a_matsuda)
-- [Feature #13751]&nbsp;Suppert SSHFP resource records in rubysl-resolv (shyouhei)
-- [Bug #13752]&nbsp;Can't observe sibling refinements (shyouhei)
-- [Feature #13763]&nbsp;Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
-- [Feature #13765]&nbsp;Add Proc#bind (shyouhei)
-- [Feature #13767]&nbsp;add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
-- [Feature #13777]&nbsp;Array#delete_all (shyouhei)
-- [Feature #13618]&nbsp;[PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (shyouhei)
-- [Feature #13784]&nbsp;Add Enumerable#filter as an alias of Enumerable#select (shyouhei)
-- [Misc #13804]&nbsp;Protected methods cannot be overridden (shyouhei)
-- [Feature #13807]&nbsp;A method to filter the receiver against some condition (shyouhei)
-- [Feature #13805]&nbsp;Make refinement scoping to be like that of constants (shyouhei)
-- [Misc #13810]&nbsp;Inconsistency between Date and Time.strftime("%v") (shyouhei)
-- [Feature #12282]&nbsp;Hash#dig! for repeated applications of Hash#fetch (shyouhei)
-- [Feature #13821]&nbsp;Allow fibers to be resumed across threads (shyouhei)
-- [Feature #9450]&nbsp;Allow overriding SSLContext options in Net::HTTP (shyouhei)
-- [Feature #13820]&nbsp;Add a nill coalescing operator (shyouhei)
-- [Feature #13770]&nbsp;Can't create valid Cyrillic-named class/module (shyouhei)
-- [Misc #13840]&nbsp;Collection methods - stability (shyouhei, duerst (propose to reject))
+- [Feature #13751] Suppert SSHFP resource records in rubysl-resolv (shyouhei)
+- [Bug #13752] Can't observe sibling refinements (shyouhei)
+- [Feature #13763] Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
+- [Feature #13765] Add Proc#bind (shyouhei)
+- [Feature #13767] add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
+- [Feature #13777] Array#delete_all (shyouhei)
+- [Feature #13618] [PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (shyouhei)
+- [Feature #13784] Add Enumerable#filter as an alias of Enumerable#select (shyouhei)
+- [Misc #13804] Protected methods cannot be overridden (shyouhei)
+- [Feature #13807] A method to filter the receiver against some condition (shyouhei)
+- [Feature #13805] Make refinement scoping to be like that of constants (shyouhei)
+- [Misc #13810] Inconsistency between Date and Time.strftime("%v") (shyouhei)
+- [Feature #12282] Hash#dig! for repeated applications of Hash#fetch (shyouhei)
+- [Feature #13821] Allow fibers to be resumed across threads (shyouhei)
+- [Feature #9450] Allow overriding SSLContext options in Net::HTTP (shyouhei)
+- [Feature #13820] Add a nill coalescing operator (shyouhei)
+- [Feature #13770] Can't create valid Cyrillic-named class/module (shyouhei)
+- [Misc #13840] Collection methods - stability (shyouhei, duerst (propose to reject))
 - bugs that are not assigned (shyouhei)
-    * [Bug #13675]&nbsp;Should Zlib::GzipReader#ungetc accept nil?
-    * [Bug #13700]&nbsp;Enumerable#sum may not work for Ranges subclasses due to optimization (**mrkn**)
-    * [Bug #13716]&nbsp;Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
-    * [Bug #13549]&nbsp;MinGW / Windows encoding - Two issues
-    * [Bug #13754]&nbsp;bigdecimal with lower precision that Float
-    * [Bug #13746]&nbsp;windows-pr gemのRuby　2.4 32bit版でのSEGV
-    * [Bug #13758]&nbsp;TestRubyOptions#test_segv_setproctitle segfaults on AARCH64
-    * [Bug #13691]&nbsp;Word- and symbol array literals not valid where regular array is
-    * [Bug #13769]&nbsp;IPAddr#ipv4_compat incorrect behavior
-    * [Bug #13768]&nbsp;SIGCHLD and Thread dead-lock problem
-    * [Bug #13773]&nbsp;Improve String#prepend performance if only one argument is given
-    * [Bug #13774]&nbsp;for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
-    * [Bug #13748]&nbsp;[PATCH] Fix mul overflow detection for LLP64 arch.
-    * [Bug #13781]&nbsp;Should the safe navigation operator invoke `nil?`
-    * [Bug #13795]&nbsp;Hash#select return type does not match Hash#find_all
-    * [Bug #13811]&nbsp;Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
-    * [Bug #13818]&nbsp;Licence issue with use of Onigmo rather than Oniguruma library files
-    * [Bug #13827]&nbsp;Improve performance of `Base64.urlsafe_encode64`
-    * [Bug #13829]&nbsp;NUL char in $0
-    * [Bug #13833]&nbsp;String#scanf("%a") incorrectly requires a sign on the (binary) exponent
-    * [Bug #13835]&nbsp;Using 'open-uri' with 'tempfile' causes an exception
-    * [Bug #13757]&nbsp;TestBacktrace#test_caller_lev segaults on PPC
-    * [Bug #13167]&nbsp;Dir.glob is 25x slower since Ruby 2.2
+    * [Bug #13675] Should Zlib::GzipReader#ungetc accept nil?
+    * [Bug #13700] Enumerable#sum may not work for Ranges subclasses due to optimization (**mrkn**)
+    * [Bug #13716] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+    * [Bug #13549] MinGW / Windows encoding - Two issues
+    * [Bug #13754] bigdecimal with lower precision that Float
+    * [Bug #13746] windows-pr gemのRuby　2.4 32bit版でのSEGV
+    * [Bug #13758] TestRubyOptions#test_segv_setproctitle segfaults on AARCH64
+    * [Bug #13691] Word- and symbol array literals not valid where regular array is
+    * [Bug #13769] IPAddr#ipv4_compat incorrect behavior
+    * [Bug #13768] SIGCHLD and Thread dead-lock problem
+    * [Bug #13773] Improve String#prepend performance if only one argument is given
+    * [Bug #13774] for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
+    * [Bug #13748] [PATCH] Fix mul overflow detection for LLP64 arch.
+    * [Bug #13781] Should the safe navigation operator invoke `nil?`
+    * [Bug #13795] Hash#select return type does not match Hash#find_all
+    * [Bug #13811] Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
+    * [Bug #13818] Licence issue with use of Onigmo rather than Oniguruma library files
+    * [Bug #13827] Improve performance of `Base64.urlsafe_encode64`
+    * [Bug #13829] NUL char in $0
+    * [Bug #13833] String#scanf("%a") incorrectly requires a sign on the (binary) exponent
+    * [Bug #13835] Using 'open-uri' with 'tempfile' causes an exception
+    * [Bug #13757] TestBacktrace#test_caller_lev segaults on PPC
+    * [Bug #13167] Dir.glob is 25x slower since Ruby 2.2
 
 ## From attendees
 
@@ -110,44 +110,44 @@ Please add your favorite ticket numbers you want to ask to discuss.
 - [Bug #13917] Comparable#clamp is slower than using Array#min,max. (naruse)
 - [Feature #13919] Add a new method to create Time instances from unix time and nsec
 
-- [Feature #13581]&nbsp;Syntax sugar for method reference (shyouhei)
-- [Feature #13867]&nbsp;Copy offloading in IO.copy_stream (shyouhei)
-- [Feature #13869]&nbsp;Filter non directories from Dir.glob (shyouhei)
-- [Feature #8948]&nbsp;Frozen regex (shyouhei)
-- [Bug #13857]&nbsp;frozen string literal: can freeze same string into two unique frozen strings (shyouhei)
-- [Feature #13881]&nbsp;Use getcontext/setcontext on OS X (shyouhei)
-- [Feature #13883]&nbsp;Change from gperf 3.0.4 to gperf 3.1 (shyouhei)
-- [Feature #13890]&nbsp;Allow a regexp as an argument to 'count', to count more interesting things than single characters (shyouhei)
-- [Feature #13873]&nbsp;Optimize Dir.glob with FNM_EXTGLOB (shyouhei)
-- [Feature #13245]&nbsp;[PATCH] reject inter-thread TLS modification (shyouhei)
-- [Feature #13893]&nbsp;Add Fiber#[] and Fiber#[]= and restore Thread#[] and Thread#[]= to their original behavior (shyouhei)
-- [Feature #13901]&nbsp;Add branch coverage  (shyouhei)
-- [Feature #12753]&nbsp;Useful operator to check bit-flag is true or false (shyouhei)
-- [Feature #8499]&nbsp;Importing Hash#slice, Hash#slice!, Hash#except, and Hash#except! from ActiveSupport (shyouhei)
-- [Feature #10344]&nbsp;[PATCH] Implement Fiber#raise (shyouhei)
-- [Feature #13922]&nbsp;Consider showing warning messages about same-named aliases - either directly or perhaps via the "did you mean gem" (shyouhei)
-- [Feature #13924]&nbsp;Add headings/hints to RubyVM::InstructionSequence#disasm (shyouhei)
-- [Feature #13923]&nbsp;Idiom to release resources safely, with less indentations (shyouhei)
-- [Feature #10849]&nbsp;Adding an alphanumeric function to SecureRandom (shyouhei)
-- [Feature #13919]&nbsp;Add a new method to create Time instances from unix time and nsec (shyouhei)
-- [Feature #13884]&nbsp;Reduce number of memory allocations for "and", "or" and "diff" operations on small arrays (shyouhei)
-- [Feature #13936]&nbsp;Make regular expressions debugable (duerst)
-- [Feature #13934]&nbsp;Being able to set a default encoding other than Unicode on a "per-project" basis (duerst)
+- [Feature #13581] Syntax sugar for method reference (shyouhei)
+- [Feature #13867] Copy offloading in IO.copy_stream (shyouhei)
+- [Feature #13869] Filter non directories from Dir.glob (shyouhei)
+- [Feature #8948] Frozen regex (shyouhei)
+- [Bug #13857] frozen string literal: can freeze same string into two unique frozen strings (shyouhei)
+- [Feature #13881] Use getcontext/setcontext on OS X (shyouhei)
+- [Feature #13883] Change from gperf 3.0.4 to gperf 3.1 (shyouhei)
+- [Feature #13890] Allow a regexp as an argument to 'count', to count more interesting things than single characters (shyouhei)
+- [Feature #13873] Optimize Dir.glob with FNM_EXTGLOB (shyouhei)
+- [Feature #13245] [PATCH] reject inter-thread TLS modification (shyouhei)
+- [Feature #13893] Add Fiber#[] and Fiber#[]= and restore Thread#[] and Thread#[]= to their original behavior (shyouhei)
+- [Feature #13901] Add branch coverage  (shyouhei)
+- [Feature #12753] Useful operator to check bit-flag is true or false (shyouhei)
+- [Feature #8499] Importing Hash#slice, Hash#slice!, Hash#except, and Hash#except! from ActiveSupport (shyouhei)
+- [Feature #10344] [PATCH] Implement Fiber#raise (shyouhei)
+- [Feature #13922] Consider showing warning messages about same-named aliases - either directly or perhaps via the "did you mean gem" (shyouhei)
+- [Feature #13924] Add headings/hints to RubyVM::InstructionSequence#disasm (shyouhei)
+- [Feature #13923] Idiom to release resources safely, with less indentations (shyouhei)
+- [Feature #10849] Adding an alphanumeric function to SecureRandom (shyouhei)
+- [Feature #13919] Add a new method to create Time instances from unix time and nsec (shyouhei)
+- [Feature #13884] Reduce number of memory allocations for "and", "or" and "diff" operations on small arrays (shyouhei)
+- [Feature #13936] Make regular expressions debugable (duerst)
+- [Feature #13934] Being able to set a default encoding other than Unicode on a "per-project" basis (duerst)
 - bugs that are not assigned (shyouhei)
-    * [Bug #13794]&nbsp;Infinite loop of sched_yield
-    * [Bug #12036]&nbsp;Enumerator's automatic rewind behavior
-    * [Bug #13872]&nbsp;Duplicate assignment no longer silences "assigned but unused variable" warning
-    * [Bug #13848]&nbsp;BigDecimal.new('200.') raises an exception
-    * [Bug #13880]&nbsp;`BigDecimal(string)` should raise on invalid values in `string`
-    * [Bug #13851]&nbsp;getting "can't modify string; temporarily locked" on non-frozen instances
-    * [Bug #13876]&nbsp;Tempfile's finalizer can be interrupted by a Timeout exception which can cause the process to hang
-    * [Bug #13885]&nbsp;Random.urandom と securerandom について
-    * [Bug #10104]&nbsp;Fileutils cp_r fails on sockets or fifes even if File.mknod and File.mkfifo are defined
-    * [Bug #13917]&nbsp;Comparable#clamp is slower than using Array#min,max.
-    * [Bug #13887]&nbsp;test/ruby/test_io.rb may get stuck with FIBER_USE_NATIVE=0 on Linux
-    * [Bug #13926]&nbsp;Non UTF response headers raise an Argument error since 2.4.2p198
-    * [Bug #13925]&nbsp;string.split(pattern, 1) should return [self.dup], but it returns [self]
-    * [Bug #13931]&nbsp;correct install_name of libruby on macOS (libruby.2.5.0.dylib -> libruby.2.5.dylib)
+    * [Bug #13794] Infinite loop of sched_yield
+    * [Bug #12036] Enumerator's automatic rewind behavior
+    * [Bug #13872] Duplicate assignment no longer silences "assigned but unused variable" warning
+    * [Bug #13848] BigDecimal.new('200.') raises an exception
+    * [Bug #13880] `BigDecimal(string)` should raise on invalid values in `string`
+    * [Bug #13851] getting "can't modify string; temporarily locked" on non-frozen instances
+    * [Bug #13876] Tempfile's finalizer can be interrupted by a Timeout exception which can cause the process to hang
+    * [Bug #13885] Random.urandom と securerandom について
+    * [Bug #10104] Fileutils cp_r fails on sockets or fifes even if File.mknod and File.mkfifo are defined
+    * [Bug #13917] Comparable#clamp is slower than using Array#min,max.
+    * [Bug #13887] test/ruby/test_io.rb may get stuck with FIBER_USE_NATIVE=0 on Linux
+    * [Bug #13926] Non UTF response headers raise an Argument error since 2.4.2p198
+    * [Bug #13925] string.split(pattern, 1) should return [self.dup], but it returns [self]
+    * [Bug #13931] correct install_name of libruby on macOS (libruby.2.5.0.dylib -> libruby.2.5.dylib)
 
 
 ## From non-attendees

--- a/2017/DevMeeting-2017-10-19.md
+++ b/2017/DevMeeting-2017-10-19.md
@@ -33,69 +33,69 @@ Please add your favorite ticket numbers you want to ask to discuss.
 ## Carry-over from previous meeting(s)
 
 - bugs that are not assigned (shyouhei)
-    * [Bug #13675]&nbsp;Should Zlib::GzipReader#ungetc accept nil?
-    * [Bug #13700]&nbsp;Enumerable#sum may not work for Ranges subclasses due to optimization (**mrkn**)
-    * [Bug #13716]&nbsp;Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
-    * [Bug #13549]&nbsp;MinGW / Windows encoding - Two issues
-    * [Bug #13746]&nbsp;windows-pr gemのRuby　2.4 32bit版でのSEGV
-    * [Bug #13768]&nbsp;SIGCHLD and Thread dead-lock problem
-    * [Bug #13773]&nbsp;Improve String#prepend performance if only one argument is given
-    * [Bug #13774]&nbsp;for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
-    * [Bug #13781]&nbsp;Should the safe navigation operator invoke `nil?`
-    * [Bug #13795]&nbsp;Hash#select return type does not match Hash#find_all
-    * [Bug #13811]&nbsp;Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
-    * [Bug #13818]&nbsp;Licence issue with use of Onigmo rather than Oniguruma library files
-    * [Bug #13827]&nbsp;Improve performance of `Base64.urlsafe_encode64`
-    * [Bug #13829]&nbsp;NUL char in $0
-    * [Bug #13833]&nbsp;String#scanf("%a") incorrectly requires a sign on the (binary) exponent
-    * [Bug #13835]&nbsp;Using 'open-uri' with 'tempfile' causes an exception
-    * [Bug #13167]&nbsp;Dir.glob is 25x slower since Ruby 2.2
-    * [Bug #12036]&nbsp;Enumerator's automatic rewind behavior
-    * [Bug #13872]&nbsp;Duplicate assignment no longer silences "assigned but unused variable" warning
-    * [Bug #13848]&nbsp;BigDecimal.new('200.') raises an exception
-    * [Bug #13880]&nbsp;`BigDecimal(string)` should raise on invalid values in `string`
-    * [Bug #13876]&nbsp;Tempfile's finalizer can be interrupted by a Timeout exception which can cause the process to hang
-    * [Bug #13885]&nbsp;Random.urandom と securerandom について
-    * [Bug #10104]&nbsp;Fileutils cp_r fails on sockets or fifes even if File.mknod and File.mkfifo are defined
-- [Feature #13653]&nbsp;Bundled zlib helper (shyouhei) hsbt?
-- [Feature #13381]&nbsp;[PATCH] Expose rb_fstring and its family to C extensions (shyouhei) ko1?
-- [Feature #13434]&nbsp;better method definition in C API (shyouhei) ko1?
-- [Feature #13713]&nbsp;socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
-- [Feature #13715]&nbsp;[PATCH] avoid garbage from Symbol#to_s in interpolation (shyouhei)
-- [Feature #13719]&nbsp;[PATCH] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
-- [Feature #13732]&nbsp;Precise Time.now on Windows (shyouhei)
-- [Feature #13733]&nbsp;Dump the delegator instead of the delegated object (shyouhei)
-- [Feature #13625]&nbsp;BigDecimal short form / shorthand (shyouhei)
-- [Feature #13712]&nbsp;String#start_with? with regexp (shyouhei)
+    * [Bug #13675] Should Zlib::GzipReader#ungetc accept nil?
+    * [Bug #13700] Enumerable#sum may not work for Ranges subclasses due to optimization (**mrkn**)
+    * [Bug #13716] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+    * [Bug #13549] MinGW / Windows encoding - Two issues
+    * [Bug #13746] windows-pr gemのRuby　2.4 32bit版でのSEGV
+    * [Bug #13768] SIGCHLD and Thread dead-lock problem
+    * [Bug #13773] Improve String#prepend performance if only one argument is given
+    * [Bug #13774] for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
+    * [Bug #13781] Should the safe navigation operator invoke `nil?`
+    * [Bug #13795] Hash#select return type does not match Hash#find_all
+    * [Bug #13811] Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
+    * [Bug #13818] Licence issue with use of Onigmo rather than Oniguruma library files
+    * [Bug #13827] Improve performance of `Base64.urlsafe_encode64`
+    * [Bug #13829] NUL char in $0
+    * [Bug #13833] String#scanf("%a") incorrectly requires a sign on the (binary) exponent
+    * [Bug #13835] Using 'open-uri' with 'tempfile' causes an exception
+    * [Bug #13167] Dir.glob is 25x slower since Ruby 2.2
+    * [Bug #12036] Enumerator's automatic rewind behavior
+    * [Bug #13872] Duplicate assignment no longer silences "assigned but unused variable" warning
+    * [Bug #13848] BigDecimal.new('200.') raises an exception
+    * [Bug #13880] `BigDecimal(string)` should raise on invalid values in `string`
+    * [Bug #13876] Tempfile's finalizer can be interrupted by a Timeout exception which can cause the process to hang
+    * [Bug #13885] Random.urandom と securerandom について
+    * [Bug #10104] Fileutils cp_r fails on sockets or fifes even if File.mknod and File.mkfifo are defined
+- [Feature #13653] Bundled zlib helper (shyouhei) hsbt?
+- [Feature #13381] [PATCH] Expose rb_fstring and its family to C extensions (shyouhei) ko1?
+- [Feature #13434] better method definition in C API (shyouhei) ko1?
+- [Feature #13713] socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
+- [Feature #13715] [PATCH] avoid garbage from Symbol#to_s in interpolation (shyouhei)
+- [Feature #13719] [PATCH] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
+- [Feature #13732] Precise Time.now on Windows (shyouhei)
+- [Feature #13733] Dump the delegator instead of the delegated object (shyouhei)
+- [Feature #13625] BigDecimal short form / shorthand (shyouhei)
+- [Feature #13712] String#start_with? with regexp (shyouhei)
 * [Bug #12159] Thread::Backtrace::Location#path returns absolute path for files loaded by require_relative (a_matsuda)
-- [Feature #13751]&nbsp;Suppert SSHFP resource records in rubysl-resolv (shyouhei)
-- [Bug #13752]&nbsp;Can't observe sibling refinements (shyouhei)
-- [Feature #13763]&nbsp;Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
-- [Feature #13765]&nbsp;Add Proc#bind (shyouhei)
-- [Feature #13767]&nbsp;add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
-- [Feature #13777]&nbsp;Array#delete_all (shyouhei)
-- [Misc #13804]&nbsp;Protected methods cannot be overridden (shyouhei)
-- [Feature #13807]&nbsp;A method to filter the receiver against some condition (shyouhei)
-- [Feature #13805]&nbsp;Make refinement scoping to be like that of constants (shyouhei)
-- [Feature #12282]&nbsp;Hash#dig! for repeated applications of Hash#fetch (shyouhei)
-- [Feature #9450]&nbsp;Allow overriding SSLContext options in Net::HTTP (shyouhei)
-- [Feature #13820]&nbsp;Add a nill coalescing operator (shyouhei)
-- [Feature #13770]&nbsp;Can't create valid Cyrillic-named class/module (shyouhei) status?
-- [Misc #13840]&nbsp;Collection methods - stability (shyouhei, duerst (propose to reject))
-- [Feature #13581]&nbsp;Syntax sugar for method reference (shyouhei)
-- [Feature #13869]&nbsp;Filter non directories from Dir.glob (shyouhei)
-- [Feature #8948]&nbsp;Frozen regex (shyouhei)
-- [Feature #13881]&nbsp;Use getcontext/setcontext on OS X (shyouhei)
-- [Feature #13883]&nbsp;Change from gperf 3.0.4 to gperf 3.1 (shyouhei)
-- [Feature #13890]&nbsp;Allow a regexp as an argument to 'count', to count more interesting things than single characters (shyouhei)
-- [Feature #13873]&nbsp;Optimize Dir.glob with FNM_EXTGLOB (shyouhei)
-- [Feature #13245]&nbsp;[PATCH] reject inter-thread TLS modification (shyouhei)
-- [Feature #13901]&nbsp;Add branch coverage  (shyouhei)
-- [Feature #12753]&nbsp;Useful operator to check bit-flag is true or false (shyouhei)
-- [Feature #8499]&nbsp;Importing Hash#slice, Hash#slice!, Hash#except, and Hash#except! from ActiveSupport (shyouhei)
-- [Feature #13922]&nbsp;Consider showing warning messages about same-named aliases - either directly or perhaps via the "did you mean gem" (shyouhei)
-- [Feature #13924]&nbsp;Add headings/hints to RubyVM::InstructionSequence#disasm (shyouhei)
-- [Feature #10849]&nbsp;Adding an alphanumeric function to SecureRandom (shyouhei)
+- [Feature #13751] Suppert SSHFP resource records in rubysl-resolv (shyouhei)
+- [Bug #13752] Can't observe sibling refinements (shyouhei)
+- [Feature #13763] Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
+- [Feature #13765] Add Proc#bind (shyouhei)
+- [Feature #13767] add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
+- [Feature #13777] Array#delete_all (shyouhei)
+- [Misc #13804] Protected methods cannot be overridden (shyouhei)
+- [Feature #13807] A method to filter the receiver against some condition (shyouhei)
+- [Feature #13805] Make refinement scoping to be like that of constants (shyouhei)
+- [Feature #12282] Hash#dig! for repeated applications of Hash#fetch (shyouhei)
+- [Feature #9450] Allow overriding SSLContext options in Net::HTTP (shyouhei)
+- [Feature #13820] Add a nill coalescing operator (shyouhei)
+- [Feature #13770] Can't create valid Cyrillic-named class/module (shyouhei) status?
+- [Misc #13840] Collection methods - stability (shyouhei, duerst (propose to reject))
+- [Feature #13581] Syntax sugar for method reference (shyouhei)
+- [Feature #13869] Filter non directories from Dir.glob (shyouhei)
+- [Feature #8948] Frozen regex (shyouhei)
+- [Feature #13881] Use getcontext/setcontext on OS X (shyouhei)
+- [Feature #13883] Change from gperf 3.0.4 to gperf 3.1 (shyouhei)
+- [Feature #13890] Allow a regexp as an argument to 'count', to count more interesting things than single characters (shyouhei)
+- [Feature #13873] Optimize Dir.glob with FNM_EXTGLOB (shyouhei)
+- [Feature #13245] [PATCH] reject inter-thread TLS modification (shyouhei)
+- [Feature #13901] Add branch coverage  (shyouhei)
+- [Feature #12753] Useful operator to check bit-flag is true or false (shyouhei)
+- [Feature #8499] Importing Hash#slice, Hash#slice!, Hash#except, and Hash#except! from ActiveSupport (shyouhei)
+- [Feature #13922] Consider showing warning messages about same-named aliases - either directly or perhaps via the "did you mean gem" (shyouhei)
+- [Feature #13924] Add headings/hints to RubyVM::InstructionSequence#disasm (shyouhei)
+- [Feature #10849] Adding an alphanumeric function to SecureRandom (shyouhei)
 
 ## From attendees
 
@@ -104,25 +104,25 @@ Please add your favorite ticket numbers you want to ask to discuss.
 * [Feature #11666] IPAddr#private? (glass)
 * [Feature #13610] IPAddr has no public method to get the current subnet mask (glass)
 * [Feature #8047] IPAddr makes host address with netmask (glass)
-- [Feature #8661]&nbsp;Add option to print backstrace in reverse order(stack frames first & error last) (shyouhei) objection appealed.
-- [Misc #13968]&nbsp;[Ruby 3.x perhaps] - A (minimal?) static variant of ruby (shyouhei)
-- [Feature #13969]&nbsp;Dir#each_child (shyouhei)
-- [Feature #12115]&nbsp;Add Symbol#call to allow to_proc shorthand with arguments (shyouhei)
-- [Feature #5964]&nbsp;Make Symbols an Alternate Syntax for Strings (shyouhei) seems updated since closed
-- [Feature #12533]&nbsp;Refinements: allow modules inclusion, in which the module can call internal methods which it defines.  (shyouhei)
-- [Feature #13984]&nbsp;BigDecimal should be immutable/frozen and return itself on #dup (shyouhei)
-- [Feature #13985]&nbsp;Avoid exception for #dup/#clone on Rational and Complex (shyouhei)
-- [Feature #13936]&nbsp;Make regular expressions debugable (shyouhei)
-- [Bug #13986]&nbsp;Integer#fdiv with Complex returns unexpected value (shyouhei)
-- [Feature #13983]&nbsp;Rational and Complex should be frozen (shyouhei)
-- [Feature #14022]&nbsp;String#surround (shyouhei)
+- [Feature #8661] Add option to print backstrace in reverse order(stack frames first & error last) (shyouhei) objection appealed.
+- [Misc #13968] [Ruby 3.x perhaps] - A (minimal?) static variant of ruby (shyouhei)
+- [Feature #13969] Dir#each_child (shyouhei)
+- [Feature #12115] Add Symbol#call to allow to_proc shorthand with arguments (shyouhei)
+- [Feature #5964] Make Symbols an Alternate Syntax for Strings (shyouhei) seems updated since closed
+- [Feature #12533] Refinements: allow modules inclusion, in which the module can call internal methods which it defines.  (shyouhei)
+- [Feature #13984] BigDecimal should be immutable/frozen and return itself on #dup (shyouhei)
+- [Feature #13985] Avoid exception for #dup/#clone on Rational and Complex (shyouhei)
+- [Feature #13936] Make regular expressions debugable (shyouhei)
+- [Bug #13986] Integer#fdiv with Complex returns unexpected value (shyouhei)
+- [Feature #13983] Rational and Complex should be frozen (shyouhei)
+- [Feature #14022] String#surround (shyouhei)
 - bugs that are not assigned (shyouhei)
-    * [Bug #13930]&nbsp;Exception is caught in rescue above ensure
-    * [Bug #13970]&nbsp;Base64 urlsafe_decode64 unsafe use of tr.
-    * [Bug #14010]&nbsp;RubyVM logic in forwardable backported to 2.3, not removed
-    * [Bug #14016]&nbsp;URI IPv6 address can't be used to open socket
-    * [Bug #14015]&nbsp;Enumerable & Hash yielding arity
-    * [Bug #13887]&nbsp;test/ruby/test_io.rb may get stuck with FIBER_USE_NATIVE=0 on Linux
+    * [Bug #13930] Exception is caught in rescue above ensure
+    * [Bug #13970] Base64 urlsafe_decode64 unsafe use of tr.
+    * [Bug #14010] RubyVM logic in forwardable backported to 2.3, not removed
+    * [Bug #14016] URI IPv6 address can't be used to open socket
+    * [Bug #14015] Enumerable & Hash yielding arity
+    * [Bug #13887] test/ruby/test_io.rb may get stuck with FIBER_USE_NATIVE=0 on Linux
 
 ## From non-attendees
 

--- a/2017/DevMeeting-2017-11-29.md
+++ b/2017/DevMeeting-2017-11-29.md
@@ -33,120 +33,120 @@ Please add your favorite ticket numbers you want to ask to discuss.
 ## Carry-over from previous meeting(s)
 
 - bugs that are not assigned (shyouhei)
-    * [Bug #13675]&nbsp;Should Zlib::GzipReader#ungetc accept nil?
-    * [Bug #13700]&nbsp;Enumerable#sum may not work for Ranges subclasses due to optimization (**mrkn**)
-    * [Bug #13716]&nbsp;Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
-    * [Bug #13549]&nbsp;MinGW / Windows encoding - Two issues
-    * [Bug #13746]&nbsp;windows-pr gemのRuby　2.4 32bit版でのSEGV
-    * [Bug #13768]&nbsp;SIGCHLD and Thread dead-lock problem
-    * [Bug #13773]&nbsp;Improve String#prepend performance if only one argument is given
-    * [Bug #13774]&nbsp;for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
-    * [Bug #13781]&nbsp;Should the safe navigation operator invoke `nil?`
-    * [Bug #13795]&nbsp;Hash#select return type does not match Hash#find_all
-    * [Bug #13811]&nbsp;Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
-    * [Bug #13818]&nbsp;Licence issue with use of Onigmo rather than Oniguruma library files
-    * [Bug #13827]&nbsp;Improve performance of `Base64.urlsafe_encode64`
-    * [Bug #13835]&nbsp;Using 'open-uri' with 'tempfile' causes an exception
-    * [Bug #13167]&nbsp;Dir.glob is 25x slower since Ruby 2.2
-    * [Bug #12036]&nbsp;Enumerator's automatic rewind behavior
-    * [Bug #13848]&nbsp;BigDecimal.new('200.') raises an exception
-    * [Bug #13880]&nbsp;`BigDecimal(string)` should raise on invalid values in `string`
-    * [Bug #13876]&nbsp;Tempfile's finalizer can be interrupted by a Timeout exception which can cause the process to hang
-    * [Bug #13885]&nbsp;Random.urandom と securerandom について
-    * [Bug #10104]&nbsp;Fileutils cp_r fails on sockets or fifes even if File.mknod and File.mkfifo are defined
-    * [Bug #13930]&nbsp;Exception is caught in rescue above ensure
-    * [Bug #13970]&nbsp;Base64 urlsafe_decode64 unsafe use of tr.
-    * [Bug #14010]&nbsp;RubyVM logic in forwardable backported to 2.3, not removed
-    * [Bug #14016]&nbsp;URI IPv6 address can't be used to open socket
-    * [Bug #14015]&nbsp;Enumerable & Hash yielding arity
-    * [Bug #13887]&nbsp;test/ruby/test_io.rb may get stuck with FIBER_USE_NATIVE=0 on Linux
-- [Feature #13381]&nbsp;[PATCH] Expose rb_fstring and its family to C extensions (shyouhei) ko1?
-- [Feature #13434]&nbsp;better method definition in C API (shyouhei) ko1?
-- [Feature #13713]&nbsp;socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
-- [Feature #13715]&nbsp;[PATCH] avoid garbage from Symbol#to_s in interpolation (shyouhei)
-- [Feature #13719]&nbsp;[PATCH] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
-- [Feature #13733]&nbsp;Dump the delegator instead of the delegated object (shyouhei)
-- [Feature #13625]&nbsp;BigDecimal short form / shorthand (shyouhei)
+    * [Bug #13675] Should Zlib::GzipReader#ungetc accept nil?
+    * [Bug #13700] Enumerable#sum may not work for Ranges subclasses due to optimization (**mrkn**)
+    * [Bug #13716] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+    * [Bug #13549] MinGW / Windows encoding - Two issues
+    * [Bug #13746] windows-pr gemのRuby　2.4 32bit版でのSEGV
+    * [Bug #13768] SIGCHLD and Thread dead-lock problem
+    * [Bug #13773] Improve String#prepend performance if only one argument is given
+    * [Bug #13774] for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
+    * [Bug #13781] Should the safe navigation operator invoke `nil?`
+    * [Bug #13795] Hash#select return type does not match Hash#find_all
+    * [Bug #13811] Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
+    * [Bug #13818] Licence issue with use of Onigmo rather than Oniguruma library files
+    * [Bug #13827] Improve performance of `Base64.urlsafe_encode64`
+    * [Bug #13835] Using 'open-uri' with 'tempfile' causes an exception
+    * [Bug #13167] Dir.glob is 25x slower since Ruby 2.2
+    * [Bug #12036] Enumerator's automatic rewind behavior
+    * [Bug #13848] BigDecimal.new('200.') raises an exception
+    * [Bug #13880] `BigDecimal(string)` should raise on invalid values in `string`
+    * [Bug #13876] Tempfile's finalizer can be interrupted by a Timeout exception which can cause the process to hang
+    * [Bug #13885] Random.urandom と securerandom について
+    * [Bug #10104] Fileutils cp_r fails on sockets or fifes even if File.mknod and File.mkfifo are defined
+    * [Bug #13930] Exception is caught in rescue above ensure
+    * [Bug #13970] Base64 urlsafe_decode64 unsafe use of tr.
+    * [Bug #14010] RubyVM logic in forwardable backported to 2.3, not removed
+    * [Bug #14016] URI IPv6 address can't be used to open socket
+    * [Bug #14015] Enumerable & Hash yielding arity
+    * [Bug #13887] test/ruby/test_io.rb may get stuck with FIBER_USE_NATIVE=0 on Linux
+- [Feature #13381] [PATCH] Expose rb_fstring and its family to C extensions (shyouhei) ko1?
+- [Feature #13434] better method definition in C API (shyouhei) ko1?
+- [Feature #13713] socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
+- [Feature #13715] [PATCH] avoid garbage from Symbol#to_s in interpolation (shyouhei)
+- [Feature #13719] [PATCH] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
+- [Feature #13733] Dump the delegator instead of the delegated object (shyouhei)
+- [Feature #13625] BigDecimal short form / shorthand (shyouhei)
 * [Bug #12159] Thread::Backtrace::Location#path returns absolute path for files loaded by require_relative (a_matsuda)
-- [Feature #13751]&nbsp;Suppert SSHFP resource records in rubysl-resolv (shyouhei)
-- [Bug #13752]&nbsp;Can't observe sibling refinements (shyouhei)
-- [Feature #13763]&nbsp;Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
-- [Feature #13765]&nbsp;Add Proc#bind (shyouhei)
-- [Feature #13767]&nbsp;add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
-- [Misc #13804]&nbsp;Protected methods cannot be overridden (shyouhei)
-- [Feature #13807]&nbsp;A method to filter the receiver against some condition (shyouhei)
-- [Feature #13805]&nbsp;Make refinement scoping to be like that of constants (shyouhei)
-- [Feature #12282]&nbsp;Hash#dig! for repeated applications of Hash#fetch (shyouhei)
-- [Feature #13820]&nbsp;Add a nill coalescing operator (shyouhei)
-- [Feature #13770]&nbsp;Can't create valid Cyrillic-named class/module (shyouhei) status?
-- [Feature #13581]&nbsp;Syntax sugar for method reference (shyouhei)
-- [Feature #13881]&nbsp;Use getcontext/setcontext on OS X (shyouhei)
-- [Feature #13883]&nbsp;Change from gperf 3.0.4 to gperf 3.1 (shyouhei)
-- [Feature #13890]&nbsp;Allow a regexp as an argument to 'count', to count more interesting things than single characters (shyouhei)
-- [Feature #13245]&nbsp;[PATCH] reject inter-thread TLS modification (shyouhei)
-- [Feature #13901]&nbsp;Add branch coverage  (shyouhei)
-- [Feature #13922]&nbsp;Consider showing warning messages about same-named aliases - either directly or perhaps via the "did you mean gem" (shyouhei)
-- [Feature #13924]&nbsp;Add headings/hints to RubyVM::InstructionSequence#disasm (shyouhei)
-- [Feature #8661]&nbsp;Add option to print backstrace in reverse order(stack frames first & error last) (shyouhei) objection appealed.
-- [Misc #13968]&nbsp;[Ruby 3.x perhaps] - A (minimal?) static variant of ruby (shyouhei)
-- [Feature #13969]&nbsp;Dir#each_child (shyouhei)
-- [Feature #12115]&nbsp;Add Symbol#call to allow to_proc shorthand with arguments (shyouhei)
-- [Feature #5964]&nbsp;Make Symbols an Alternate Syntax for Strings (shyouhei) seems updated since closed
-- [Feature #12533]&nbsp;Refinements: allow modules inclusion, in which the module can call internal methods which it defines.  (shyouhei)
-- [Feature #13984]&nbsp;BigDecimal should be immutable/frozen and return itself on #dup (shyouhei)
-- [Feature #13936]&nbsp;Make regular expressions debugable (shyouhei)
-- [Bug #13986]&nbsp;Integer#fdiv with Complex returns unexpected value (shyouhei)
-- [Feature #14022]&nbsp;String#surround (shyouhei)
+- [Feature #13751] Suppert SSHFP resource records in rubysl-resolv (shyouhei)
+- [Bug #13752] Can't observe sibling refinements (shyouhei)
+- [Feature #13763] Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
+- [Feature #13765] Add Proc#bind (shyouhei)
+- [Feature #13767] add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
+- [Misc #13804] Protected methods cannot be overridden (shyouhei)
+- [Feature #13807] A method to filter the receiver against some condition (shyouhei)
+- [Feature #13805] Make refinement scoping to be like that of constants (shyouhei)
+- [Feature #12282] Hash#dig! for repeated applications of Hash#fetch (shyouhei)
+- [Feature #13820] Add a nill coalescing operator (shyouhei)
+- [Feature #13770] Can't create valid Cyrillic-named class/module (shyouhei) status?
+- [Feature #13581] Syntax sugar for method reference (shyouhei)
+- [Feature #13881] Use getcontext/setcontext on OS X (shyouhei)
+- [Feature #13883] Change from gperf 3.0.4 to gperf 3.1 (shyouhei)
+- [Feature #13890] Allow a regexp as an argument to 'count', to count more interesting things than single characters (shyouhei)
+- [Feature #13245] [PATCH] reject inter-thread TLS modification (shyouhei)
+- [Feature #13901] Add branch coverage  (shyouhei)
+- [Feature #13922] Consider showing warning messages about same-named aliases - either directly or perhaps via the "did you mean gem" (shyouhei)
+- [Feature #13924] Add headings/hints to RubyVM::InstructionSequence#disasm (shyouhei)
+- [Feature #8661] Add option to print backstrace in reverse order(stack frames first & error last) (shyouhei) objection appealed.
+- [Misc #13968] [Ruby 3.x perhaps] - A (minimal?) static variant of ruby (shyouhei)
+- [Feature #13969] Dir#each_child (shyouhei)
+- [Feature #12115] Add Symbol#call to allow to_proc shorthand with arguments (shyouhei)
+- [Feature #5964] Make Symbols an Alternate Syntax for Strings (shyouhei) seems updated since closed
+- [Feature #12533] Refinements: allow modules inclusion, in which the module can call internal methods which it defines.  (shyouhei)
+- [Feature #13984] BigDecimal should be immutable/frozen and return itself on #dup (shyouhei)
+- [Feature #13936] Make regular expressions debugable (shyouhei)
+- [Bug #13986] Integer#fdiv with Complex returns unexpected value (shyouhei)
+- [Feature #14022] String#surround (shyouhei)
 
 ## From attendees
 
-  * [Bug #8352]&nbsp;URI squeezes a sequence of slashes in merging paths when it shouldn't (knu)
-  * [Feature #14123]&nbsp;Kernel#pp by default (mame)
-  * [Feature #12275]&nbsp;String unescape (tadd)
+  * [Bug #8352] URI squeezes a sequence of slashes in merging paths when it shouldn't (knu)
+  * [Feature #14123] Kernel#pp by default (mame)
+  * [Feature #12275] String unescape (tadd)
 
 The tickets below are old tickets whose status is open or assigned (and mame can somewhat understand)
 
 - matz
-  * [Feature #1586]&nbsp;Including a module already present in ancestors should not be ignored
-  * [Feature #2080]&nbsp;Proc#to_source, Method#to_source
-  * [Feature #2323]&nbsp;"Z".."Z".succが空
-  * [Feature #2348]&nbsp;RBTree Should be Added to the Standard Library
-  * [Feature #2740]&nbsp;Extend const_missing to pass in the nesting
-  * [Feature #3072]&nbsp;Classes Inheriting from Data
-  * [Feature #11256]&nbsp;anonymous block forwarding
-  * [Feature #3447]&nbsp;argument delegation
-  * [Feature #3450]&nbsp;Format Strings with Named Arguments & Hash#default
-  * [Feature #3591]&nbsp;Adding Numeric#divisor? (Have working implementation)
-  * [Feature #3653]&nbsp;Diferential behaviour of positives and negatives ranges as subindex of string or arrays.
-  * [Feature #3916]&nbsp;Add flag to ruby to make warnings fatal.
-  * [Feature #4052]&nbsp;File.lutime Patch
-  * [Feature #4189]&nbsp;FileUtils#ln_r
+  * [Feature #1586] Including a module already present in ancestors should not be ignored
+  * [Feature #2080] Proc#to_source, Method#to_source
+  * [Feature #2323] "Z".."Z".succが空
+  * [Feature #2348] RBTree Should be Added to the Standard Library
+  * [Feature #2740] Extend const_missing to pass in the nesting
+  * [Feature #3072] Classes Inheriting from Data
+  * [Feature #11256] anonymous block forwarding
+  * [Feature #3447] argument delegation
+  * [Feature #3450] Format Strings with Named Arguments & Hash#default
+  * [Feature #3591] Adding Numeric#divisor? (Have working implementation)
+  * [Feature #3653] Diferential behaviour of positives and negatives ranges as subindex of string or arrays.
+  * [Feature #3916] Add flag to ruby to make warnings fatal.
+  * [Feature #4052] File.lutime Patch
+  * [Feature #4189] FileUtils#ln_r
 - nobu
-  * [Feature #836]&nbsp;Patches for StringScanner, adding #size, #captures and #values_at
-  * [Feature #2324]&nbsp;Dir instance methods for relative path
-  * [Bug #3618]&nbsp;inf-ruby prompt and tab completion
+  * [Feature #836] Patches for StringScanner, adding #size, #captures and #values_at
+  * [Feature #2324] Dir instance methods for relative path
+  * [Bug #3618] inf-ruby prompt and tab completion
 - ko1
-  * [Feature #2447]&nbsp;reduce GC pressure by symbol table without String instance
-  * [Feature #3187]&nbsp;Allow dynamic Fiber stack size
-  * [Feature #3731]&nbsp;Easier Embedding API for Ruby
-  * [Feature #3809]&nbsp;allow multiple set_trace_func() calls
-  * [Bug #4040]&nbsp;SystemStackError with Hash[*a] for Large _a_
+  * [Feature #2447] reduce GC pressure by symbol table without String instance
+  * [Feature #3187] Allow dynamic Fiber stack size
+  * [Feature #3731] Easier Embedding API for Ruby
+  * [Feature #3809] allow multiple set_trace_func() calls
+  * [Bug #4040] SystemStackError with Hash[*a] for Large _a_
 - naruse
-  * [Feature #2567]&nbsp;Net::HTTP does not handle encoding correctly
-  * [Feature #2631]&nbsp;Allow IO#reopen to take a block
-  * [Bug #4173]&nbsp;TestProcess#test_wait_and_sigchild が、たまに失敗する
+  * [Feature #2567] Net::HTTP does not handle encoding correctly
+  * [Feature #2631] Allow IO#reopen to take a block
+  * [Bug #4173] TestProcess#test_wait_and_sigchild が、たまに失敗する
 - mrkn
-  * [Feature #3269]&nbsp;BigMath.tan がない
-  * [Feature #3270]&nbsp;BigMath.exp が絶対値が大きな引数で遅い
+  * [Feature #3269] BigMath.tan がない
+  * [Feature #3270] BigMath.exp が絶対値が大きな引数で遅い
 - akr
-  * [Feature #3608]&nbsp;Enhancing Pathname#each_child to be lazy
-  * [Feature #3848]&nbsp;Using http basic authentication for FTP with Open URI
+  * [Feature #3608] Enhancing Pathname#each_child to be lazy
+  * [Feature #3848] Using http basic authentication for FTP with Open URI
 - knu
-  * [Feature #3953]&nbsp;TCPSocket / UDPSocket do not accept IPAddr objects.
+  * [Feature #3953] TCPSocket / UDPSocket do not accept IPAddr objects.
 - anyone
-  * [Bug #3594]&nbsp;URI class doesn't do file URL's properly.
-  * [Feature #4017]&nbsp;[PATCH] CSV parsing speedup
-  * [Bug #4157]&nbsp;test_pty で、たまに出る Failure
+  * [Bug #3594] URI class doesn't do file URL's properly.
+  * [Feature #4017] [PATCH] CSV parsing speedup
+  * [Bug #4157] test_pty で、たまに出る Failure
 
 ## From non-attendees
 

--- a/2017/DevMeeting-2017-12-12.md
+++ b/2017/DevMeeting-2017-12-12.md
@@ -39,34 +39,34 @@ Please add your favorite ticket numbers you want to ask to discuss.
 The tickets below are old tickets whose status is open or assigned (and mame can somewhat understand)
 
 - matz
-  * [Feature #11256]&nbsp;anonymous block forwarding
-  * [Feature #4288]&nbsp;Allow invoking arbitrary method names with foo."something" syntax
-  * [Bug #4352]&nbsp;[patch] Fix eval(s, b) backtrace; make eval(s, b) consistent with eval(s)
-  * [Bug #4443]&nbsp;odd evaluation order in a multiple assignment
-  * [Feature #4475]&nbsp;default variable name for parameter
-  * [Feature #4830]&nbsp;Provide Default Variables for Array#each and other iterators
-  * [Feature #4513]&nbsp;allow whitespace following EOL continuation backslash
-  * [Feature #4514]&nbsp;#deep_clone and #deep_dup for Objects
-  * [Feature #4521]&nbsp;NoMethodError#message may take very long to execute
-  * [Feature #4539]&nbsp;Array#zip_with
-  * [Feature #5044]&nbsp;#zip with block return mapped results
-  * [Feature #4541]&nbsp;Inconsistent Array.slice()
-  * [Feature #4592]&nbsp;Tempfileを直接保存したい
-  * [Feature #4780]&nbsp;String#split with a block
-  * [Feature #4818]&nbsp;Add method marshalable?
-  * [Feature #4824]&nbsp;Provide method Kernel#executed?
-  * [Feature #4907]&nbsp;enumerable#permutation and combination
-  * [Feature #4910]&nbsp;Classes as factories
-  * [Feature #4921]&nbsp;Remove intern.h
-  * [Feature #4938]&nbsp;Add Random.bytes [patch]
-  * [Feature #5007]&nbsp;Proc#call_under: Unifying instance_eval and instance_exec
-  * [Feature #5064]&nbsp;HTTP user-agent class
-  * [Feature #5120]&nbsp;String#split needs to be logical
-  * [Feature #5123]&nbsp;Alias Hash 1.9 as OrderedHash
-  * [Feature #5129]&nbsp;Create a core class "FileArray" and make "ARGF" its instance
-  * [Feature #5133]&nbsp;Array#unzip as an alias of Array#transpose
-  * [Bug #5179]&nbsp;Complex#rationalize and to_r with approximate zeros
-  * [Feature #5206]&nbsp;ruby -K should warn
+  * [Feature #11256] anonymous block forwarding
+  * [Feature #4288] Allow invoking arbitrary method names with foo."something" syntax
+  * [Bug #4352] [patch] Fix eval(s, b) backtrace; make eval(s, b) consistent with eval(s)
+  * [Bug #4443] odd evaluation order in a multiple assignment
+  * [Feature #4475] default variable name for parameter
+  * [Feature #4830] Provide Default Variables for Array#each and other iterators
+  * [Feature #4513] allow whitespace following EOL continuation backslash
+  * [Feature #4514] #deep_clone and #deep_dup for Objects
+  * [Feature #4521] NoMethodError#message may take very long to execute
+  * [Feature #4539] Array#zip_with
+  * [Feature #5044] #zip with block return mapped results
+  * [Feature #4541] Inconsistent Array.slice()
+  * [Feature #4592] Tempfileを直接保存したい
+  * [Feature #4780] String#split with a block
+  * [Feature #4818] Add method marshalable?
+  * [Feature #4824] Provide method Kernel#executed?
+  * [Feature #4907] enumerable#permutation and combination
+  * [Feature #4910] Classes as factories
+  * [Feature #4921] Remove intern.h
+  * [Feature #4938] Add Random.bytes [patch]
+  * [Feature #5007] Proc#call_under: Unifying instance_eval and instance_exec
+  * [Feature #5064] HTTP user-agent class
+  * [Feature #5120] String#split needs to be logical
+  * [Feature #5123] Alias Hash 1.9 as OrderedHash
+  * [Feature #5129] Create a core class "FileArray" and make "ARGF" its instance
+  * [Feature #5133] Array#unzip as an alias of Array#transpose
+  * [Bug #5179] Complex#rationalize and to_r with approximate zeros
+  * [Feature #5206] ruby -K should warn
   * Ruby3.0 depretation warnings
        - %<whatever>?
        - backtick (`)?
@@ -74,42 +74,42 @@ The tickets below are old tickets whose status is open or assigned (and mame can
        - etc.
   * Ruby3 Concurrent model (AutoFiber? Guild?)
 - nobu
-  * [Feature #2324]&nbsp;Dir instance methods for relative path
-  * [Bug #3618]&nbsp;inf-ruby prompt and tab completion
-  * [Feature #4924]&nbsp;mkmf have_header fails with C++ headers
+  * [Feature #2324] Dir instance methods for relative path
+  * [Bug #3618] inf-ruby prompt and tab completion
+  * [Feature #4924] mkmf have_header fails with C++ headers
 - ko1
-  * [Feature #2447]&nbsp;reduce GC pressure by symbol table without String instance
-  * [Feature #3187]&nbsp;Allow dynamic Fiber stack size
-  * [Feature #3731]&nbsp;Easier Embedding API for Ruby
-  * [Bug #4040]&nbsp;SystemStackError with Hash[*a] for Large _a_
+  * [Feature #2447] reduce GC pressure by symbol table without String instance
+  * [Feature #3187] Allow dynamic Fiber stack size
+  * [Feature #3731] Easier Embedding API for Ruby
+  * [Bug #4040] SystemStackError with Hash[*a] for Large _a_
 - naruse
-  * [Feature #2567]&nbsp;Net::HTTP does not handle encoding correctly
-  * [Feature #2631]&nbsp;Allow IO#reopen to take a block
-  * [Bug #4173]&nbsp;TestProcess#test_wait_and_sigchild が、たまに失敗する
+  * [Feature #2567] Net::HTTP does not handle encoding correctly
+  * [Feature #2631] Allow IO#reopen to take a block
+  * [Bug #4173] TestProcess#test_wait_and_sigchild が、たまに失敗する
 - akr
-  * [Feature #3608]&nbsp;Enhancing Pathname#each_child to be lazy
-  * [Feature #3848]&nbsp;Using http basic authentication for FTP with Open URI
-  * [Feature #4560]&nbsp;[PATCH] lib/net/protocol.rb: avoid exceptions in rbuf_fill
+  * [Feature #3608] Enhancing Pathname#each_child to be lazy
+  * [Feature #3848] Using http basic authentication for FTP with Open URI
+  * [Feature #4560] [PATCH] lib/net/protocol.rb: avoid exceptions in rbuf_fill
 - knu
-  * [Feature #3953]&nbsp;TCPSocket / UDPSocket do not accept IPAddr objects.
+  * [Feature #3953] TCPSocket / UDPSocket do not accept IPAddr objects.
 - mame
-  * [Feature #4247]&nbsp;New features for Array#sample, Array#choice
+  * [Feature #4247] New features for Array#sample, Array#choice
 - suke
-  * [Bug #4405]&nbsp;WIN32OLE & Threads incompatible
+  * [Bug #4405] WIN32OLE & Threads incompatible
 - kosaki
-  * [Feature #4464]&nbsp;[PATCH] add Fcntl::Flock object for easier use of POSIX file locks
+  * [Feature #4464] [PATCH] add Fcntl::Flock object for easier use of POSIX file locks
 - yugui
-  * [Feature #4831]&nbsp;Integer#prime_factors
+  * [Feature #4831] Integer#prime_factors
 - mrkn
-  * [Feature #4968]&nbsp;BigDecimal#sqrt は BigMath.sqrt へ移動すべき
+  * [Feature #4968] BigDecimal#sqrt は BigMath.sqrt へ移動すべき
 - hsbt
-  * [Bug #5060]&nbsp;Executables in bin folder conflict with their gem versions.
+  * [Bug #5060] Executables in bin folder conflict with their gem versions.
 - sorah
-  * [Feature #14141]&nbsp;Add a method to Exception for retrieving formatted exception for logging purpose (Exception#{formatted,display})
+  * [Feature #14141] Add a method to Exception for retrieving formatted exception for logging purpose (Exception#{formatted,display})
 - anyone
-  * [Feature #4017]&nbsp;[PATCH] CSV parsing speedup
-  * [Bug #4157]&nbsp;test_pty で、たまに出る Failure
-  * [Feature #4483]&nbsp;PStoreをデフォルトで複数のスレッドから扱えるようにしたい
+  * [Feature #4017] [PATCH] CSV parsing speedup
+  * [Bug #4157] test_pty で、たまに出る Failure
+  * [Feature #4483] PStoreをデフォルトで複数のスレッドから扱えるようにしたい
 
 ## From non-attendees
 

--- a/2017/DevMeeting-2017-12-26.md
+++ b/2017/DevMeeting-2017-12-26.md
@@ -46,73 +46,73 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 ## Open/assigned old issues
 
-  * [Bug #14229]&nbsp;An exception in eval has strange message
-  * [Bug #14230]&nbsp;Binding#source_location
-  * [Bug #4352]&nbsp;[patch] Fix eval(s, b) backtrace; make eval(s, b) consistent with eval(s)
+  * [Bug #14229] An exception in eval has strange message
+  * [Bug #14230] Binding#source_location
+  * [Bug #4352] [patch] Fix eval(s, b) backtrace; make eval(s, b) consistent with eval(s)
 
 The tickets below are old tickets whose status is open or assigned (and mame can somewhat understand)
 
 - matz
-  * [Bug #4443]&nbsp;odd evaluation order in a multiple assignment
-  * [Feature #4475]&nbsp;default variable name for parameter
-  * [Feature #4830]&nbsp;Provide Default Variables for Array#each and other iterators
-  * [Feature #4513]&nbsp;allow whitespace following EOL continuation backslash
-  * [Feature #4514]&nbsp;#deep_clone and #deep_dup for Objects
-  * [Feature #4521]&nbsp;NoMethodError#message may take very long to execute
-  * [Feature #4539]&nbsp;Array#zip_with
-  * [Feature #5044]&nbsp;#zip with block return mapped results
-  * [Feature #4541]&nbsp;Inconsistent Array.slice()
-  * [Feature #4592]&nbsp;Tempfileを直接保存したい
-  * [Feature #4780]&nbsp;String#split with a block
-  * [Feature #4818]&nbsp;Add method marshalable?
-  * [Feature #4824]&nbsp;Provide method Kernel#executed?
-  * [Feature #4907]&nbsp;enumerable#permutation and combination
-  * [Feature #4910]&nbsp;Classes as factories
-  * [Feature #4921]&nbsp;Remove intern.h
-  * [Feature #4938]&nbsp;Add Random.bytes [patch]
-  * [Feature #5007]&nbsp;Proc#call_under: Unifying instance_eval and instance_exec
-  * [Feature #5064]&nbsp;HTTP user-agent class
-  * [Feature #5120]&nbsp;String#split needs to be logical
-  * [Feature #5123]&nbsp;Alias Hash 1.9 as OrderedHash
-  * [Feature #5129]&nbsp;Create a core class "FileArray" and make "ARGF" its instance
-  * [Feature #5133]&nbsp;Array#unzip as an alias of Array#transpose
-  * [Bug #5179]&nbsp;Complex#rationalize and to_r with approximate zeros
-  * [Feature #5206]&nbsp;ruby -K should warn
+  * [Bug #4443] odd evaluation order in a multiple assignment
+  * [Feature #4475] default variable name for parameter
+  * [Feature #4830] Provide Default Variables for Array#each and other iterators
+  * [Feature #4513] allow whitespace following EOL continuation backslash
+  * [Feature #4514] #deep_clone and #deep_dup for Objects
+  * [Feature #4521] NoMethodError#message may take very long to execute
+  * [Feature #4539] Array#zip_with
+  * [Feature #5044] #zip with block return mapped results
+  * [Feature #4541] Inconsistent Array.slice()
+  * [Feature #4592] Tempfileを直接保存したい
+  * [Feature #4780] String#split with a block
+  * [Feature #4818] Add method marshalable?
+  * [Feature #4824] Provide method Kernel#executed?
+  * [Feature #4907] enumerable#permutation and combination
+  * [Feature #4910] Classes as factories
+  * [Feature #4921] Remove intern.h
+  * [Feature #4938] Add Random.bytes [patch]
+  * [Feature #5007] Proc#call_under: Unifying instance_eval and instance_exec
+  * [Feature #5064] HTTP user-agent class
+  * [Feature #5120] String#split needs to be logical
+  * [Feature #5123] Alias Hash 1.9 as OrderedHash
+  * [Feature #5129] Create a core class "FileArray" and make "ARGF" its instance
+  * [Feature #5133] Array#unzip as an alias of Array#transpose
+  * [Bug #5179] Complex#rationalize and to_r with approximate zeros
+  * [Feature #5206] ruby -K should warn
 - nobu
-  * [Feature #2324]&nbsp;Dir instance methods for relative path
-  * [Bug #3618]&nbsp;inf-ruby prompt and tab completion
-  * [Feature #4924]&nbsp;mkmf have_header fails with C++ headers
+  * [Feature #2324] Dir instance methods for relative path
+  * [Bug #3618] inf-ruby prompt and tab completion
+  * [Feature #4924] mkmf have_header fails with C++ headers
 - ko1
-  * [Feature #2447]&nbsp;reduce GC pressure by symbol table without String instance
-  * [Feature #3187]&nbsp;Allow dynamic Fiber stack size
-  * [Feature #3731]&nbsp;Easier Embedding API for Ruby
-  * [Bug #4040]&nbsp;SystemStackError with Hash[*a] for Large _a_
+  * [Feature #2447] reduce GC pressure by symbol table without String instance
+  * [Feature #3187] Allow dynamic Fiber stack size
+  * [Feature #3731] Easier Embedding API for Ruby
+  * [Bug #4040] SystemStackError with Hash[*a] for Large _a_
 - naruse
-  * [Feature #2567]&nbsp;Net::HTTP does not handle encoding correctly
-  * [Feature #2631]&nbsp;Allow IO#reopen to take a block
-  * [Bug #4173]&nbsp;TestProcess#test_wait_and_sigchild が、たまに失敗する
+  * [Feature #2567] Net::HTTP does not handle encoding correctly
+  * [Feature #2631] Allow IO#reopen to take a block
+  * [Bug #4173] TestProcess#test_wait_and_sigchild が、たまに失敗する
 - akr
-  * [Feature #3608]&nbsp;Enhancing Pathname#each_child to be lazy
-  * [Feature #3848]&nbsp;Using http basic authentication for FTP with Open URI
-  * [Feature #4560]&nbsp;[PATCH] lib/net/protocol.rb: avoid exceptions in rbuf_fill
+  * [Feature #3608] Enhancing Pathname#each_child to be lazy
+  * [Feature #3848] Using http basic authentication for FTP with Open URI
+  * [Feature #4560] [PATCH] lib/net/protocol.rb: avoid exceptions in rbuf_fill
 - knu
-  * [Feature #3953]&nbsp;TCPSocket / UDPSocket do not accept IPAddr objects.
+  * [Feature #3953] TCPSocket / UDPSocket do not accept IPAddr objects.
 - mame
-  * [Feature #4247]&nbsp;New features for Array#sample, Array#choice
+  * [Feature #4247] New features for Array#sample, Array#choice
 - suke
-  * [Bug #4405]&nbsp;WIN32OLE & Threads incompatible
+  * [Bug #4405] WIN32OLE & Threads incompatible
 - kosaki
-  * [Feature #4464]&nbsp;[PATCH] add Fcntl::Flock object for easier use of POSIX file locks
+  * [Feature #4464] [PATCH] add Fcntl::Flock object for easier use of POSIX file locks
 - yugui
-  * [Feature #4831]&nbsp;Integer#prime_factors
+  * [Feature #4831] Integer#prime_factors
 - mrkn
-  * [Feature #4968]&nbsp;BigDecimal#sqrt は BigMath.sqrt へ移動すべき
+  * [Feature #4968] BigDecimal#sqrt は BigMath.sqrt へ移動すべき
 - hsbt
-  * [Bug #5060]&nbsp;Executables in bin folder conflict with their gem versions.
+  * [Bug #5060] Executables in bin folder conflict with their gem versions.
 - anyone
-  * [Feature #4017]&nbsp;[PATCH] CSV parsing speedup
-  * [Bug #4157]&nbsp;test_pty で、たまに出る Failure
-  * [Feature #4483]&nbsp;PStoreをデフォルトで複数のスレッドから扱えるようにしたい
+  * [Feature #4017] [PATCH] CSV parsing speedup
+  * [Bug #4157] test_pty で、たまに出る Failure
+  * [Feature #4483] PStoreをデフォルトで複数のスレッドから扱えるようにしたい
 
 # Log
 

--- a/2018/DevMeeting-2018-01-24.md
+++ b/2018/DevMeeting-2018-01-24.md
@@ -56,66 +56,66 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 ## Carry-over from previous meeting(s)
 
 - matz
-  * [Bug #4443]&nbsp;odd evaluation order in a multiple assignment
-  * [Feature #4475]&nbsp;default variable name for parameter
-  * [Feature #4830]&nbsp;Provide Default Variables for Array#each and other iterators
-  * [Feature #4513]&nbsp;allow whitespace following EOL continuation backslash
-  * [Feature #4514]&nbsp;#deep_clone and #deep_dup for Objects
-  * [Feature #4521]&nbsp;NoMethodError#message may take very long to execute
-  * [Feature #4539]&nbsp;Array#zip_with
-  * [Feature #5044]&nbsp;#zip with block return mapped results
-  * [Feature #4541]&nbsp;Inconsistent Array.slice()
-  * [Feature #4592]&nbsp;Tempfileを直接保存したい
-  * [Feature #4780]&nbsp;String#split with a block
-  * [Feature #4818]&nbsp;Add method marshalable?
-  * [Feature #4824]&nbsp;Provide method Kernel#executed?
-  * [Feature #4907]&nbsp;enumerable#permutation and combination
-  * [Feature #4910]&nbsp;Classes as factories
-  * [Feature #4921]&nbsp;Remove intern.h
-  * [Feature #4938]&nbsp;Add Random.bytes [patch]
-  * [Feature #5007]&nbsp;Proc#call_under: Unifying instance_eval and instance_exec
-  * [Feature #5064]&nbsp;HTTP user-agent class
-  * [Feature #5120]&nbsp;String#split needs to be logical
-  * [Feature #5123]&nbsp;Alias Hash 1.9 as OrderedHash
-  * [Feature #5129]&nbsp;Create a core class "FileArray" and make "ARGF" its instance
-  * [Feature #5133]&nbsp;Array#unzip as an alias of Array#transpose
-  * [Bug #5179]&nbsp;Complex#rationalize and to_r with approximate zeros
-  * [Feature #5206]&nbsp;ruby -K should warn
+  * [Bug #4443] odd evaluation order in a multiple assignment
+  * [Feature #4475] default variable name for parameter
+  * [Feature #4830] Provide Default Variables for Array#each and other iterators
+  * [Feature #4513] allow whitespace following EOL continuation backslash
+  * [Feature #4514] #deep_clone and #deep_dup for Objects
+  * [Feature #4521] NoMethodError#message may take very long to execute
+  * [Feature #4539] Array#zip_with
+  * [Feature #5044] #zip with block return mapped results
+  * [Feature #4541] Inconsistent Array.slice()
+  * [Feature #4592] Tempfileを直接保存したい
+  * [Feature #4780] String#split with a block
+  * [Feature #4818] Add method marshalable?
+  * [Feature #4824] Provide method Kernel#executed?
+  * [Feature #4907] enumerable#permutation and combination
+  * [Feature #4910] Classes as factories
+  * [Feature #4921] Remove intern.h
+  * [Feature #4938] Add Random.bytes [patch]
+  * [Feature #5007] Proc#call_under: Unifying instance_eval and instance_exec
+  * [Feature #5064] HTTP user-agent class
+  * [Feature #5120] String#split needs to be logical
+  * [Feature #5123] Alias Hash 1.9 as OrderedHash
+  * [Feature #5129] Create a core class "FileArray" and make "ARGF" its instance
+  * [Feature #5133] Array#unzip as an alias of Array#transpose
+  * [Bug #5179] Complex#rationalize and to_r with approximate zeros
+  * [Feature #5206] ruby -K should warn
 - nobu
-  * [Feature #2324]&nbsp;Dir instance methods for relative path
-  * [Bug #3618]&nbsp;inf-ruby prompt and tab completion
-  * [Feature #4924]&nbsp;mkmf have_header fails with C++ headers
+  * [Feature #2324] Dir instance methods for relative path
+  * [Bug #3618] inf-ruby prompt and tab completion
+  * [Feature #4924] mkmf have_header fails with C++ headers
 - ko1
-  * [Feature #2447]&nbsp;reduce GC pressure by symbol table without String instance
-  * [Feature #3187]&nbsp;Allow dynamic Fiber stack size
-  * [Feature #3731]&nbsp;Easier Embedding API for Ruby
-  * [Bug #4040]&nbsp;SystemStackError with Hash[*a] for Large _a_
+  * [Feature #2447] reduce GC pressure by symbol table without String instance
+  * [Feature #3187] Allow dynamic Fiber stack size
+  * [Feature #3731] Easier Embedding API for Ruby
+  * [Bug #4040] SystemStackError with Hash[*a] for Large _a_
 - naruse
-  * [Feature #2567]&nbsp;Net::HTTP does not handle encoding correctly
-  * [Feature #2631]&nbsp;Allow IO#reopen to take a block
-  * [Bug #4173]&nbsp;TestProcess#test_wait_and_sigchild が、たまに失敗する
+  * [Feature #2567] Net::HTTP does not handle encoding correctly
+  * [Feature #2631] Allow IO#reopen to take a block
+  * [Bug #4173] TestProcess#test_wait_and_sigchild が、たまに失敗する
 - akr
-  * [Feature #3608]&nbsp;Enhancing Pathname#each_child to be lazy
-  * [Feature #3848]&nbsp;Using http basic authentication for FTP with Open URI
-  * [Feature #4560]&nbsp;[PATCH] lib/net/protocol.rb: avoid exceptions in rbuf_fill
+  * [Feature #3608] Enhancing Pathname#each_child to be lazy
+  * [Feature #3848] Using http basic authentication for FTP with Open URI
+  * [Feature #4560] [PATCH] lib/net/protocol.rb: avoid exceptions in rbuf_fill
 - knu
-  * [Feature #3953]&nbsp;TCPSocket / UDPSocket do not accept IPAddr objects.
+  * [Feature #3953] TCPSocket / UDPSocket do not accept IPAddr objects.
 - mame
-  * [Feature #4247]&nbsp;New features for Array#sample, Array#choice
+  * [Feature #4247] New features for Array#sample, Array#choice
 - suke
-  * [Bug #4405]&nbsp;WIN32OLE & Threads incompatible
+  * [Bug #4405] WIN32OLE & Threads incompatible
 - kosaki
-  * [Feature #4464]&nbsp;[PATCH] add Fcntl::Flock object for easier use of POSIX file locks
+  * [Feature #4464] [PATCH] add Fcntl::Flock object for easier use of POSIX file locks
 - yugui
-  * [Feature #4831]&nbsp;Integer#prime_factors
+  * [Feature #4831] Integer#prime_factors
 - mrkn
-  * [Feature #4968]&nbsp;BigDecimal#sqrt は BigMath.sqrt へ移動すべき
+  * [Feature #4968] BigDecimal#sqrt は BigMath.sqrt へ移動すべき
 - hsbt
-  * [Bug #5060]&nbsp;Executables in bin folder conflict with their gem versions.
+  * [Bug #5060] Executables in bin folder conflict with their gem versions.
 - anyone
-  * [Feature #4017]&nbsp;[PATCH] CSV parsing speedup
-  * [Bug #4157]&nbsp;test_pty で、たまに出る Failure
-  * [Feature #4483]&nbsp;PStoreをデフォルトで複数のスレッドから扱えるようにしたい
+  * [Feature #4017] [PATCH] CSV parsing speedup
+  * [Bug #4157] test_pty で、たまに出る Failure
+  * [Feature #4483] PStoreをデフォルトで複数のスレッドから扱えるようにしたい
 
 # Log
 

--- a/2018/DevMeeting-2018-02-20.md
+++ b/2018/DevMeeting-2018-02-20.md
@@ -56,63 +56,63 @@ Please add your favorite ticket numbers you want to ask to discuss.
 ## Carry-over from previous meeting(s)
 
 - matz
-  * [Feature #4513]&nbsp;allow whitespace following EOL continuation backslash
-  * [Feature #4514]&nbsp;#deep_clone and #deep_dup for Objects
-  * [Feature #4521]&nbsp;NoMethodError#message may take very long to execute
-  * [Feature #4539]&nbsp;Array#zip_with
-  * [Feature #5044]&nbsp;#zip with block return mapped results
-  * [Feature #4541]&nbsp;Inconsistent Array.slice()
-  * [Feature #4592]&nbsp;Tempfileを直接保存したい
-  * [Feature #4780]&nbsp;String#split with a block
-  * [Feature #4818]&nbsp;Add method marshalable?
-  * [Feature #4824]&nbsp;Provide method Kernel#executed?
-  * [Feature #4907]&nbsp;enumerable#permutation and combination
-  * [Feature #4910]&nbsp;Classes as factories
-  * [Feature #4921]&nbsp;Remove intern.h
-  * [Feature #4938]&nbsp;Add Random.bytes [patch]
-  * [Feature #5007]&nbsp;Proc#call_under: Unifying instance_eval and instance_exec
-  * [Feature #5064]&nbsp;HTTP user-agent class
-  * [Feature #5120]&nbsp;String#split needs to be logical
-  * [Feature #5123]&nbsp;Alias Hash 1.9 as OrderedHash
-  * [Feature #5129]&nbsp;Create a core class "FileArray" and make "ARGF" its instance
-  * [Feature #5133]&nbsp;Array#unzip as an alias of Array#transpose
-  * [Bug #5179]&nbsp;Complex#rationalize and to_r with approximate zeros
-  * [Feature #5206]&nbsp;ruby -K should warn
+  * [Feature #4513] allow whitespace following EOL continuation backslash
+  * [Feature #4514] #deep_clone and #deep_dup for Objects
+  * [Feature #4521] NoMethodError#message may take very long to execute
+  * [Feature #4539] Array#zip_with
+  * [Feature #5044] #zip with block return mapped results
+  * [Feature #4541] Inconsistent Array.slice()
+  * [Feature #4592] Tempfileを直接保存したい
+  * [Feature #4780] String#split with a block
+  * [Feature #4818] Add method marshalable?
+  * [Feature #4824] Provide method Kernel#executed?
+  * [Feature #4907] enumerable#permutation and combination
+  * [Feature #4910] Classes as factories
+  * [Feature #4921] Remove intern.h
+  * [Feature #4938] Add Random.bytes [patch]
+  * [Feature #5007] Proc#call_under: Unifying instance_eval and instance_exec
+  * [Feature #5064] HTTP user-agent class
+  * [Feature #5120] String#split needs to be logical
+  * [Feature #5123] Alias Hash 1.9 as OrderedHash
+  * [Feature #5129] Create a core class "FileArray" and make "ARGF" its instance
+  * [Feature #5133] Array#unzip as an alias of Array#transpose
+  * [Bug #5179] Complex#rationalize and to_r with approximate zeros
+  * [Feature #5206] ruby -K should warn
 - nobu
-  * [Feature #2324]&nbsp;Dir instance methods for relative path
-  * [Bug #3618]&nbsp;inf-ruby prompt and tab completion
-  * [Feature #4924]&nbsp;mkmf have_header fails with C++ headers
+  * [Feature #2324] Dir instance methods for relative path
+  * [Bug #3618] inf-ruby prompt and tab completion
+  * [Feature #4924] mkmf have_header fails with C++ headers
 - ko1
-  * [Feature #2447]&nbsp;reduce GC pressure by symbol table without String instance
-  * [Feature #3187]&nbsp;Allow dynamic Fiber stack size
-  * [Feature #3731]&nbsp;Easier Embedding API for Ruby
-  * [Bug #4040]&nbsp;SystemStackError with Hash[*a] for Large _a_
+  * [Feature #2447] reduce GC pressure by symbol table without String instance
+  * [Feature #3187] Allow dynamic Fiber stack size
+  * [Feature #3731] Easier Embedding API for Ruby
+  * [Bug #4040] SystemStackError with Hash[*a] for Large _a_
 - naruse
-  * [Feature #2567]&nbsp;Net::HTTP does not handle encoding correctly
-  * [Feature #2631]&nbsp;Allow IO#reopen to take a block
-  * [Bug #4173]&nbsp;TestProcess#test_wait_and_sigchild が、たまに失敗する
+  * [Feature #2567] Net::HTTP does not handle encoding correctly
+  * [Feature #2631] Allow IO#reopen to take a block
+  * [Bug #4173] TestProcess#test_wait_and_sigchild が、たまに失敗する
 - akr
-  * [Feature #3608]&nbsp;Enhancing Pathname#each_child to be lazy
-  * [Feature #3848]&nbsp;Using http basic authentication for FTP with Open URI
-  * [Feature #4560]&nbsp;[PATCH] lib/net/protocol.rb: avoid exceptions in rbuf_fill
+  * [Feature #3608] Enhancing Pathname#each_child to be lazy
+  * [Feature #3848] Using http basic authentication for FTP with Open URI
+  * [Feature #4560] [PATCH] lib/net/protocol.rb: avoid exceptions in rbuf_fill
 - knu
-  * [Feature #3953]&nbsp;TCPSocket / UDPSocket do not accept IPAddr objects.
+  * [Feature #3953] TCPSocket / UDPSocket do not accept IPAddr objects.
 - mame
-  * [Feature #4247]&nbsp;New features for Array#sample, Array#choice
+  * [Feature #4247] New features for Array#sample, Array#choice
 - suke
-  * [Bug #4405]&nbsp;WIN32OLE & Threads incompatible
+  * [Bug #4405] WIN32OLE & Threads incompatible
 - kosaki
-  * [Feature #4464]&nbsp;[PATCH] add Fcntl::Flock object for easier use of POSIX file locks
+  * [Feature #4464] [PATCH] add Fcntl::Flock object for easier use of POSIX file locks
 - yugui
-  * [Feature #4831]&nbsp;Integer#prime_factors
+  * [Feature #4831] Integer#prime_factors
 - mrkn
-  * [Feature #4968]&nbsp;BigDecimal#sqrt は BigMath.sqrt へ移動すべき
+  * [Feature #4968] BigDecimal#sqrt は BigMath.sqrt へ移動すべき
 - hsbt
-  * [Bug #5060]&nbsp;Executables in bin folder conflict with their gem versions.
+  * [Bug #5060] Executables in bin folder conflict with their gem versions.
 - anyone
-  * [Feature #4017]&nbsp;[PATCH] CSV parsing speedup
-  * [Bug #4157]&nbsp;test_pty で、たまに出る Failure
-  * [Feature #4483]&nbsp;PStoreをデフォルトで複数のスレッドから扱えるようにしたい
+  * [Feature #4017] [PATCH] CSV parsing speedup
+  * [Bug #4157] test_pty で、たまに出る Failure
+  * [Feature #4483] PStoreをデフォルトで複数のスレッドから扱えるようにしたい
 
 # Log
 

--- a/2018/DevMeeting-2018-03-15.md
+++ b/2018/DevMeeting-2018-03-15.md
@@ -48,53 +48,53 @@ Please add your favorite ticket numbers you want to ask to discuss.
 ## Carry-over from previous meeting(s)
 
 - matz
-  * [Feature #4514]&nbsp;#deep_clone and #deep_dup for Objects
-  * [Feature #4521]&nbsp;NoMethodError#message may take very long to execute
-  * [Feature #4539]&nbsp;Array#zip_with
-  * [Feature #4592]&nbsp;Tempfileを直接保存したい
-  * [Feature #4780]&nbsp;String#split with a block
-  * [Feature #4818]&nbsp;Add method marshalable?
-  * [Feature #4824]&nbsp;Provide method Kernel#executed?
-  * [Feature #4907]&nbsp;enumerable#permutation and combination
-  * [Feature #4910]&nbsp;Classes as factories
-  * [Feature #5007]&nbsp;Proc#call_under: Unifying instance_eval and instance_exec
-  * [Feature #5064]&nbsp;HTTP user-agent class
-  * [Feature #5129]&nbsp;Create a core class "FileArray" and make "ARGF" its instance
-  * [Feature #5133]&nbsp;Array#unzip as an alias of Array#transpose
-  * [Bug #5179]&nbsp;Complex#rationalize and to_r with approximate zeros
+  * [Feature #4514] #deep_clone and #deep_dup for Objects
+  * [Feature #4521] NoMethodError#message may take very long to execute
+  * [Feature #4539] Array#zip_with
+  * [Feature #4592] Tempfileを直接保存したい
+  * [Feature #4780] String#split with a block
+  * [Feature #4818] Add method marshalable?
+  * [Feature #4824] Provide method Kernel#executed?
+  * [Feature #4907] enumerable#permutation and combination
+  * [Feature #4910] Classes as factories
+  * [Feature #5007] Proc#call_under: Unifying instance_eval and instance_exec
+  * [Feature #5064] HTTP user-agent class
+  * [Feature #5129] Create a core class "FileArray" and make "ARGF" its instance
+  * [Feature #5133] Array#unzip as an alias of Array#transpose
+  * [Bug #5179] Complex#rationalize and to_r with approximate zeros
 - nobu
-  * [Feature #2324]&nbsp;Dir instance methods for relative path
-  * [Bug #3618]&nbsp;inf-ruby prompt and tab completion
-  * [Feature #4924]&nbsp;mkmf have_header fails with C++ headers
+  * [Feature #2324] Dir instance methods for relative path
+  * [Bug #3618] inf-ruby prompt and tab completion
+  * [Feature #4924] mkmf have_header fails with C++ headers
 - ko1
-  * [Feature #2447]&nbsp;reduce GC pressure by symbol table without String instance
-  * [Feature #3187]&nbsp;Allow dynamic Fiber stack size
-  * [Feature #3731]&nbsp;Easier Embedding API for Ruby
-  * [Bug #4040]&nbsp;SystemStackError with Hash[*a] for Large _a_
+  * [Feature #2447] reduce GC pressure by symbol table without String instance
+  * [Feature #3187] Allow dynamic Fiber stack size
+  * [Feature #3731] Easier Embedding API for Ruby
+  * [Bug #4040] SystemStackError with Hash[*a] for Large _a_
 - naruse
-  * [Feature #2567]&nbsp;Net::HTTP does not handle encoding correctly
-  * [Feature #2631]&nbsp;Allow IO#reopen to take a block
-  * [Bug #4173]&nbsp;TestProcess#test_wait_and_sigchild が、たまに失敗する
+  * [Feature #2567] Net::HTTP does not handle encoding correctly
+  * [Feature #2631] Allow IO#reopen to take a block
+  * [Bug #4173] TestProcess#test_wait_and_sigchild が、たまに失敗する
 - akr
-  * [Feature #3608]&nbsp;Enhancing Pathname#each_child to be lazy
-  * [Feature #3848]&nbsp;Using http basic authentication for FTP with Open URI
-  * [Feature #4560]&nbsp;[PATCH] lib/net/protocol.rb: avoid exceptions in rbuf_fill
+  * [Feature #3608] Enhancing Pathname#each_child to be lazy
+  * [Feature #3848] Using http basic authentication for FTP with Open URI
+  * [Feature #4560] [PATCH] lib/net/protocol.rb: avoid exceptions in rbuf_fill
 - knu
-  * [Feature #3953]&nbsp;TCPSocket / UDPSocket do not accept IPAddr objects.
+  * [Feature #3953] TCPSocket / UDPSocket do not accept IPAddr objects.
 - mame
-  * [Feature #4247]&nbsp;New features for Array#sample, Array#choice
+  * [Feature #4247] New features for Array#sample, Array#choice
 - suke
-  * [Bug #4405]&nbsp;WIN32OLE & Threads incompatible
+  * [Bug #4405] WIN32OLE & Threads incompatible
 - kosaki
-  * [Feature #4464]&nbsp;[PATCH] add Fcntl::Flock object for easier use of POSIX file locks
+  * [Feature #4464] [PATCH] add Fcntl::Flock object for easier use of POSIX file locks
 - yugui
-  * [Feature #4831]&nbsp;Integer#prime_factors
+  * [Feature #4831] Integer#prime_factors
 - hsbt
-  * [Bug #5060]&nbsp;Executables in bin folder conflict with their gem versions.
+  * [Bug #5060] Executables in bin folder conflict with their gem versions.
 - anyone
-  * [Feature #4017]&nbsp;[PATCH] CSV parsing speedup
-  * [Bug #4157]&nbsp;test_pty で、たまに出る Failure
-  * [Feature #4483]&nbsp;PStoreをデフォルトで複数のスレッドから扱えるようにしたい
+  * [Feature #4017] [PATCH] CSV parsing speedup
+  * [Bug #4157] test_pty で、たまに出る Failure
+  * [Feature #4483] PStoreをデフォルトで複数のスレッドから扱えるようにしたい
 
 # Log
 


### PR DESCRIPTION
## Summary

Meeting logs from late 2016 through early 2018 contain `&nbsp;` HTML entities where regular spaces should be, due to Google Docs export artifacts. These appear most commonly between ticket references and their titles:

```markdown
- [Feature #13608]&nbsp;Add TracePoint#thread (shyouhei)
```

This renders correctly in browsers but is noisy in raw markdown and can cause issues with some parsers.

## Changes

Replace all `&nbsp;` entities with regular spaces:

```diff
-- [Feature #13608]&nbsp;Add TracePoint#thread (shyouhei)
+- [Feature #13608] Add TracePoint#thread (shyouhei)
```

675 replacements across 11 files.

## Affected files

- `2016/DevMeeting-2016-11-25.md` (1)
- `2017/DevMeeting-2017-07-14.md` (68)
- `2017/DevMeeting-2017-08-31.md` (89)
- `2017/DevMeeting-2017-09-25.md` (106)
- `2017/DevMeeting-2017-10-19.md` (80)
- `2017/DevMeeting-2017-11-29.md` (99)
- `2017/DevMeeting-2017-12-12.md` (52)
- `2017/DevMeeting-2017-12-26.md` (51)
- `2018/DevMeeting-2018-01-24.md` (48)
- `2018/DevMeeting-2018-02-20.md` (45)
- `2018/DevMeeting-2018-03-15.md` (36)

---

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.