### PR TITLE
Fix escaped horizontal rules in 2017 meeting logs

### DIFF
--- a/2017/DevMeeting-2017-07-14.md
+++ b/2017/DevMeeting-2017-07-14.md
@@ -241,7 +241,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## \[Bug [#13569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13569&sa=D&source=editors&ust=1686087205340978&usg=AOvVaw1ePy4_g8xpOQ77PtddT4ht)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
 
-- \-----
+---
 - nobu: I cannot reproduce these problems.
 - shyouhei: It seems the reporter is not eligible to fix them.
 - hsbt: I made an environment so I’ll see if they reproduce.

--- a/2017/DevMeeting-2017-08-31.md
+++ b/2017/DevMeeting-2017-08-31.md
@@ -229,7 +229,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## \[Feature [#13604](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13604&sa=D&source=editors&ust=1686087248446747&usg=AOvVaw0orG4YS8WpJkN7Q0SL2gXJ)\] Exposing alternative interface of readline (shyouhei)
 
-- \-----
+---
 ## \[Feature [#13608](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13608&sa=D&source=editors&ust=1686087248447468&usg=AOvVaw2jNbM2WcIRAe9NpU71Fryy)\] Add TracePoint#thread (shyouhei)
 
 ## \[Feature [#13602](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13602&sa=D&source=editors&ust=1686087248448071&usg=AOvVaw1ZOTzKNoPx16A5oh3aefn-)\] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)


### PR DESCRIPTION
## Summary

Two meeting logs from 2017 contain escaped horizontal rules from Google Docs export:

```markdown
- \-----
```

This renders as a list item containing a literal backslash and dashes, instead of a horizontal rule separator.

## Changes

Replace with standard markdown horizontal rules:

```diff
-- \-----
+---
```

## Affected files

- `2017/DevMeeting-2017-07-14.md`
- `2017/DevMeeting-2017-08-31.md`

---

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.