### PR TITLE
Unwrap Google redirect URLs to direct URLs (2014-2019)

### DIFF
--- a/2014/DevMeeting-2014-05-17.md
+++ b/2014/DevMeeting-2014-05-17.md
@@ -35,9 +35,9 @@ attendee: sora\_h, shyouhei, akr, naruse, ko1, hsbt, tarui
 
 online: matz, n0kada,
 
-[https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20140517Japan](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20140517Japan&sa=D&source=editors&ust=1686085986168495&usg=AOvVaw2qDkI2UNy2tY6i-O7OLDb6)
+[https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20140517Japan](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20140517Japan)
 
-## \[Feature [#9772](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9772&sa=D&source=editors&ust=1686085986169195&usg=AOvVaw13Hj1GUd9iGfhEfgliMhXZ)\] IO#statfs and File::Statfs
+## \[Feature [#9772](https://bugs.ruby-lang.org/issues/9772)\] IO#statfs and File::Statfs
 
 本当に必要なのか？(rubygem でいいんでないのという議論)
 
@@ -49,7 +49,7 @@ statvfsという名前で入れる
 
 Matz: 色々込み入ってるので core には入れないで test 配下へ. 欲しいということがあったら gem にしてください.
 
-## \[Feature [#9647](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9647&sa=D&source=editors&ust=1686085986170190&usg=AOvVaw1uMUNpiJsnYr0ei-4AgcI5)\] File::Stat#birthtime
+## \[Feature [#9647](https://bugs.ruby-lang.org/issues/9647)\] File::Stat#birthtime
 
 何に使うのこれ
 
@@ -75,7 +75,7 @@ python にもあるが、stat() を直接返すらしく、対応していない
 
 ないときはNotImplementedError
 
-## \[Feature [#9816](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9816&sa=D&source=editors&ust=1686085986171784&usg=AOvVaw3rriSvuhjT_D89hYSuKihX)\] 文字列内の数字を数値として比較するメソッド
+## \[Feature [#9816](https://bugs.ruby-lang.org/issues/9816)\] 文字列内の数字を数値として比較するメソッド
 
 numericcmpという名前はない
 
@@ -103,13 +103,13 @@ numericcmpとかではなくバージョンを比較するものであるとわ�
 
 bundle gem にして、time が依存する箇所だけ ext に持っていく. 切り離す準備だけしておくのはどうか. いつやるかは未定.
 
-## \[Feature [#9513](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9513&sa=D&source=editors&ust=1686085986173458&usg=AOvVaw0ZmXbEcNB1OYWMFGCE1pNF)\] Hide Rational internal (akr)
+## \[Feature [#9513](https://bugs.ruby-lang.org/issues/9513)\] Hide Rational internal (akr)
 
 これはOKなのでは
 
 →matzがOKと返信する
 
-## \[Feature [#9826](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9826&sa=D&source=editors&ust=1686085986173998&usg=AOvVaw33hoVQXRsVzQAftVPpVSkJ)\] Enumerable#slice\_between (akr)
+## \[Feature [#9826](https://bugs.ruby-lang.org/issues/9826)\] Enumerable#slice\_between (akr)
 
 ニーズはある
 
@@ -117,7 +117,7 @@ matz: 機能としては採用してあげたいけど、この名前では採�
 
 #slice? → Array#slice があるのでNG
 
-## \[Feature [#9071](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9071&sa=D&source=editors&ust=1686085986174515&usg=AOvVaw3nVRXqbXwLO1nLipZbSrkc)\] Enumerable#slice\_after (akr)
+## \[Feature [#9071](https://bugs.ruby-lang.org/issues/9071)\] Enumerable#slice\_after (akr)
 
 対称性
 
@@ -125,7 +125,7 @@ matz: 機能としては採用してあげたいけど、この名前では採�
 
 →accept
 
-## \[Feature [#9770](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9770&sa=D&source=editors&ust=1686085986175065&usg=AOvVaw3IgJmRb3akBji09eU6djwO)\] Etc.uname (akr)
+## \[Feature [#9770](https://bugs.ruby-lang.org/issues/9770)\] Etc.uname (akr)
 
 test の中で uname -r を叩いているのを見かけるので組み込みで用意してもよさそう.
 
@@ -139,17 +139,17 @@ test の中で uname -r を叩いているのを見かけるので組み込み�
 
 →accept
 
-## \[Feature [#9842](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9842&sa=D&source=editors&ust=1686085986175988&usg=AOvVaw1mbfBCvzve8sL4D62Gpxgb)\] system configuration variables (sysconf(), confstr(), pathconf() and fpathconf()) (akr)
+## \[Feature [#9842](https://bugs.ruby-lang.org/issues/9842)\] system configuration variables (sysconf(), confstr(), pathconf() and fpathconf()) (akr)
 
 Matz: sysconf と confstr で同じ機能だけど、数値と文字列を返すかで違う、何とかマージできないかなあ
 
 Windows でどうしよう →NotImplementedError
 
-## \[Feature [#9834](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9834&sa=D&source=editors&ust=1686085986176646&usg=AOvVaw2RGMKtgOhK2Pd_J9cBCFIw)\] Float#{next\_float,prev\_float} (akr)
+## \[Feature [#9834](https://bugs.ruby-lang.org/issues/9834)\] Float#{next\_float,prev\_float} (akr)
 
 これは用途があまり明らかでない→テストで便利(printfのテストとか)。
 
-## \[Feature [#9632](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9632&sa=D&source=editors&ust=1686085986177097&usg=AOvVaw0RqqIKmuDCSCfmkM55hQjr)\] \[offtopic\] remove doxygen?
+## \[Feature [#9632](https://bugs.ruby-lang.org/issues/9632)\] \[offtopic\] remove doxygen?
 
 ccan フォルダの追加に伴って doxygen の警告が凄いでてきた、そもそも使ってないなら消したい
 
@@ -157,7 +157,7 @@ ko1: 消すのではなくて、デフォルトで動くのはやめて make dox
 
 Matz: デフォルトでは動かさないようにして、何かレポートきたら誰か頑張る.
 
-## \[Feature [#9711](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9711&sa=D&source=editors&ust=1686085986177849&usg=AOvVaw2h6eZ1gI8yNCjUviV-Ry-L)\] Remove test-unit and minitest from stdlib. Can I remove test-unit? /cc sora\_h (hsbt)
+## \[Feature [#9711](https://bugs.ruby-lang.org/issues/9711)\] Remove test-unit and minitest from stdlib. Can I remove test-unit? /cc sora\_h (hsbt)
 
 lib/test, lib/minitest を使うのはもうやめている.
 
@@ -189,7 +189,7 @@ ko1: gem にしてメンテナンスサイクルを分けよう
 
 方針としては無くしていく。
 
-## [Hash#comprized?](https://www.google.com/url?q=https://gist.github.com/nobu/dfe8ba14a48fc949f2ed&sa=D&source=editors&ust=1686085986179542&usg=AOvVaw3LtlZvSHuKQ-QIeFwdpEjt) , [http://olivierlacan.com/posts/proposal-for-a-better-ruby-hash-include/](https://www.google.com/url?q=http://olivierlacan.com/posts/proposal-for-a-better-ruby-hash-include/&sa=D&source=editors&ust=1686085986179840&usg=AOvVaw2tVAvxpT174KiO6i4U6qfO) (hone02)
+## [Hash#comprized?](https://gist.github.com/nobu/dfe8ba14a48fc949f2ed) , [http://olivierlacan.com/posts/proposal-for-a-better-ruby-hash-include/](http://olivierlacan.com/posts/proposal-for-a-better-ruby-hash-include/) (hone02)
 
 これは何か: あるハッシュがハッシュの一部にあるかを調べる
 

--- a/2014/DevMeeting-2014-07-26.md
+++ b/2014/DevMeeting-2014-07-26.md
@@ -33,13 +33,13 @@ log: https://docs.google.com/document/d/1g2mu2qngyxw3ge-EbDGLsDDZR-Uj_6fWaVb0YPw
 - attendee: ko1, sora\_h, akr, naruse, knu, duerst
 - on-line: matz, zzak, nobu, kosaki
 
-# \[Feature [#7797](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7797&sa=D&source=editors&ust=1686086131112226&usg=AOvVaw3gihUSX1OdVrT5B-OVwRa5)\] Hash should be renamed to StrictHash and a new Hash should be created to behave like AS HashWithIndifferentAccess
+# \[Feature [#7797](https://bugs.ruby-lang.org/issues/7797)\] Hash should be renamed to StrictHash and a new Hash should be created to behave like AS HashWithIndifferentAccess
 
 matz: I have to reject, since it breaks compatibility
 
 → reject
 
-# \[Feature [#9980](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9980&sa=D&source=editors&ust=1686086131112605&usg=AOvVaw3xNgkwD5Y-YVF7_-RZFtcK)\] Create HashWithIndiferentAccess using new syntax {a: 1}i
+# \[Feature [#9980](https://bugs.ruby-lang.org/issues/9980)\] Create HashWithIndiferentAccess using new syntax {a: 1}i
 
 matz: Suffix \`i\` is used for complex (imaginary) numbers. It's bit confusing.
 
@@ -47,21 +47,21 @@ Maybe what you want can be gained by shorter/nicer name for Hash#compare\_by\_id
 
 → reject
 
-# \[Feature [#9064](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9064&sa=D&source=editors&ust=1686086131112999&usg=AOvVaw1jx5r59gdhnGjW_oH_XUzs)\] Add support for packages, like in Java
+# \[Feature [#9064](https://bugs.ruby-lang.org/issues/9064)\] Add support for packages, like in Java
 
 Action: Matz  to write a few questions back to the proposer
 
-# \[Feature [#8631](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8631&sa=D&source=editors&ust=1686086131113269&usg=AOvVaw0BGKRsEb44xaPMCdRBFF6Q)\] Add a new method to ERB to allow assigning the local variables from a hash
+# \[Feature [#8631](https://bugs.ruby-lang.org/issues/8631)\] Add a new method to ERB to allow assigning the local variables from a hash
 
 Now it can be implemnted with Pure Ruby.
 
 If hash is given, what will be \`self\` of ERB?
 
-# \[Bug [#8543](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8543&sa=D&source=editors&ust=1686086131113575&usg=AOvVaw0xEtH6LgLA9lRl6vwQ8Wq1)\] rb\_iseq\_load
+# \[Bug [#8543](https://bugs.ruby-lang.org/issues/8543)\] rb\_iseq\_load
 
 Modify it (best effort).
 
-# \[Feature [#10084](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10084&sa=D&source=editors&ust=1686086131113839&usg=AOvVaw0sGJKzuRX2SiIYpdqdUvl9)\] Add Unicode String Normalization to String class
+# \[Feature [#10084](https://bugs.ruby-lang.org/issues/10084)\] Add Unicode String Normalization to String class
 
 Proposed method names by Matz: unicode\_normalize or normalize\_kd,... (not too short)
 
@@ -81,25 +81,25 @@ encodng: UTF-32BE/LE, UTF-16BE/LE, UTF-8
 
 allow UTF8-MAC is confusing.
 
-# \[Feature [#10085](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10085&sa=D&source=editors&ust=1686086131114630&usg=AOvVaw0DntBguD8DzWXY6sgnTyof)\] Add non-ASCII case conversion to String#upcase/downcase/swapcase/capitalize
+# \[Feature [#10085](https://bugs.ruby-lang.org/issues/10085)\] Add non-ASCII case conversion to String#upcase/downcase/swapcase/capitalize
 
-# \[Feature [#4276](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4276&sa=D&source=editors&ust=1686086131114903&usg=AOvVaw126K2l6fNEaYEZmoqBerAA)\] Allow use of quotes in symbol syntactic sugar for hashes
+# \[Feature [#4276](https://bugs.ruby-lang.org/issues/4276)\] Allow use of quotes in symbol syntactic sugar for hashes
 
 Compare with JSON, it is ambiguous (String or Symbol).
 
-# \[Feature [#9924](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9924&sa=D&source=editors&ust=1686086131115145&usg=AOvVaw2BmXaOlNZX8coghQwGlnqV)\] Revisitting GC.stat keys
+# \[Feature [#9924](https://bugs.ruby-lang.org/issues/9924)\] Revisitting GC.stat keys
 
 no objection.
 
 approval.
 
-# \[Feature [#9781](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9781&sa=D&source=editors&ust=1686086131115450&usg=AOvVaw3vQkbgM2ZzdRmmroeuFmT6)\] Feature Proposal: Method#super\_method
+# \[Feature [#9781](https://bugs.ruby-lang.org/issues/9781)\] Feature Proposal: Method#super\_method
 
 super: ambiguous which is calling method or getting method object of super.
 
 \-> “super\_method”
 
-# \[Feature [#10095](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10095&sa=D&source=editors&ust=1686086131115930&usg=AOvVaw1GX7O21O2KRcZDlvKl_FN4)\] Object#as
+# \[Feature [#10095](https://bugs.ruby-lang.org/issues/10095)\] Object#as
 
 many bike shedding.
 

--- a/2014/DevMeeting-2014-09-04.md
+++ b/2014/DevMeeting-2014-09-04.md
@@ -45,7 +45,7 @@ Attendees: sign up required: http://cruby.doorkeeper.jp/events/13742
 - attendee: ko1, sora\_h, akr, naruse, ayumin, a\_matsuda
 - on-line: matz, nobu
 
-## \[Feature [#10199](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10199&sa=D&source=editors&ust=1686086152310501&usg=AOvVaw2a92QzUZbS3-ZF81AAZ1-Q)\] Drop to support Symbian (hsbt)
+## \[Feature [#10199](https://bugs.ruby-lang.org/issues/10199)\] Drop to support Symbian (hsbt)
 
 Matz: agreed.
 
@@ -55,7 +55,7 @@ akr: no need to think about it now.
 
 hsbt: I will remove.
 
-## \[Feature [#10200](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10200&sa=D&source=editors&ust=1686086152311601&usg=AOvVaw1apUWwf8TufTYw_P-41jEV)\] Symbol API (static count, dynamic count, all\_symbols and so on) (ko1)
+## \[Feature [#10200](https://bugs.ruby-lang.org/issues/10200)\] Symbol API (static count, dynamic count, all\_symbols and so on) (ko1)
 
 Symbol.all\_symbols:
 
@@ -73,7 +73,7 @@ matz: remove it and ask people
 
 Couting immortal symbols is not solved. ko1 will make prototype of such methods.
 
-## \[Feature [#9880](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9880&sa=D&source=editors&ust=1686086152313162&usg=AOvVaw2-YU_uS-VvFQLEwSZRk8eo)\] Dir#fileno (akr)
+## \[Feature [#9880](https://bugs.ruby-lang.org/issues/9880)\] Dir#fileno (akr)
 
 matz: portability?
 
@@ -83,7 +83,7 @@ akr: For windows and so on, not implemented error can be acceptable.
 
 matz: ok. write document for compatibility.
 
-## \[Feature [#10201](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10201&sa=D&source=editors&ust=1686086152314712&usg=AOvVaw25yl5wfR-E5NvYjfJkBOTe)\] Dynamically changing GC tuning parameters (ko1)
+## \[Feature [#10201](https://bugs.ruby-lang.org/issues/10201)\] Dynamically changing GC tuning parameters (ko1)
 
 ko1 will try.
 
@@ -111,6 +111,6 @@ RC2 (if needed)
 
 Release 2.2.0 (12/25)
 
-[https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering22](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering22&sa=D&source=editors&ust=1686086152316831&usg=AOvVaw1m06gcrxWhkJAQR4rXQl-N)
+[https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering22](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering22)
 
 ## Next meeting 10/29

--- a/2014/DevMeeting-2014-10-29.md
+++ b/2014/DevMeeting-2014-10-29.md
@@ -39,7 +39,7 @@ Remote participation: Google hangout?
 
 # Log
 
-# \[Bug [#10416](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10416&sa=D&source=editors&ust=1686086192911682&usg=AOvVaw3prUBL57E1Lkee6gvlaia6)\] Create mechanism for updating of Unicode data files downstreams when we want (duerst
+# \[Bug [#10416](https://bugs.ruby-lang.org/issues/10416)\] Create mechanism for updating of Unicode data files downstreams when we want (duerst
 
 summary:
 
@@ -48,7 +48,7 @@ summary:
 - 今は最新版を落とす、となっているが7.0.0 に明記してダウンロードするようにした方がよい(2015年に8.0.0が出る)
 - ディレクトリやファイル構造をどうするか→nobuに一任する
 
-knu: Unicode 7からは毎年半ばに定期リリースされることになった: [http://www.unicode.org/versions/index.html#schedule](https://www.google.com/url?q=http://www.unicode.org/versions/index.html%23schedule&sa=D&source=editors&ust=1686086192912419&usg=AOvVaw3TlDidHUAi7EGIRAklX0mA)
+knu: Unicode 7からは毎年半ばに定期リリースされることになった: [http://www.unicode.org/versions/index.html#schedule](http://www.unicode.org/versions/index.html#schedule)
 
 naruse: 2.2では7.0.0指定にすべき
 
@@ -64,7 +64,7 @@ akr: ディレクトリ構造にバージョンを入れれば反映出来るだ
 
 ダウンロードおよび置き場に関してはnobuが実装するので、どうしたいかだけ伝えればOK
 
-# \[Feature [#5458](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5458&sa=D&source=editors&ust=1686086192913108&usg=AOvVaw3afuHtK9pKnsu2Bj93Llse)\] DL should be removed (hsbt)
+# \[Feature [#5458](https://bugs.ruby-lang.org/issues/5458)\] DL should be removed (hsbt)
 
 akr: dlを消す時にlibffiのソースを添付するという話だった。（libffiをWindowsでビルドするのは大変なので、CRubyにバンドルし、ビルド時に一緒にビルドして欲しい）
 
@@ -72,7 +72,7 @@ knu: libyamlも同様の理由で同梱している
 
 naruse: libffiはpermissiveなライセンスだったはず（※MIT License）
 
-knu: 余談だけど1.9, 2.0, 2.1のDL/Fiddleの差異や、ffi gemともまた違うという件についてkakasi gemというのを作ったのでご覧ください [https://github.com/knu/kakasi\_ffi](https://www.google.com/url?q=https://github.com/knu/kakasi_ffi&sa=D&source=editors&ust=1686086192913541&usg=AOvVaw1y95dingkjf0Jkksc8k8up) （どのバージョンのrubyでも使えるdl gemを作る場合の非互換性について参考になるかも）
+knu: 余談だけど1.9, 2.0, 2.1のDL/Fiddleの差異や、ffi gemともまた違うという件についてkakasi gemというのを作ったのでご覧ください [https://github.com/knu/kakasi\_ffi](https://github.com/knu/kakasi_ffi) （どのバージョンのrubyでも使えるdl gemを作る場合の非互換性について参考になるかも）
 
 akr: すぐDLを消すとWindowsで困る（usaさんが怒る）のでは？
 
@@ -80,7 +80,7 @@ akr: libffiソースバンドルチケットを作って、remove dlの依存先
 
 hsbt が関係者(tenderloveとunak)に remove 作業の詳細をもう一度確認して、どこまでやるかのラインを決めてもらう
 
-# \[Bug [#10314](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10314&sa=D&source=editors&ust=1686086192913939&usg=AOvVaw3RRTdRy3pTvSc9KqDeklt_)\] Default argument lookup fails in Ruby 2.2 for circular shadowed variable names (hsbt)
+# \[Bug [#10314](https://bugs.ruby-lang.org/issues/10314)\] Default argument lookup fails in Ruby 2.2 for circular shadowed variable names (hsbt)
 
 matz: ローカル変数代入と同じように見えるから、挙動もあわせるべき
 
@@ -88,7 +88,7 @@ akr: （foo = fooでnilが代入されるというのは）役に立つ挙動で
 
 matzがこれに関しては一貫性を取る（このリグレッションは諦めてもらう）と決定
 
-# \[Feature [#9612](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9612&sa=D&source=editors&ust=1686086192914508&usg=AOvVaw0WScH0Ln-uGoLWsO_iknbC)\] Gemify OpenSSL(hsbt)
+# \[Feature [#9612](https://bugs.ruby-lang.org/issues/9612)\] Gemify OpenSSL(hsbt)
 
 akr: experimental 実装について gemのバージョンは、OpenSSL (OpenSSL::OPENSSL\_VERSION)そのものではなく、OpenSSL拡張ライブラリのバージョン (OpenSSL::VERSION) にするべき（※libsslランタイムのバージョンはOpenSSL::OPENSSL\_LIBRARY\_VERSION）
 
@@ -100,7 +100,7 @@ matz: 異議はありません
 
 naruse さんが issue にコメントする
 
-# \[misc [#10287](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10287&sa=D&source=editors&ust=1686086192915344&usg=AOvVaw1K0w74ffPHHe7g7eNaF-O_)\] rename COLON3 to COLON2\_HEAD. (hsbt)
+# \[misc [#10287](https://bugs.ruby-lang.org/issues/10287)\] rename COLON3 to COLON2\_HEAD. (hsbt)
 
 \*: COLON3がおかしいのはおっしゃる通りだが、名前が「HEAD」はちょっと違う気がするので「TOP」?
 
@@ -108,7 +108,7 @@ akr: 「議論はしましたがいい名前が浮かばない」
 
 ko1: matz にふっておきましょう
 
-# \[Feature [#8976](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8976&sa=D&source=editors&ust=1686086192915963&usg=AOvVaw0V_YnAzmNrSze6h4Zrz8a6)\] file-scope freeze\_string directive (akr)
+# \[Feature [#8976](https://bugs.ruby-lang.org/issues/8976)\] file-scope freeze\_string directive (akr)
 
 matz: 遠い未来には賛成
 
@@ -141,7 +141,7 @@ matz: 嫌な予感がするので2.2では（実験的実装も含めて）や�
 
 2.3（以降）に照準を合わせる
 
-# \[Feature [#10344](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10344&sa=D&source=editors&ust=1686086192917383&usg=AOvVaw3c7_WLiOZKGq3WZ5_xvupQ)\] \[PATCH\] Implement Fiber#raise (ko1)
+# \[Feature [#10344](https://bugs.ruby-lang.org/issues/10344)\] \[PATCH\] Implement Fiber#raise (ko1)
 
 ko1: Thread#raiseは危険なのでなくした経緯
 
@@ -152,7 +152,7 @@ ko1: セミコルーチンの親子・裏表関係からして気持ち悪さが
 反対はなし
 matzは賛成
 
-# \[Feature [#10440](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10440&sa=D&source=editors&ust=1686086192918128&usg=AOvVaw3c4m4zW6mslM8pc8Ie8RBs)\] Optimize keyword and splat argument (ko1)
+# \[Feature [#10440](https://bugs.ruby-lang.org/issues/10440)\] Optimize keyword and splat argument (ko1)
 
 ko1: 99%は互換
 

--- a/2015/DevMeeting-2015-04-08.md
+++ b/2015/DevMeeting-2015-04-08.md
@@ -41,7 +41,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 # Log
 
-[https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20150408Japan](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20150408Japan&sa=D&source=editors&ust=1686086236508564&usg=AOvVaw02-lq8-NB_HSkyB1wv47zS)
+[https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20150408Japan](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20150408Japan)
 
 Attendee:
 
@@ -51,14 +51,14 @@ matz, akr, hsbt, nurse, nobu, ayumin, sora, ko1
 
 - Schedule: similar to Ruby 2.2 (nurse)
 
-- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23&sa=D&source=editors&ust=1686086236509384&usg=AOvVaw16bhHguN3ku5a0MIfsqRHt)
+- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23)
 
 - Favorite feature
 
 - did you mean gem (matz) -> better exception message mechanism
 
 - Ruby should improve exception message mechanism (ko1, nobu)
-- Related: [https://bugs.ruby-lang.org/issues/10982](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10982&sa=D&source=editors&ust=1686086236509817&usg=AOvVaw1SXhuhOMutkVOcwBYm-w85)
+- Related: [https://bugs.ruby-lang.org/issues/10982](https://bugs.ruby-lang.org/issues/10982)
 - Reverse backtrace outout
 - Internationalization (nobu)
 
@@ -102,7 +102,7 @@ matz, akr, hsbt, nurse, nobu, ayumin, sora, ko1
 
 - Frozen literal string
 
-- [https://bugs.ruby-lang.org/issues/8579](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8579&sa=D&source=editors&ust=1686086236511553&usg=AOvVaw2GYAdI6b3XQu_YauGaQhcJ)
+- [https://bugs.ruby-lang.org/issues/8579](https://bugs.ruby-lang.org/issues/8579)
 - https://bugs.ruby-lang.org/issues/8976
 - rdoc uses force\_encoding where the string is not created
 - matz don’t like pragma
@@ -150,19 +150,19 @@ matz, akr, hsbt, nurse, nobu, ayumin, sora, ko1
 
 - Methods to certify packages (chatting)
 
-## \[Feature [#8259](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8259&sa=D&source=editors&ust=1686086236515493&usg=AOvVaw3YHInHxjFIfNmsVbHclSjf)\] atomic attribute accessors (tenderlove)
+## \[Feature [#8259](https://bugs.ruby-lang.org/issues/8259)\] atomic attribute accessors (tenderlove)
 
 (matz) Let me survy more about it.
 
-## \[Feature [#10932](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10932&sa=D&source=editors&ust=1686086236515913&usg=AOvVaw3D8SgoQ1NEF9XHDb02rmVM)\] Enable allocation tracing ASAP (tenderlove)
+## \[Feature [#10932](https://bugs.ruby-lang.org/issues/10932)\] Enable allocation tracing ASAP (tenderlove)
 
 (ko1) no problem except the name and “include ObjectSpace”.
 
-## [GitHub #858](https://www.google.com/url?q=https://github.com/ruby/ruby/pull/858&sa=D&source=editors&ust=1686086236516318&usg=AOvVaw1J_iisyTLLojiimXBtU09v) Add a RUBY\_ENGINE\_VERSION constant (tenderlove)
+## [GitHub #858](https://github.com/ruby/ruby/pull/858) Add a RUBY\_ENGINE\_VERSION constant (tenderlove)
 
 (matz) approved.
 
-## \[Feature [#10728](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10728&sa=D&source=editors&ust=1686086236516734&usg=AOvVaw2-zWcHI-Dgg_YES1xppmLK)\] Warning for Fixnum#size to use RbConfig::SIZEOF 'long' (akr)
+## \[Feature [#10728](https://bugs.ruby-lang.org/issues/10728)\] Warning for Fixnum#size to use RbConfig::SIZEOF 'long' (akr)
 
 (matz) reject.
 

--- a/2015/DevMeeting-2015-05-14.md
+++ b/2015/DevMeeting-2015-05-14.md
@@ -49,7 +49,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 Attendee: ko1,ayumin,akr,hsbt,naruse; matz,sora\_h
 
-## \[Feature [#11084](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11084&sa=D&source=editors&ust=1686086372471249&usg=AOvVaw1AUX-rPJiMbGnUU6Uy2K8P)\] Use rb-readline instead of ext/readline
+## \[Feature [#11084](https://bugs.ruby-lang.org/issues/11084)\] Use rb-readline instead of ext/readline
 
 hsbt: Ruby needs readline. openssl, zlib to build. rb-readline is a pure Ruby library. Replacing current readline with rb-readline (as a bundled gem) helps build problems. Current readline will be a gem. Now windows ruby installer already use rb-readline.
 
@@ -87,7 +87,7 @@ Next action:
 
 hsbt: I continue to use rb-readline and try it.
 
-## \[Feature [#11083](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11083&sa=D&source=editors&ust=1686086372474766&usg=AOvVaw1fsqftrcsDUHDGZ8iwYzHx)\] Gemify net-telnet
+## \[Feature [#11083](https://bugs.ruby-lang.org/issues/11083)\] Gemify net-telnet
 
 hsbt: no maintainer so it should be gemify.
 
@@ -97,7 +97,7 @@ hsbt: Not sure.
 
 Matz: I accept bundled gem.
 
-## \[Feature [#11082](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11082&sa=D&source=editors&ust=1686086372475773&usg=AOvVaw1It0FTzDf5YEnqD85dlndN)\] Remove condition of RUBY\_VERSION < 1.9 (hsbt)
+## \[Feature [#11082](https://bugs.ruby-lang.org/issues/11082)\] Remove condition of RUBY\_VERSION < 1.9 (hsbt)
 
 hsbt: Title is wrong. Not < 1.9, but <= 1.9.
 
@@ -123,7 +123,7 @@ ayumin: Positive because using newer features helps to evaluate such features.
 
 ko1: Use newer features with keeping compatibility.
 
-## \[Feature [#11049](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11049&sa=D&source=editors&ust=1686086372477343&usg=AOvVaw3ZF7dRSTNliaZ_h1qb9ybU)\] Enumerable#grep\_v (inversed grep) (sorah)
+## \[Feature [#11049](https://bugs.ruby-lang.org/issues/11049)\] Enumerable#grep\_v (inversed grep) (sorah)
 
 matz: are you okay to use the name “grep\_v”
 
@@ -141,7 +141,7 @@ matz: but grep\_v() is okay. -> accept on ticket.
 
 naruse: How about reject(pattern) ?
 
-## \[Bug [#10967](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10967&sa=D&source=editors&ust=1686086372478539&usg=AOvVaw2yV2ubsSc32pjwiv479d8v)\] Remove "private attribute?" warning (zzak)
+## \[Bug [#10967](https://bugs.ruby-lang.org/issues/10967)\] Remove "private attribute?" warning (zzak)
 
 akr: self.private\_something\_method is accepted recently.
 
@@ -149,7 +149,7 @@ naruse: test can find problem, so warning is not needed.
 
 matz: accept .
 
-## \[Feature [#10984](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10984&sa=D&source=editors&ust=1686086372479409&usg=AOvVaw1aj9mfL62pDDl_MsKtey31)\] Hash#contain? (zzak)
+## \[Feature [#10984](https://bugs.ruby-lang.org/issues/10984)\] Hash#contain? (zzak)
 
 akr: “contain” is too general. “subhash”?
 
@@ -157,7 +157,7 @@ n0kada: “contain?” seems similiar to “include?”
 
 akr: do we really use? we need concrete examples.
 
-## \[Bug [#10856](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10856&sa=D&source=editors&ust=1686086372480104&usg=AOvVaw1SZKB2wQZXPLpvAn1DfTLl)\] Splat with empty keyword args
+## \[Bug [#10856](https://bugs.ruby-lang.org/issues/10856)\] Splat with empty keyword args
 
 def foo
 
@@ -185,13 +185,13 @@ foo(\*\*{}) #=> okay
 
 The first one seems wrong code, so an error is reasonable.
 
-## \[Feature [#11140](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11140&sa=D&source=editors&ust=1686086372482440&usg=AOvVaw3tq9ifZ7KxS9gLVIZDFF1h)\] autoload should call Kernel.require to give rubygems a chance to handle loading (tenderlove)
+## \[Feature [#11140](https://bugs.ruby-lang.org/issues/11140)\] autoload should call Kernel.require to give rubygems a chance to handle loading (tenderlove)
 
 nobu: no problem. -r already calls replaced require().
 
 matz: accept.
 
-## \[Feature [#11151](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11151&sa=D&source=editors&ust=1686086372483286&usg=AOvVaw1CSypUyGvqTK8mEViTqT2M)\] Numeric#positive? and Numeric#negative?
+## \[Feature [#11151](https://bugs.ruby-lang.org/issues/11151)\] Numeric#positive? and Numeric#negative?
 
 akr: well usecase.
 
@@ -205,7 +205,7 @@ matz: accept because it has usecase.
 
 # How to implement Range#include? and Range#cover?
 
-nobu: [https://bugs.ruby-lang.org/issues/11113](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11113&sa=D&source=editors&ust=1686086372484852&usg=AOvVaw1uksl35RCV9mtemvhUD6ww) specialize Time object
+nobu: [https://bugs.ruby-lang.org/issues/11113](https://bugs.ruby-lang.org/issues/11113) specialize Time object
 
 How to make general solution?
 
@@ -218,7 +218,7 @@ Nobu: Impement Range specializes String and try it.
 New syntax proposals
 
 # Feature #11141:  new syntax suggestion for abbreviate definition on block parameters in order
-[https://bugs.ruby-lang.org/issues/11141](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11141&sa=D&source=editors&ust=1686086372486127&usg=AOvVaw2hXvn3WIAEX9kTaXr2AEhH)
+[https://bugs.ruby-lang.org/issues/11141](https://bugs.ruby-lang.org/issues/11141)
 
 Matz: negative
 
@@ -273,7 +273,7 @@ Which is favorite?
 Next action: ko1 will add discussion into 11141.
 
 # Feature #11105: ES6-like hash literals
-[https://bugs.ruby-lang.org/issues/11105#change-52447](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11105%23change-52447&sa=D&source=editors&ust=1686086372491568&usg=AOvVaw1EstlIHHbWkqHiz57T_lwZ)
+[https://bugs.ruby-lang.org/issues/11105#change-52447](https://bugs.ruby-lang.org/issues/11105#change-52447)
 
 Problem 1: It seems “Set”
 

--- a/2015/DevMeeting-2015-06-12.md
+++ b/2015/DevMeeting-2015-06-12.md
@@ -55,7 +55,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 Attendee: akr, hsbt, ko1, matz, naruse, nobu
 
-## \[Feature [#7148](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7148&sa=D&source=editors&ust=1686086420316632&usg=AOvVaw04IpXnttiOw_m9h0ZX0k21)\] Improved Tempfile w/o DelegateClass (glass\_saga)
+## \[Feature [#7148](https://bugs.ruby-lang.org/issues/7148)\] Improved Tempfile w/o DelegateClass (glass\_saga)
 
 matz: I have some issue on this proposal. Tempfile should not be a subclass of File. It is different concept from File. I’m okay to implement Tempfile without delegator. However, I’m not sure it implemeted with subclass of File.
 
@@ -63,7 +63,7 @@ File is a wrapper of fd. Tempfile is not only a wrapper but handle other informa
 
 Action: Matz will reply this issue.
 
-## \[Feature [#11218](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11218&sa=D&source=editors&ust=1686086420317787&usg=AOvVaw0KSke3_MK8esxsZUYJqlZy)\] File.open FILE\_SHARE\_DELETE (naruse)
+## \[Feature [#11218](https://bugs.ruby-lang.org/issues/11218)\] File.open FILE\_SHARE\_DELETE (naruse)
 
 naruse: (explain about this proposal). This proposal is only for Windows.
 
@@ -85,7 +85,7 @@ naruse: I need modestr2modeint for add the new integer flag (rb\_io\_modestr\_of
 
 Action: Discuss on ticket
 
-## \[Feature [#11251](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11251&sa=D&source=editors&ust=1686086420320036&usg=AOvVaw2BT9ptJ9dw8OOgeTtfybkc)\] pthread\_set\_name\_np (naruse)
+## \[Feature [#11251](https://bugs.ruby-lang.org/issues/11251)\] pthread\_set\_name\_np (naruse)
 
 ko1: Interface?
 
@@ -103,19 +103,19 @@ Action: naruse will implement it
 
 Action: reply on issue.
 
-## \[Feature [#5455](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5455&sa=D&source=editors&ust=1686086420322762&usg=AOvVaw39dNDxfnYfswP6nGQe0Ebv)\] $SAFE should be removed(hsbt)
+## \[Feature [#5455](https://bugs.ruby-lang.org/issues/5455)\] $SAFE should be removed(hsbt)
 
 matz: $2 and $3 can be removed.
 
 Action: Matz will reply on ticket. hsbt-san will try implent.
 
-## \[Feature [#10730](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10730&sa=D&source=editors&ust=1686086420324242&usg=AOvVaw31hryX1D9DbpuqAsLl_eN1)\] Implement Array#bsearch\_index(hsbt)
+## \[Feature [#10730](https://bugs.ruby-lang.org/issues/10730)\] Implement Array#bsearch\_index(hsbt)
 
 matz: go ahead.
 
 Action: Matz will reply. nobu will merge.
 
-## \[Feature [#10017](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10017&sa=D&source=editors&ust=1686086420325348&usg=AOvVaw1yJRgzUVP2Sj7Vqk0jO5tq)\] Add Hash#values\_at!(hsbt)
+## \[Feature [#10017](https://bugs.ruby-lang.org/issues/10017)\] Add Hash#values\_at!(hsbt)
 
 matz: approved (Hash#fetch\_values).
 

--- a/2015/DevMeeting-2015-07-28.md
+++ b/2015/DevMeeting-2015-07-28.md
@@ -65,7 +65,7 @@ matz: ok
 
 matz: ok
 
-## [https://bugs.ruby-lang.org/issues/11339](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11339&sa=D&source=editors&ust=1686086447558338&usg=AOvVaw2vgkHD9pqJjDzGHhqvEaG1)
+## [https://bugs.ruby-lang.org/issues/11339](https://bugs.ruby-lang.org/issues/11339)
 
 Introducing IDL will
 
@@ -95,13 +95,13 @@ Also, additional TracePoint will be introduced.
 
 - our storage account is expired from about 2-3 week ago.
 - we will replace following azure backends to s3.
-- [https://github.com/akr/chkbuild/blob/master/chkbuild/upload.rb#L75](https://www.google.com/url?q=https://github.com/akr/chkbuild/blob/master/chkbuild/upload.rb%23L75&sa=D&source=editors&ust=1686086447560583&usg=AOvVaw1Y-fiqFqbpP-ZlbBuzn_Uu)
+- [https://github.com/akr/chkbuild/blob/master/chkbuild/upload.rb#L75](https://github.com/akr/chkbuild/blob/master/chkbuild/upload.rb#L75)
 
 ## about the necessity of r51384 (it takes toooooo looooong time to run test-all) (usa)
 
 Resolved.
 
-## \[Feature [#8919](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8919&sa=D&source=editors&ust=1686086447561376&usg=AOvVaw1GpriQ8IBecqjlUXWryVI9)\] Queue as embedded class: please determine whether or not it should be introduced. (glass\_saga)
+## \[Feature [#8919](https://bugs.ruby-lang.org/issues/8919)\] Queue as embedded class: please determine whether or not it should be introduced. (glass\_saga)
 
 Matz: seems good.
 
@@ -109,7 +109,7 @@ Nobu: how is SizedQueue? They share same codes.
 
 … no conclusion. Koichi will try.
 
-# Feature #10600: \[PATCH\] Queue#close [https://bugs.ruby-lang.org/issues/10600](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10600&sa=D&source=editors&ust=1686086447562092&usg=AOvVaw3ALYRgd-eCbEZsvau_bO_e)
+# Feature #10600: \[PATCH\] Queue#close [https://bugs.ruby-lang.org/issues/10600](https://bugs.ruby-lang.org/issues/10600)
 
 Matz: seems good.
 
@@ -117,6 +117,6 @@ akr: What happens on pushing/popping closed Queue?
 
 ko1: there are discussions on ticket. I’ll take it.
 
-## \[Feature [#11297](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11297&sa=D&source=editors&ust=1686086447562734&usg=AOvVaw2n78P0SgnFCpyVhlq5wN_v)\] Allow private method of self to be called (a\_matsuda)
+## \[Feature [#11297](https://bugs.ruby-lang.org/issues/11297)\] Allow private method of self to be called (a\_matsuda)
 
 Matz: seems good

--- a/2015/DevMeeting-2015-08-20.md
+++ b/2015/DevMeeting-2015-08-20.md
@@ -129,7 +129,7 @@ empty line is not needed because lines of display is essential resource. indent 
 
 # Release Schedule
 
-[https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23&sa=D&source=editors&ust=1686086477052466&usg=AOvVaw3hwP5YZeC2T7g7wUaS3P6l)
+[https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23)
 
 # Subversion Repository Migration
 
@@ -162,7 +162,7 @@ Default of the status of String Literal will be frozen from Ruby 3.0.
 - it has been rejected before 2.2 by matz
 - it has been rejected again early 2.3 development by matz
 - amatsuda: tired of seeing pull requests adding “..”.freeze here and there. This is ugly.
-- amatsuda: please reconsider akr’s magic comment solution \[[https://bugs.ruby-lang.org/issues/8976](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8976&sa=D&source=editors&ust=1686086477055496&usg=AOvVaw3BxWR-US2T9liIUms8wscS)\]
+- amatsuda: please reconsider akr’s magic comment solution \[[https://bugs.ruby-lang.org/issues/8976](https://bugs.ruby-lang.org/issues/8976)\]
 - matz: accepted. As a migration path, magic comment is reasonable. naming is still problem.
 
 - command line option to frozen string literal by default
@@ -171,16 +171,16 @@ Default of the status of String Literal will be frozen from Ruby 3.0.
 
 - Ruby 3.0 will interpret string literal frozen by default.
 
-- akr’s challenge. [https://github.com/akr/ruby/tree/frozen-string](https://www.google.com/url?q=https://github.com/akr/ruby/tree/frozen-string&sa=D&source=editors&ust=1686086477056841&usg=AOvVaw1Q5t0Y08z5plqxrl9Xz1Gp)
+- akr’s challenge. [https://github.com/akr/ruby/tree/frozen-string](https://github.com/akr/ruby/tree/frozen-string)
 - String.new(“...”) is preferred over “...”.dup.
 - magic comment candidates
 
-- freeze\_string: true \[[https://bugs.ruby-lang.org/issues/8976](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8976&sa=D&source=editors&ust=1686086477057913&usg=AOvVaw2YbhybS8bzSzr5GzgB04_3)\]
+- freeze\_string: true \[[https://bugs.ruby-lang.org/issues/8976](https://bugs.ruby-lang.org/issues/8976)\]
 - freeze\_string\_literal: true
 - frozen\_string\_literal: true \[prefered by matz\]
 - freezing\_string\_literal: true
 - mutable\_string\_literal: false
-- immutable: string \[[https://github.com/ruby/ruby/pull/487](https://www.google.com/url?q=https://github.com/ruby/ruby/pull/487&sa=D&source=editors&ust=1686086477058941&usg=AOvVaw0QyJjUIm_f3W7OZaq0CN_X)\]
+- immutable: string \[[https://github.com/ruby/ruby/pull/487](https://github.com/ruby/ruby/pull/487)\]
 
 - command line option candidates
 

--- a/2015/DevMeeting-2015-10-21.md
+++ b/2015/DevMeeting-2015-10-21.md
@@ -41,9 +41,9 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 # Log
 
-# Decide whether -\*- should be required for frozen\_string\_literal magic comments \[Feature [#8976](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8976&sa=D&source=editors&ust=1686086593905098&usg=AOvVaw0PwQESLP4h-eULUVbRLbQv)\]
+# Decide whether -\*- should be required for frozen\_string\_literal magic comments \[Feature [#8976](https://bugs.ruby-lang.org/issues/8976)\]
 
-naruse: vim’s indicator is “vim: …” [http://vim.wikia.com/wiki/Modeline\_magic](https://www.google.com/url?q=http://vim.wikia.com/wiki/Modeline_magic&sa=D&source=editors&ust=1686086593905604&usg=AOvVaw3YVUpvRDjdZaL7rn27xQ7T)
+naruse: vim’s indicator is “vim: …” [http://vim.wikia.com/wiki/Modeline\_magic](http://vim.wikia.com/wiki/Modeline_magic)
 
 nobu: should be have an indicator of pragrma.
 
@@ -165,7 +165,7 @@ matz: i can accept original proposal.
 
 C# Design Notes for Sep 8, 2015
 
-[https://github.com/dotnet/roslyn/issues/5383](https://www.google.com/url?q=https://github.com/dotnet/roslyn/issues/5383&sa=D&source=editors&ust=1686086593910852&usg=AOvVaw0VPTlIBXZymQ3Wo5ldpUym)
+[https://github.com/dotnet/roslyn/issues/5383](https://github.com/dotnet/roslyn/issues/5383)
 
 ?a syntax
 
@@ -248,7 +248,7 @@ str = ?’foo’
 
 str = !’foo’ -> bad idea (ex: str = !’foo’.start\_with(‘f’))
 
-# [https://twitter.com/sferik/status/642063693304451072](https://www.google.com/url?q=https://twitter.com/sferik/status/642063693304451072&sa=D&source=editors&ust=1686086593915082&usg=AOvVaw2Y2K9qgCFN4c_YBAvMSouS)
+# [https://twitter.com/sferik/status/642063693304451072](https://twitter.com/sferik/status/642063693304451072)
 
 matz; how about to warn for “initialise”?
 

--- a/2015/DevMeeting-2015-11-09.md
+++ b/2015/DevMeeting-2015-11-09.md
@@ -44,7 +44,7 @@ Attendees: matz, nobu, hsbt, akr, naruse, sorah, yuki, ko1
 
 2015/12/07 Mon 14:00 JST at SFDC
 
-## \[Feature [#8976](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8976&sa=D&source=editors&ust=1686086629237034&usg=AOvVaw305ggw0LyuhLDsm00vbufd)\] file-scope freeze\_string directive
+## \[Feature [#8976](https://bugs.ruby-lang.org/issues/8976)\] file-scope freeze\_string directive
 
 ## freeze dynamic string literal or not?
 
@@ -91,7 +91,7 @@ Attendees: matz, nobu, hsbt, akr, naruse, sorah, yuki, ko1
 
 - We don’t need an option name if it is always enabled.
 
-## \[Feature [#4840](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4840&sa=D&source=editors&ust=1686086629240030&usg=AOvVaw2uPK_OKxtBrOwaRgGbruU6)\] Allow returning from require
+## \[Feature [#4840](https://bugs.ruby-lang.org/issues/4840)\] Allow returning from require
 
 \### Before
 
@@ -204,7 +204,7 @@ def foo
 
 end
 
-## \[Feature [#9098](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9098&sa=D&source=editors&ust=1686086629246775&usg=AOvVaw2jAu9y3Ym2D62Ll4HI044G)\] Indent heredoc against the left margin by default when "indented closing identifier" is turned on.
+## \[Feature [#9098](https://bugs.ruby-lang.org/issues/9098)\] Indent heredoc against the left margin by default when "indented closing identifier" is turned on.
 
 \# 2 spaces
 
@@ -237,7 +237,7 @@ Matz: acecptable, but there could be a problem if hard tabs and spaces are both 
 
 Nishijima-san suggested another way to write strings like DATA for each files. It will be proposed as another ticket.
 
-## \[Feature [#11643](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11643&sa=D&source=editors&ust=1686086629249954&usg=AOvVaw3bgMFujgdEH0PWLs9Slb_P)\] A new method on Hash to grab values out of nested hashes, failing gracefully
+## \[Feature [#11643](https://bugs.ruby-lang.org/issues/11643)\] A new method on Hash to grab values out of nested hashes, failing gracefully
 
 Matz: acceptable, but name is problem.
 
@@ -257,7 +257,7 @@ h.fetch\_in(:a, :b, :c) #=> 1
 
 Note that Matz doesn’t like &.\[\] (safe navigation operator with \[\]).
 
-Nishijima-san mentioned past rejected proposals in Rails [\[1\]](https://www.google.com/url?q=https://groups.google.com/d/topic/rubyonrails-core/hww2nP8Zx4w/discussion&sa=D&source=editors&ust=1686086629251781&usg=AOvVaw1ZekyIipEG1XSKbU892j93) [\[2\]](https://www.google.com/url?q=https://twitter.com/a_matsuda/status/592849107762475009&sa=D&source=editors&ust=1686086629252101&usg=AOvVaw28diYOnHT1nPddccQGQL85), they were rejected because such object in use cases should be wrapped with proper objects.
+Nishijima-san mentioned past rejected proposals in Rails [\[1\]](https://groups.google.com/d/topic/rubyonrails-core/hww2nP8Zx4w/discussion) [\[2\]](https://twitter.com/a_matsuda/status/592849107762475009), they were rejected because such object in use cases should be wrapped with proper objects.
 
 - pros
 
@@ -278,7 +278,7 @@ Nishijima-san mentioned past rejected proposals in Rails [\[1\]](https://www.goo
 
 - e.g. {a: {b: {c: 1}}}.dig(:a, :b, :x) == nil (not {c: 1})
 
-## \[Feature [#11665](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11665&sa=D&source=editors&ust=1686086629253785&usg=AOvVaw2-Hkf1kjJuY73Ta3ftAWCB)\] Support nested functions for better code organization
+## \[Feature [#11665](https://bugs.ruby-lang.org/issues/11665)\] Support nested functions for better code organization
 
 class C
 
@@ -318,13 +318,13 @@ end
 
 - result
 
-- matz: commented at [https://bugs.ruby-lang.org/issues/11665#note-3](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11665%23note-3&sa=D&source=editors&ust=1686086629256181&usg=AOvVaw3M-5Ke8tsnKa9JoTAVJIh5)
+- matz: commented at [https://bugs.ruby-lang.org/issues/11665#note-3](https://bugs.ruby-lang.org/issues/11665#note-3)
 
-## \[Feature [#11666](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11666&sa=D&source=editors&ust=1686086629256639&usg=AOvVaw2aoPqU-rovW6shbNPYSZ9C)\] IPAddr#private?
+## \[Feature [#11666](https://bugs.ruby-lang.org/issues/11666)\] IPAddr#private?
 
 Matz accepted this feature. Pass to knu -san (maintainer).
 
-## \[Feature [#11588](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11588&sa=D&source=editors&ust=1686086629257153&usg=AOvVaw0Je12v8DTmmbG_r7AMBnre)\] Implement structured warnings
+## \[Feature [#11588](https://bugs.ruby-lang.org/issues/11588)\] Implement structured warnings
 
 - pros
 
@@ -344,7 +344,7 @@ Matz accepted this feature. Pass to knu -san (maintainer).
 
 - no conclusion.
 
-## \[Feature [#11653](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11653&sa=D&source=editors&ust=1686086629258468&usg=AOvVaw3ybz4P1lTPCMyh8SRIdR2v)\] Add to\_proc on Hash
+## \[Feature [#11653](https://bugs.ruby-lang.org/issues/11653)\] Add to\_proc on Hash
 
 class Hash
 
@@ -368,7 +368,7 @@ Matz: acceptable
 
 Matz: to\_proc is intended for & argument operator. So it is reasonable to add.
 
-## \[Feature [#10984](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10984&sa=D&source=editors&ust=1686086629260420&usg=AOvVaw3Dtz_rIysRVt2ZLvU56NzV)\] Hash#contain? to check whether hash contains other hash
+## \[Feature [#10984](https://bugs.ruby-lang.org/issues/10984)\] Hash#contain? to check whether hash contains other hash
 
 Matz: Feature is acceptable. But naming issue;
 
@@ -391,7 +391,7 @@ Method name candidates:
 
 Matz: I vote for “<”, “>”, “<=” and “>=” (no “<=>” and “===”).
 
-## \[Feature [#9108](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9108&sa=D&source=editors&ust=1686086629262227&usg=AOvVaw0yao0ymha7fNRMDhrXv3Nm)\]\[Feature [#8499](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8499&sa=D&source=editors&ust=1686086629262509&usg=AOvVaw27B-oerOWdzRueNvZA7oKx)\] Importing Hash#slice, Hash#slice!, Hash#except, and Hash#except! from ActiveSupport
+## \[Feature [#9108](https://bugs.ruby-lang.org/issues/9108)\]\[Feature [#8499](https://bugs.ruby-lang.org/issues/8499)\] Importing Hash#slice, Hash#slice!, Hash#except, and Hash#except! from ActiveSupport
 
 Current status: naming issue, select and reject are acceptable for Matz.
 

--- a/2016/DevMeeting-2016-01-18.md
+++ b/2016/DevMeeting-2016-01-18.md
@@ -68,9 +68,9 @@ Attendees: unak, mrkn, naruse, ayumin, ko1, sorah, zack, martin
 - Shibata-san
 - Usa-san
 
-## \[Feature [#11949](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11949&sa=D&source=editors&ust=1686086669304153&usg=AOvVaw2yGAdfbMDsH3mYZjJlB9mt)\] Allow @/$ prefix in Regexp's named captures (naruse)
+## \[Feature [#11949](https://bugs.ruby-lang.org/issues/11949)\] Allow @/$ prefix in Regexp's named captures (naruse)
 
-/(?<[@timestamp](https://www.google.com/url?q=https://github.com/timestamp&sa=D&source=editors&ust=1686086669304610&usg=AOvVaw28N6Kq4TmNVpiRZst-nyet)\>\[^ \]\*): / =~
+/(?<[@timestamp](https://github.com/timestamp)\>\[^ \]\*): / =~
 
 \>> /(?<@a>.)/ =~ 'x'
 
@@ -114,7 +114,7 @@ valid: > /(?<a@-あfoo>a)/.match("a")
 
 Conclusion: acceptable confusion or not. Matz is positive to accept this feature
 
-## \[Feature [#11987](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11987&sa=D&source=editors&ust=1686086669307460&usg=AOvVaw2PuKCWfc_szpekM7TIHEK1)\] daemons can't show the backtrace of rb\_bug
+## \[Feature [#11987](https://bugs.ruby-lang.org/issues/11987)\] daemons can't show the backtrace of rb\_bug
 
 Process.daemon closes STDERR (or redirect to /dev/null).
 
@@ -148,8 +148,8 @@ Conclusion: Use wrapper process to intercept stderr.
 
 # 2.3 Retrospective
 
-- [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20151109Japan](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20151109Japan&sa=D&source=editors&ust=1686086669310598&usg=AOvVaw25GeF4vM-cHmwfMkLfejtW)
-- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23&sa=D&source=editors&ust=1686086669311009&usg=AOvVaw2nVN5Qfn8LWeLeMjW0uP0s)
+- [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20151109Japan](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20151109Japan)
+- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering23)
 
 - Release dates:
 
@@ -180,22 +180,22 @@ Conclusion: Use wrapper process to intercept stderr.
 - 10 Nov (RubyConf): Preview 2
 - XX Dec: Release Candidate, feature freezed
 - 25 Dec: Final Release
-- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24&sa=D&source=editors&ust=1686086669313362&usg=AOvVaw3uHuwHJAeh8pQElmOk1vVA)
+- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24)
 - Note:
 
 - Declare that preview releases are experimental and subject to change.
-- Additional announcement (e.g. [www.ruby-lang.org](https://www.google.com/url?q=http://www.ruby-lang.org&sa=D&source=editors&ust=1686086669313945&usg=AOvVaw2LiOkyrgGBpe4AvVS1ub4q))?
+- Additional announcement (e.g. [www.ruby-lang.org](http://www.ruby-lang.org))?
 - Reminders at before a release?
 
-[https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/CallForFeatureProposalTemplate](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/CallForFeatureProposalTemplate&sa=D&source=editors&ust=1686086669314387&usg=AOvVaw2_xKpFGpK5ToUyH3Mk1bHJ)
+[https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/CallForFeatureProposalTemplate](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/CallForFeatureProposalTemplate)
 
 ## Announcement channel
 
-We have only mailing lists and [www.ruby-lang.org](https://www.google.com/url?q=http://www.ruby-lang.org&sa=D&source=editors&ust=1686086669314808&usg=AOvVaw2jIwC6FxxSu2ArZR9sN6NM) to annouce news. However, it is difficult to catch up latest news by such channels. Any other ideas?
+We have only mailing lists and [www.ruby-lang.org](http://www.ruby-lang.org) to annouce news. However, it is difficult to catch up latest news by such channels. Any other ideas?
 
 - official twitter account (www.ruby-lang.org headline)
 
-- [https://twitter.com/rubylangorg](https://www.google.com/url?q=https://twitter.com/rubylangorg&sa=D&source=editors&ust=1686086669315333&usg=AOvVaw2yZLdGmsG3gFwM8eH0YG_B)
+- [https://twitter.com/rubylangorg](https://twitter.com/rubylangorg)
 - something RSS bot
 
 # Next release
@@ -207,7 +207,7 @@ We have only mailing lists and [www.ruby-lang.org](https://www.google.com/url?q=
 - type check
 - performance
 
-naruse’s note [https://gist.github.com/nurse/4324519](https://www.google.com/url?q=https://gist.github.com/nurse/4324519&sa=D&source=editors&ust=1686086669316169&usg=AOvVaw1S-v2DcSFwk_HCHc7mIP17)
+naruse’s note [https://gist.github.com/nurse/4324519](https://gist.github.com/nurse/4324519)
 
 ## Remove Fixnum and Bignum
 

--- a/2016/DevMeeting-2016-02-16.md
+++ b/2016/DevMeeting-2016-02-16.md
@@ -62,17 +62,17 @@ Members: hsbt, akr, mrkn, shyouhei, naruse, nobu, ko1, sorah, matz (skype)
 - gem-codesearch
 
 - We want to share gem-codesearch as a service.
-- [https://github.com/etsy/hound](https://www.google.com/url?q=https://github.com/etsy/hound&sa=D&source=editors&ust=1686086705503465&usg=AOvVaw2cwzpJ_gQkqZYCFtJDw1ye) is webapp which uses the algorithm same as [https://github.com/google/codesearch](https://www.google.com/url?q=https://github.com/google/codesearch&sa=D&source=editors&ust=1686086705503747&usg=AOvVaw0KL6Jghj1uoWe0NYHZZHRy).
+- [https://github.com/etsy/hound](https://github.com/etsy/hound) is webapp which uses the algorithm same as [https://github.com/google/codesearch](https://github.com/google/codesearch).
 - What we need is a server with big (such as 1Tbytes) storage.
 
-## \[[Misc #12004](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12004&sa=D&source=editors&ust=1686086705504112&usg=AOvVaw1mrw7kuUGCmHp6dnG9TsXw)\] CoC
+## \[[Misc #12004](https://bugs.ruby-lang.org/issues/12004)\] CoC
 
 - Matz does not want to include CoC in repository nor release tarball
 - Based on PostgreSQL’s CoC v2
 
-- [http://www.postgresql.org/message-id/56A2E9C5.2040707@commandprompt.com](https://www.google.com/url?q=http://www.postgresql.org/message-id/56A2E9C5.2040707@commandprompt.com&sa=D&source=editors&ust=1686086705504596&usg=AOvVaw0uD3vSBEhOtnAv1GdP2Aty)
+- [http://www.postgresql.org/message-id/56A2E9C5.2040707@commandprompt.com](http://www.postgresql.org/message-id/56A2E9C5.2040707@commandprompt.com)
 
-- Create post on [www.ruby-lang.org](https://www.google.com/url?q=http://www.ruby-lang.org&sa=D&source=editors&ust=1686086705504849&usg=AOvVaw0eozBRj2xbUIoJdNFUIj_5)
+- Create post on [www.ruby-lang.org](http://www.ruby-lang.org)
 
 - Link on bugs.ruby-lang.org new account page and w.r-l.o ML list?
 
@@ -95,13 +95,13 @@ Members: hsbt, akr, mrkn, shyouhei, naruse, nobu, ko1, sorah, matz (skype)
 - Applied area: (“collaborative space”)
 
 - A. bugs.ruby-lang.org, commit comments + etc?
-- Include MLs? [http://lists.ruby-lang.org/cgi-bin/mailman/listinfo](https://www.google.com/url?q=http://lists.ruby-lang.org/cgi-bin/mailman/listinfo&sa=D&source=editors&ust=1686086705505903&usg=AOvVaw0Mz1q6tejNm86H3hetgOIv)
+- Include MLs? [http://lists.ruby-lang.org/cgi-bin/mailman/listinfo](http://lists.ruby-lang.org/cgi-bin/mailman/listinfo)
 
 - A. No
 
-GitHub: web [https://github.com/ruby/www.ruby-lang.org/issues](https://www.google.com/url?q=https://github.com/ruby/www.ruby-lang.org/issues&sa=D&source=editors&ust=1686086705506300&usg=AOvVaw13XtU-mNJtbddkPPPLRqv8)
+GitHub: web [https://github.com/ruby/www.ruby-lang.org/issues](https://github.com/ruby/www.ruby-lang.org/issues)
 
-## \[Feature [#11666](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11666&sa=D&source=editors&ust=1686086705506587&usg=AOvVaw1tjbrvJPZVY9Z8kEFT1DG2)\] IPAddr#private? (glass\_saga)
+## \[Feature [#11666](https://bugs.ruby-lang.org/issues/11666)\] IPAddr#private? (glass\_saga)
 
 - feature issues
 
@@ -118,7 +118,7 @@ GitHub: web [https://github.com/ruby/www.ruby-lang.org/issues](https://www.googl
 
 - The name “ipv4\_private?” is clear that the method returns false on IPv6 addresses.
 
-## \[Feature [#12046](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12046&sa=D&source=editors&ust=1686086705507489&usg=AOvVaw0v4FJMcLH3kWGTpDAbazSr)\] Allow attr\_reader :foo? to define instance method foo? for accessing @foo (mrkn)
+## \[Feature [#12046](https://bugs.ruby-lang.org/issues/12046)\] Allow attr\_reader :foo? to define instance method foo? for accessing @foo (mrkn)
 
 - matz: Still negative; I’m not good to have difference in ivar name and method name
 - behavior issues:
@@ -133,7 +133,7 @@ Reported by ko1.
 
 ---
 
-## \[Feature [#11999](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11999&sa=D&source=editors&ust=1686086705508376&usg=AOvVaw38SL--MaFWupV1gU_VMhHn)\] MatchData#to\_h to get a Hash from named captures (sorah)
+## \[Feature [#11999](https://bugs.ruby-lang.org/issues/11999)\] MatchData#to\_h to get a Hash from named captures (sorah)
 
 - #to\_h is inappropriate name while non-named capture exists
 
@@ -157,7 +157,7 @@ Reported by ko1.
 
 - #captures return \[\] when no capture, so #named\_captures returns {} when no named capture
 
-## \[Bug [#9810](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9810&sa=D&source=editors&ust=1686086705509739&usg=AOvVaw0UkOaTFUpD2EUE_5UefBkg)\] Numeric#step behavior with mixed Float, String arguments inconsistent with documentation
+## \[Bug [#9810](https://bugs.ruby-lang.org/issues/9810)\] Numeric#step behavior with mixed Float, String arguments inconsistent with documentation
 
 This issue is because of invalid type, not mismatch the number of arguments.
 
@@ -183,28 +183,28 @@ def foo;return a: 1; end
 
 matz rejected it because return is not a method call.  Matz wants to split kwargs versus trailing-hash-arg in a long term.  He wants to distinguish them mentally.  Rocket notation is not always related to kwargs while colon notation is tightly-connected, even though it is also used in hash literals.  When it comes to a method, calling a method with keyword-argument does not always create hashes.
 
-## \[Feature [#10121](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10121&sa=D&source=editors&ust=1686086705511783&usg=AOvVaw2CWloEnTUW57rX3YiKEMYU)\] Dir.empty?
+## \[Feature [#10121](https://bugs.ruby-lang.org/issues/10121)\] Dir.empty?
 
 - \`Dir.entries(dir).size == 2\` is not efficient.  Also not platform-agnostic.
 - It is useful to write spec which checkes test files are crrectly cleaned.
 - matz: accepted.
 
-## \[Feature [#12075](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12075&sa=D&source=editors&ust=1686086705512484&usg=AOvVaw25iObBfr2sd7KifOf3bhmz)\] some container#nonempty?
+## \[Feature [#12075](https://bugs.ruby-lang.org/issues/12075)\] some container#nonempty?
 
 - nobu: you can write \`ary&.empty?.!\`.
 - mrkn: How about \`ary.include\_something?\` ?
 
-## \[Feature [#12024](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12024&sa=D&source=editors&ust=1686086705513120&usg=AOvVaw1Zo9sI8prFc5nGZjFuy-s_)\] Add String.buffer, for creating strings with large capacities
+## \[Feature [#12024](https://bugs.ruby-lang.org/issues/12024)\] Add String.buffer, for creating strings with large capacities
 
-akr: Once matz rejected String.new(size) proposed on [#905](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/905&sa=D&source=editors&ust=1686086705513502&usg=AOvVaw3RgjT6X-ECMXTNHik4siRm), but now we have kwargs. given that there already is String.new with encoding argument, isn’t it OK to add kwargs to that method?
+akr: Once matz rejected String.new(size) proposed on [#905](https://bugs.ruby-lang.org/issues/905), but now we have kwargs. given that there already is String.new with encoding argument, isn’t it OK to add kwargs to that method?
 
 matz: accepted.
 
 ---
 
-## \[Bug [#11991](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11991&sa=D&source=editors&ust=1686086705514275&usg=AOvVaw08t6DX5V_-2CyuQP4Iqbaj)\] Symbol#match
+## \[Bug [#11991](https://bugs.ruby-lang.org/issues/11991)\] Symbol#match
 
-## \[Feature [#12043](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12043&sa=D&source=editors&ust=1686086705514677&usg=AOvVaw0GbqUB5qb_PISOcoNAxc57)\] NoMethodError#private\_call?
+## \[Feature [#12043](https://bugs.ruby-lang.org/issues/12043)\] NoMethodError#private\_call?
 
 bikeshed problem (naming issue).
 

--- a/2016/DevMeeting-2016-03-16.md
+++ b/2016/DevMeeting-2016-03-16.md
@@ -78,7 +78,7 @@ Attendees: Matz, ko1, nobu, akr, naruse, mrkn, shyouhei, sorah, martin, hsbt
 
 2016/04/13 13:00 @ Money Forward
 
-## \[[#10098](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10098&sa=D&source=editors&ust=1686086749385707&usg=AOvVaw3gQl6DSASHjZpH6FqabR-1)\] Timing-safe string comparison for OpenSSL::HMAC (naruse)
+## \[[#10098](https://bugs.ruby-lang.org/issues/10098)\] Timing-safe string comparison for OpenSSL::HMAC (naruse)
 
 - (n0kada) name not fixed.
 - Rack implements this in pure-ruby
@@ -115,7 +115,7 @@ Attendees: Matz, ko1, nobu, akr, naruse, mrkn, shyouhei, sorah, martin, hsbt
 
 - true/false.  -1/0/1 makes almost no sense for us.
 
-## \[Feature [#12125](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12125&sa=D&source=editors&ust=1686086749387714&usg=AOvVaw1RmQzK7XJ9pH-mn9-GH-3l)\] Proposal: Shorthand operator for Object#method (hsbt)
+## \[Feature [#12125](https://bugs.ruby-lang.org/issues/12125)\] Proposal: Shorthand operator for Object#method (hsbt)
 
 - (Matz) I want this. But all proposed syntax so far don’t feel right.
 
@@ -145,7 +145,7 @@ github.com/k-takata/Onigmo
 
 - Titlecase and String#swapcase
 
-- In unicode there is a special case called titlecase cf [http://unicode.org/faq/casemap\_charprop.html#4](https://www.google.com/url?q=http://unicode.org/faq/casemap_charprop.html%234&sa=D&source=editors&ust=1686086749389610&usg=AOvVaw2rYGkRgBgyzmT3DEJP2RMB)
+- In unicode there is a special case called titlecase cf [http://unicode.org/faq/casemap\_charprop.html#4](http://unicode.org/faq/casemap_charprop.html#4)
 - How should swapcase behave?
 - Or, how should swapcase behave in general?
 - Other languages:
@@ -156,16 +156,16 @@ github.com/k-takata/Onigmo
 
 - Matz: maybe it’s from Python.
 
-## \[Bug [#11844](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11844&sa=D&source=editors&ust=1686086749390459&usg=AOvVaw16uA5taQdhmoTNz9Vgd7sv)\] Please update unicode-licensed files (license issue) (shyouhei)
+## \[Bug [#11844](https://bugs.ruby-lang.org/issues/11844)\] Please update unicode-licensed files (license issue) (shyouhei)
 
 - This table was from NetBSD.
 - The table is a data, not an “expression of author” that a copyright should apply.
 - Is unicode’s license GPL compatible?
-- [http://www.unicode.org/Public/MAPPINGS/OBSOLETE/EASTASIA/JIS/JIS0212.TXT](https://www.google.com/url?q=http://www.unicode.org/Public/MAPPINGS/OBSOLETE/EASTASIA/JIS/JIS0212.TXT&sa=D&source=editors&ust=1686086749391389&usg=AOvVaw17T-y6qbEPj7KB7WXe_Yt1)
+- [http://www.unicode.org/Public/MAPPINGS/OBSOLETE/EASTASIA/JIS/JIS0212.TXT](http://www.unicode.org/Public/MAPPINGS/OBSOLETE/EASTASIA/JIS/JIS0212.TXT)
 - It seems unicode.org has version 2 of those files.
 - Lets update our copy to the latest ones.
 
-## \[Bug [#11816](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11816&sa=D&source=editors&ust=1686086749392092&usg=AOvVaw1xxbApCu-u3YUemDOxl810)\] Partial safe navigation operator (shyouhei)
+## \[Bug [#11816](https://bugs.ruby-lang.org/issues/11816)\] Partial safe navigation operator (shyouhei)
 
 - (shyouhei) current status?
 
@@ -184,7 +184,7 @@ github.com/k-takata/Onigmo
 - Swift : it does
 - C# : it does
 
-## \[Feature [#12142](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12142&sa=D&source=editors&ust=1686086749393326&usg=AOvVaw1AaoX14i5v0Cz35buX3WiS)\] Hash tables with open addressing (in particular, question about 32/64-bit indices) (duerst)
+## \[Feature [#12142](https://bugs.ruby-lang.org/issues/12142)\] Hash tables with open addressing (in particular, question about 32/64-bit indices) (duerst)
 
 - 4G entry hash is rare, but not an unrealistic thing in long term.
 - It is definitely a good thing to provide a fast alternative for 99% use case, however.
@@ -201,18 +201,18 @@ github.com/k-takata/Onigmo
 
 - Switch 16bit->32bit->64bit smoothly?
 
-## \[Feature [#12020](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12020&sa=D&source=editors&ust=1686086749394354&usg=AOvVaw3gt3G26r93I53vXFVANCvL)\] Documenting Ruby memory model (shyouhei)
+## \[Feature [#12020](https://bugs.ruby-lang.org/issues/12020)\] Documenting Ruby memory model (shyouhei)
 
 - Koichi is going to dump his opinion to reply the thread.
 - (Matz) I don’t want to bother such in-detail memory
 
-## \[Bug [#12039](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12039&sa=D&source=editors&ust=1686086749394879&usg=AOvVaw0z75YX3pZWFUyQpAVY_bRO)\] Fixnum#infinite?/Bignum#infinite or Numeric#infinte, consistent with Float#infinite? and BigDecimal#infinite? (shyouhei)
+## \[Bug [#12039](https://bugs.ruby-lang.org/issues/12039)\] Fixnum#infinite?/Bignum#infinite or Numeric#infinte, consistent with Float#infinite? and BigDecimal#infinite? (shyouhei)
 
 - For about JSON, #finite? (not #infinite?) is much better because JSON also has to reject NaNs.
 - (Matz) positive.  Float <-> Integer polymorphism is a good thing.
 - Add both #finite? and #infinite?
 
-## \[Feature [#12005](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12005&sa=D&source=editors&ust=1686086749395434&usg=AOvVaw1kskjs8XTbl6pZAo2WTRJs)\] Unify Fixnum and Bignum into Integer (shyouhei)
+## \[Feature [#12005](https://bugs.ruby-lang.org/issues/12005)\] Unify Fixnum and Bignum into Integer (shyouhei)
 
 - Nobody is negative.
 - Mrkn is assigned for this
@@ -244,15 +244,15 @@ github.com/k-takata/Onigmo
 - Normal pull-request is the ideal way.
 - We have to look at actual code to judge details.
 
-## \[Feature [#12026](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12026&sa=D&source=editors&ust=1686086749397324&usg=AOvVaw0i7CnH6SGeqsLohkcsZOtM)\] Support warning filters (jeremyevans0)
+## \[Feature [#12026](https://bugs.ruby-lang.org/issues/12026)\] Support warning filters (jeremyevans0)
 
-- This is related to [https://bugs.ruby-lang.org/issues/11588](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11588&sa=D&source=editors&ust=1686086749397623&usg=AOvVaw1cN4dG9I6nY6t0_JyMt8Y6)
+- This is related to [https://bugs.ruby-lang.org/issues/11588](https://bugs.ruby-lang.org/issues/11588)
 - (Matz) I thought structured warning was overkill.
 - (naruse) how about squashing all seen warning strings.
 - (ko1) regular expression seems too shortcoming.
 - (akr) It’s not a bad idea to provide a primitive to do something on warnings.
 
-## \[Feature [#12092](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12092&sa=D&source=editors&ust=1686086749398148&usg=AOvVaw0-5d2H0BhRBPIT3Q0sQCmy)\] Allow Object#clone to yield cloned object before freezing (jeremyevans0)
+## \[Feature [#12092](https://bugs.ruby-lang.org/issues/12092)\] Allow Object#clone to yield cloned object before freezing (jeremyevans0)
 
 - Use case?
 - There are two ways to create a cloned object, namely #clone and #dup.  The difference is singleton classes, and frozenness.
@@ -260,7 +260,7 @@ github.com/k-takata/Onigmo
 
 - That way you have to manage all and every calls to extend
 
-## \[Feature [#12172](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12172&sa=D&source=editors&ust=1686086749398897&usg=AOvVaw02l2H5DMfcQVHwXobncBnq)\] Array#max and Array#min (mame)
+## \[Feature [#12172](https://bugs.ruby-lang.org/issues/12172)\] Array#max and Array#min (mame)
 
 - Nobody is against Array#max
 - (shyouhei): Why only opt\_newarray\_max?
@@ -273,81 +273,81 @@ github.com/k-takata/Onigmo
 - Koichi afraids that increase VM complexity and other people want to add other methods.
 - However, \[...\].min or .max are used CPU intensive cases. So that it is acceptable. If other techniques are invented, then Koichi will remove them.
 
-## \[Feature [#9969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9969&sa=D&source=editors&ust=1686086749400255&usg=AOvVaw1-xxFcGwL56am8U9bmDqm2)\] Add File.empty? as alias to File.zero? (shyouhei)
+## \[Feature [#9969](https://bugs.ruby-lang.org/issues/9969)\] Add File.empty? as alias to File.zero? (shyouhei)
 
 - (akr) File.zero? is too bad in naming.
 - Nobody is against it.
 
-## \[Bug [#12121](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12121&sa=D&source=editors&ust=1686086749401020&usg=AOvVaw3M_bJtYIKCDK2sFXLuxlqP)\]異なる名前空間にある同名の定数により Module.constants の結果の並びが変わる (shyouhei)
+## \[Bug [#12121](https://bugs.ruby-lang.org/issues/12121)\]異なる名前空間にある同名の定数により Module.constants の結果の並びが変わる (shyouhei)
 
 - The reason behind this is we introduced id\_table, which does not preserve order.
 - We did not, and do not want to, warrant such thing.
 - This is a doc issue.
 
-## \[Bug [#12112](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12112&sa=D&source=editors&ust=1686086749401828&usg=AOvVaw0s5iqvyTKhTBUs-paF077a)\] Resolv.getname with IPv6 noop (shyouhei)
+## \[Bug [#12112](https://bugs.ruby-lang.org/issues/12112)\] Resolv.getname with IPv6 noop (shyouhei)
 
 - Assign to akr
 
-## \[Bug [#12162](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12162&sa=D&source=editors&ust=1686086749402193&usg=AOvVaw2EW29PspVdUKlYxhLSV93l)\] OpenSSL::PKCS7 seems to create broken objects (nested asn.1 error) (shyouhei)
+## \[Bug [#12162](https://bugs.ruby-lang.org/issues/12162)\] OpenSSL::PKCS7 seems to create broken objects (nested asn.1 error) (shyouhei)
 
 - Assign to openssl
 
-## \[Bug [#12091](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12091&sa=D&source=editors&ust=1686086749402717&usg=AOvVaw3HIgOZtFcRUEe2gdUpGkhR)\] Freezing a SortedSet breaks Enumerable (shyouhei)
+## \[Bug [#12091](https://bugs.ruby-lang.org/issues/12091)\] Freezing a SortedSet breaks Enumerable (shyouhei)
 
 - Assign to knu
 
-## \[Bug [#12126](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12126&sa=D&source=editors&ust=1686086749403177&usg=AOvVaw05YfpqKITgEluC9cjlnscr)\] \[PATCH\] openssl: accept moving write buffer for write\_nonblock (shyouhei)
+## \[Bug [#12126](https://bugs.ruby-lang.org/issues/12126)\] \[PATCH\] openssl: accept moving write buffer for write\_nonblock (shyouhei)
 
 - Seems ok
 
-## \[Feature [#10617](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10617&sa=D&source=editors&ust=1686086749403514&usg=AOvVaw0NRinVnaZlN_WbfSDI-s-j)\] Change multiple assignment in conditional from parse error to warning (shyouhei)
+## \[Feature [#10617](https://bugs.ruby-lang.org/issues/10617)\] Change multiple assignment in conditional from parse error to warning (shyouhei)
 
 - Koichi: i want to make it “void” expression for performance.
 
-## \[Feature [#12094](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12094&sa=D&source=editors&ust=1686086749403903&usg=AOvVaw3CkMAYaCjHXfkKVnFnZHXK)\] parameterized property assignment: o.prop(arg) = 1 (shyouhei)
+## \[Feature [#12094](https://bugs.ruby-lang.org/issues/12094)\] parameterized property assignment: o.prop(arg) = 1 (shyouhei)
 
 - Nobu is going to update the current status
 
-## \[Feature [#12096](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12096&sa=D&source=editors&ust=1686086749404418&usg=AOvVaw2kAoJyObz8orFKYWVwnKBI)\] New notation for instance variables and class variables (shyouhei)
+## \[Feature [#12096](https://bugs.ruby-lang.org/issues/12096)\] New notation for instance variables and class variables (shyouhei)
 
 - This is metaprogramming.  And having a metaprogramming in syntax is \`\`wrong’’.
 - Being able to write identical variable in different form is problematic (both for users and editors)
 
-## \[Bug [#12104](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12104&sa=D&source=editors&ust=1686086749404951&usg=AOvVaw1tIlTf9hjKSL-6moE5MIFZ)\] Procs keyword arguments affect value of previous argument (shyouhei)
+## \[Bug [#12104](https://bugs.ruby-lang.org/issues/12104)\] Procs keyword arguments affect value of previous argument (shyouhei)
 
 - Ko1 will update his current opinion.
 
-## \[Bug [#12106](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12106&sa=D&source=editors&ust=1686086749405301&usg=AOvVaw3Q5L0Q1a1iIEN3Y_643GWO)\] Behavior of double splatting of hashes with non symbol key is different according to splatted hash position (shyouhei)
+## \[Bug [#12106](https://bugs.ruby-lang.org/issues/12106)\] Behavior of double splatting of hashes with non symbol key is different according to splatted hash position (shyouhei)
 
 - Assign to nobu.
 
-## \[Feature [#11997](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11997&sa=D&source=editors&ust=1686086749405664&usg=AOvVaw0dsmBX-oWYpli8C2wOysAH)\] A method to read a file with interpolations (shyouhei)
+## \[Feature [#11997](https://bugs.ruby-lang.org/issues/11997)\] A method to read a file with interpolations (shyouhei)
 
 - Nobu thinks this is not that simple to do.  He will add comments about it.
 
-## \[Feature [#12116](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12116&sa=D&source=editors&ust=1686086749405996&usg=AOvVaw1YokowjdF-Yc_iBUXa3AQr)\] Fixnum#divmod, Bignum#divmod with multiple arguments (shyouhei)
+## \[Feature [#12116](https://bugs.ruby-lang.org/issues/12116)\] Fixnum#divmod, Bignum#divmod with multiple arguments (shyouhei)
 
 Good example.
 
-## \[Feature [#12119](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12119&sa=D&source=editors&ust=1686086749406346&usg=AOvVaw1tN_Pb7Vs61chUAm5QVBUY)\] next\_prime for lib/prime.rb (shyouhei)
+## \[Feature [#12119](https://bugs.ruby-lang.org/issues/12119)\] next\_prime for lib/prime.rb (shyouhei)
 
 - Assign to yugui.
 
-## \[Feature [#12134](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12134&sa=D&source=editors&ust=1686086749406676&usg=AOvVaw32rzs7n-ZaWamM9SZRgXY_)\] Comparison between true and false (shyouhei)
+## \[Feature [#12134](https://bugs.ruby-lang.org/issues/12134)\] Comparison between true and false (shyouhei)
 
 - Use partition method.
 
-## \[Feature [#11547](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11547&sa=D&source=editors&ust=1686086749407009&usg=AOvVaw0opqwtn90q0AxrIn-OlafZ)\] remove top-level constant lookup (shyouhei)
+## \[Feature [#11547](https://bugs.ruby-lang.org/issues/11547)\] remove top-level constant lookup (shyouhei)
 
 - Matz issue.
 
-## \[Misc [#12124](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12124&sa=D&source=editors&ust=1686086749407414&usg=AOvVaw17SN_kLETkHouu80-egV_V)\] Use Automake (shyouhei)
+## \[Misc [#12124](https://bugs.ruby-lang.org/issues/12124)\] Use Automake (shyouhei)
 
 - (naruse) common.mk is also used by nmake.
 - (naruse) Current patch fails CI.
 - Generally ok, but it must works with nmake.
 
-## \[Bug [#12139](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12139&sa=D&source=editors&ust=1686086749407947&usg=AOvVaw3ozVss_Ebnh2XfQPUY1e4J)\] return OpenSSL::Random.random\_bytes(n) call takes to long. OpenSSL:: bug on windows. (naruse)
+## \[Bug [#12139](https://bugs.ruby-lang.org/issues/12139)\] return OpenSSL::Random.random\_bytes(n) call takes to long. OpenSSL:: bug on windows. (naruse)
 
 - (naruse) How about using Random.naw\_seed on Windows
 - (akr) ok while it doesn’t cost too much entropy.

--- a/2016/DevMeeting-2016-04-13.md
+++ b/2016/DevMeeting-2016-04-13.md
@@ -74,7 +74,7 @@ Attendees: matz, sorah, naruse, ko1, mame, kosaki, hsbt, nobu, tarui, akr, shyou
 
 venue: TBD
 
-## \[Feature [#9969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9969&sa=D&source=editors&ust=1686086778188607&usg=AOvVaw1r1Ex8lWi1rHAWqywICQXs)\] Add File.empty? as alias to File.zero? (shyouhei)
+## \[Feature [#9969](https://bugs.ruby-lang.org/issues/9969)\] Add File.empty? as alias to File.zero? (shyouhei)
 
 (discussing about current behavior of related methods)
 
@@ -83,11 +83,11 @@ venue: TBD
 - matz: ok
 - kosaki: do you say “zero sized file”?
 
-## \[Feature [#10617](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10617&sa=D&source=editors&ust=1686086778189557&usg=AOvVaw3n9pUWMsFxA5DDKNUZfPip)\] Change multiple assignment in conditional from parse error to warning (shyouhei)
+## \[Feature [#10617](https://bugs.ruby-lang.org/issues/10617)\] Change multiple assignment in conditional from parse error to warning (shyouhei)
 
 - ko1: counter proposal. returning array can affect performance. how about to make mltiple assignment as a void expression?
 
-- example: [http://www.atdot.net/~ko1/diary/201502.html#d16](https://www.google.com/url?q=http://www.atdot.net/~ko1/diary/201502.html%23d16&sa=D&source=editors&ust=1686086778190126&usg=AOvVaw19YZbfs8LPRC7b-VT8S2vA)
+- example: [http://www.atdot.net/~ko1/diary/201502.html#d16](http://www.atdot.net/~ko1/diary/201502.html#d16)
 
 - naruse: I doubt the reporter’s true working code is
     a, b = some\_method\_returning\_array\_or\_nil
@@ -103,70 +103,70 @@ venue: TBD
 - ko1: i can’t understand what happen on it.
 - matz: I want to use it. accept.
 
-## \[Feature [#11547](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11547&sa=D&source=editors&ust=1686086778190922&usg=AOvVaw23JOvjx6EpwV97PrLIDc_j)\] remove top-level constant lookup (shyouhei)
+## \[Feature [#11547](https://bugs.ruby-lang.org/issues/11547)\] remove top-level constant lookup (shyouhei)
 
 - matz: lets try this to see how much codes break with it.
 
-## \[Feature [#12020](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12020&sa=D&source=editors&ust=1686086778191350&usg=AOvVaw3sgp2Ic24E2wWTSRAkYH5E)\] Documenting Ruby memory model (shyouhei)
+## \[Feature [#12020](https://bugs.ruby-lang.org/issues/12020)\] Documenting Ruby memory model (shyouhei)
 
-## \[Feature [#11210](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11210&sa=D&source=editors&ust=1686086778191764&usg=AOvVaw0PZ2mNK6EHchSdiUrieGvj)\] IPAddr has no public method to get the current subnet mask (eregon) Who can review this?
+## \[Feature [#11210](https://bugs.ruby-lang.org/issues/11210)\] IPAddr has no public method to get the current subnet mask (eregon) Who can review this?
 
 - assign to knu-san
 - naruse: mentioned to knu
 
-## \[Feature [#6647](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6647&sa=D&source=editors&ust=1686086778192280&usg=AOvVaw2LyPWo0K3jf04EyBzOokuo)\] Exceptions raised in threads should be logged, Thread#report\_on\_exception= (eregon) Can we agree on the feature?
+## \[Feature [#6647](https://bugs.ruby-lang.org/issues/6647)\] Exceptions raised in threads should be logged, Thread#report\_on\_exception= (eregon) Can we agree on the feature?
 
 Matz is positive to provide Thread#report\_on\_exception, but negative to turning it on by default.
 
-## \[Feature [#12026](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12026&sa=D&source=editors&ust=1686086778192918&usg=AOvVaw3YACU_CmKEFp9xMz9UatbE)\] Support warning processor
+## \[Feature [#12026](https://bugs.ruby-lang.org/issues/12026)\] Support warning processor
 
 - matz: agree with customizable warning
 
 - should not use global variables
 - there are many design choise. continue to discuss
 
-## \[Feature [#12092](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12092&sa=D&source=editors&ust=1686086778193591&usg=AOvVaw362zFI9yX5FLMBV39DlGEa)\] Allow Object#clone to yield cloned object before freezing (jeremyevans0)
+## \[Feature [#12092](https://bugs.ruby-lang.org/issues/12092)\] Allow Object#clone to yield cloned object before freezing (jeremyevans0)
 
-## \[Feature #[12217](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12217&sa=D&source=editors&ust=1686086778193978&usg=AOvVaw3vSDoLPRbhD2p4nLs74xyZ)\] Introducing Enumerable#sum for precision compensated summation and revert r54237 (mrkn)
+## \[Feature #[12217](https://bugs.ruby-lang.org/issues/12217)\] Introducing Enumerable#sum for precision compensated summation and revert r54237 (mrkn)
 
 - matz: Adding Array#sum is ok
 - Revert r54237 and optimization for Float
 
-## \[Bug [#12271](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12271&sa=D&source=editors&ust=1686086778194538&usg=AOvVaw14yLnN2YsYcx4sZVUj1FC2)\] Time#to\_time removes timezone information
+## \[Bug [#12271](https://bugs.ruby-lang.org/issues/12271)\] Time#to\_time removes timezone information
 
 - nobu: It is a bug, so I commited
 - yui\_knk: ActiveSupport was testing this behavior (FYI)
 
-## \[Feature [#12157](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12157&sa=D&source=editors&ust=1686086778195148&usg=AOvVaw1dkXIbSX_4tem_kgHpAXSQ)\] Is the option hash necessary for future Rubys?
+## \[Feature [#12157](https://bugs.ruby-lang.org/issues/12157)\] Is the option hash necessary for future Rubys?
 
 - We have no matz for time when discussed this issue, so pend until next meeting.
 
-## \[Bug [#12181](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12181&sa=D&source=editors&ust=1686086778195586&usg=AOvVaw1BeuIWyT45sBg25ws4uD3S)\] ブロックがたくさんあるファイルを編集するとruby-modeが重い
+## \[Bug [#12181](https://bugs.ruby-lang.org/issues/12181)\] ブロックがたくさんあるファイルを編集するとruby-modeが重い
 
 - Who can look this issue? Nobu?
 - nobu will investigate and make some action.
 
-## \[Bug [#12179](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12179&sa=D&source=editors&ust=1686086778196151&usg=AOvVaw08pK7nXdMKrpaJuSTVU5AL)\] Build failure due to VPATH expansion
+## \[Bug [#12179](https://bugs.ruby-lang.org/issues/12179)\] Build failure due to VPATH expansion
 
 - Weird. Nobu will investigate.
 
-## \[Bug [#12183](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12183&sa=D&source=editors&ust=1686086778196632&usg=AOvVaw1ZRuU3ajsZH3ZM6ge0ztga)\] require "win32ole" すると終了ステータスが必ず 0 になる
+## \[Bug [#12183](https://bugs.ruby-lang.org/issues/12183)\] require "win32ole" すると終了ステータスが必ず 0 になる
 
 - Assigned to appropriate maintainer.
 
-## \[Bug [#12184](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12184&sa=D&source=editors&ust=1686086778197108&usg=AOvVaw2ki9AJmCdWLvAWlPcQIXih)\] Cygwin LANG=ja\_JP.SJIS 環境でコマンドライン引数に日本語が渡せない
+## \[Bug [#12184](https://bugs.ruby-lang.org/issues/12184)\] Cygwin LANG=ja\_JP.SJIS 環境でコマンドライン引数に日本語が渡せない
 
 - nobu: Cygwin only supports UTF-8
 - nobu(?) will reply something
 
-## \[Feature [#7361](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7361&sa=D&source=editors&ust=1686086778197739&usg=AOvVaw1lOc3i9xapIXK_UJqVFcTX)\] Adding Pathname#touch
+## \[Feature [#7361](https://bugs.ruby-lang.org/issues/7361)\] Adding Pathname#touch
 
 - actually touch(1) does lot of thing. What ticket author wanted?
 - Encourage author to make feature request more solid.
 
-## \[Feature [#12236](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12236&sa=D&source=editors&ust=1686086778198454&usg=AOvVaw2_LsdmZvTnMTxkHk7wry8o)\] Introduce mmap managed heap (ko1)
+## \[Feature [#12236](https://bugs.ruby-lang.org/issues/12236)\] Introduce mmap managed heap (ko1)
 
-## \[Feature [#11925](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11925&sa=D&source=editors&ust=1686086778199160&usg=AOvVaw1AZQHGNpNQdwtjEo11lP0o)\] Struct construction with kwargs (ko1)
+## \[Feature [#11925](https://bugs.ruby-lang.org/issues/11925)\] Struct construction with kwargs (ko1)
 
 - Understood and +1 for this feature, but maybe naming is a problem
 - We also have to wait a Matz.
@@ -183,4 +183,4 @@ Matz is positive to provide Thread#report\_on\_exception, but negative to turnin
 
 \[FYI\] Cookpad’s styleguide of the number of characters in a line:
 
-[https://github.com/cookpad/styleguide/blob/master/ruby.ja.md#line-columns](https://www.google.com/url?q=https://github.com/cookpad/styleguide/blob/master/ruby.ja.md%23line-columns&sa=D&source=editors&ust=1686086778200683&usg=AOvVaw2sHrDB0U7tanU_UU1HpRMh)
+[https://github.com/cookpad/styleguide/blob/master/ruby.ja.md#line-columns](https://github.com/cookpad/styleguide/blob/master/ruby.ja.md#line-columns)

--- a/2016/DevMeeting-2016-05-17.md
+++ b/2016/DevMeeting-2016-05-17.md
@@ -105,17 +105,17 @@ Milestones
 - previrew 1 maybe?  Then we can call for slides.
 - conclusion: Next meeting will confirm to release preview1
 
-## \[Feature [#12324](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12324&sa=D&source=editors&ust=1686086801763960&usg=AOvVaw2GnnN2YH_EDRwNAaeZh_vJ)\] Support OpenSSL 1.1.0 (and drop support for 0.9.6/0.9.7) (hsbt) We need to get aproval of Matz
+## \[Feature [#12324](https://bugs.ruby-lang.org/issues/12324)\] Support OpenSSL 1.1.0 (and drop support for 0.9.6/0.9.7) (hsbt) We need to get aproval of Matz
 
 - matz: OK to give him a commit grant.
 - compatibility? is it OK to drop OpenSSL < 1.0?
 - hsbt: we need to describe maintainer policy:
 
-[https://bugs.ruby-lang.org/projects/ruby/wiki/DeveloperHowtoJa](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby/wiki/DeveloperHowtoJa&sa=D&source=editors&ust=1686086801764565&usg=AOvVaw1QgCVlxhODutt2HAXy0fFK)
+[https://bugs.ruby-lang.org/projects/ruby/wiki/DeveloperHowtoJa](https://bugs.ruby-lang.org/projects/ruby/wiki/DeveloperHowtoJa)
 
 - introduce ruby/openssl subproject goal and status.
 
-## \[Misc [#12283](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12283&sa=D&source=editors&ust=1686086801764860&usg=AOvVaw08c2xBuImeNrckn5RGNWIv)\] Obsolete ChangeLog and commit message in Git-style (shyouhei)
+## \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei)
 
 - (shyouhei) seems nobody is against.
 - (Martin) I support it.
@@ -126,11 +126,11 @@ Milestones
 - (conclusion) lets auto-generate ChangeLog, like we do in version.h.
 - nobu and naruse will look at it.
 
-## \[Feature [#12352](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12352&sa=D&source=editors&ust=1686086801765554&usg=AOvVaw3L6-4ykRB0bozIpq8wLeJg)\] New hash syntax broken for numeric keys (shyouhei)
+## \[Feature [#12352](https://bugs.ruby-lang.org/issues/12352)\] New hash syntax broken for numeric keys (shyouhei)
 
 - matz: reject.  If this syntax is allowed { 1: 2 } should be considered { :’1’ => 2 }.
 
-## \[Feature [#6647](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6647&sa=D&source=editors&ust=1686086801765965&usg=AOvVaw1CN_huQqOaw5vopE51EFrh)\] Exceptions raised in threads should be logged (shyouhei) what was the reason against defaulting true?
+## \[Feature [#6647](https://bugs.ruby-lang.org/issues/6647)\] Exceptions raised in threads should be logged (shyouhei) what was the reason against defaulting true?
 
 - Thread\[.#\]report\_on\_exception= is accepted
 - Matz does not want this default true, because it breaks current situations where programmer expects dead threads to silently exit.
@@ -138,7 +138,7 @@ Milestones
 
 - Threads dead before join shall report exceptions.  If that is not a desired behaviour, explicitly set false.
 
-## \[Feature [#12244](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12244&sa=D&source=editors&ust=1686086801766558&usg=AOvVaw1rDtSCTYABrkgKHoUXAtcr)\] Add a way to integer - integer % num (shyouhei)
+## \[Feature [#12244](https://bugs.ruby-lang.org/issues/12244)\] Add a way to integer - integer % num (shyouhei)
 
 - shyouhei: it’s slow.
 - ko1: you can speed this up by dispatch in Ruby, say, in prelude.
@@ -146,7 +146,7 @@ Milestones
 - matz: API OK, speed concern.
 - ko1: @naruse please show us speed comparison.
 
-## \[Feature [#12005](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12005&sa=D&source=editors&ust=1686086801767324&usg=AOvVaw3On1tXiL_wjCfgud-opkUk)\] Unify Fixnum and Bignum into Integer (naruse,mrkn,akr)
+## \[Feature [#12005](https://bugs.ruby-lang.org/issues/12005)\] Unify Fixnum and Bignum into Integer (naruse,mrkn,akr)
 
 - akr: there is only one problem for this: do this now, or don’t.
 - pros/cons:
@@ -156,12 +156,12 @@ Milestones
 
 - matz: let’s try.
 
-## \[Bug [#12337](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12337&sa=D&source=editors&ust=1686086801768213&usg=AOvVaw03qVnOzwZVbJ7emnr4c4Rb)\] inconsistency between Fixnum#coerce and Bignum#coerce (akr)
+## \[Bug [#12337](https://bugs.ruby-lang.org/issues/12337)\] inconsistency between Fixnum#coerce and Bignum#coerce (akr)
 
 - Matz: TypeError was an intended behavior, to prevent data loss.  So no need to backport this behaviour to previous releases.
 - But as we try Fixnunm/Bignum unification, things gets much simpler.
 
-## \[Feature [#10548](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10548&sa=D&source=editors&ust=1686086801768965&usg=AOvVaw3Z0Ltp8x0wC8MOUw5MPaEg)\] remove callcc (hsbt)
+## \[Feature [#10548](https://bugs.ruby-lang.org/issues/10548)\] remove callcc (hsbt)
 
 - hsbt: current status?
 - ko1: we historically tried callcc but was not successful.  The intension of this issue is we wish to treat callcc-related issues to be 3rd-party issue.
@@ -176,16 +176,16 @@ Milestones
 - hsbt: will look for a way to prevent assignment.
 - Yui changed all “Assignee: ruby-core” to “Assignee: nobody” with a global operation. Thanks! But this doesn’t yet prevent future assignments.
 
-## \[Feature [#12263](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12263&sa=D&source=editors&ust=1686086801769875&usg=AOvVaw1sYflZ4K1B3A8hoMaCIJsi)\] Feature request: &&. operator (shorthand for foo && foo.method) (shyouhei)
+## \[Feature [#12263](https://bugs.ruby-lang.org/issues/12263)\] Feature request: &&. operator (shorthand for foo && foo.method) (shyouhei)
 
 - matz: example seems illustrative.  any real-world use-case?
 
-## \[Bug [#4388](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4388&sa=D&source=editors&ust=1686086801770265&usg=AOvVaw2QwktX9Z-wvZxMCfb60ktg)\] open-uriで環境変数http\_proxyを使うときに認証付きのProxyが使えません
+## \[Bug [#4388](https://bugs.ruby-lang.org/issues/4388)\] open-uriで環境変数http\_proxyを使うときに認証付きのProxyが使えません
 
 - akr: hsbt already introduced this at r54432.
 - lets ask if trunk is ok.
 
-## \[Feature [#5899](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5899&sa=D&source=editors&ust=1686086801770708&usg=AOvVaw2bCofo1kjPawWj7mpoSQWA)\] chaining comparisons
+## \[Feature [#5899](https://bugs.ruby-lang.org/issues/5899)\] chaining comparisons
 
 - Hmm.
 - This is about language design.  Matz should decide.
@@ -196,21 +196,21 @@ Milestones
 
 - Matz: doesn’t sould yummy.
 
-## \[Feature [#12157](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12157&sa=D&source=editors&ust=1686086801771599&usg=AOvVaw2RmEWhMPoPgdg9K1CCTa8y)\] Is the option hash necessary for future Rubys? (shyouhei)
+## \[Feature [#12157](https://bugs.ruby-lang.org/issues/12157)\] Is the option hash necessary for future Rubys? (shyouhei)
 
 - Matz: positive.  It is good in long term
 - akr: migration path?
 
 - warning when a kwargs-called method receives that in option hash.
 
-## \[Feature [#11925](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11925&sa=D&source=editors&ust=1686086801772138&usg=AOvVaw21m6Sazf1G-4L5R5WzUrBz)\] Struct construction with kwargs (ko1)
+## \[Feature [#11925](https://bugs.ruby-lang.org/issues/11925)\] Struct construction with kwargs (ko1)
 
 - convenient, but is #create an appropriate name?
 - no one is against? (except naming)
 - nobu: Hash#to\_struct(klass)
 - create! doesnt follow naming convention.
 
-## \[Feature [#6739](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6739&sa=D&source=editors&ust=1686086801772792&usg=AOvVaw26uC9J02HloGnXbYoPWIVh)\] One-line rescue statement should support specifying an exception class
+## \[Feature [#6739](https://bugs.ruby-lang.org/issues/6739)\] One-line rescue statement should support specifying an exception class
 
 - no good syntax so far.
 - nobu: all the proposed syntax, except for rescue when, generated syntx conflicts.
@@ -218,18 +218,18 @@ Milestones
 - naruse: practical use case is io.close rescue nil
 - mrkn: another real world application is if expr resuce false
 
-## \[Feature [#7314](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7314&sa=D&source=editors&ust=1686086801773502&usg=AOvVaw3GjaEkAYxJ1bO_4XzCBw33)\] Convert Proc to Lambda doesn't work in MRI
+## \[Feature [#7314](https://bugs.ruby-lang.org/issues/7314)\] Convert Proc to Lambda doesn't work in MRI
 
 - The current behaviour is not “unpredictable” in a sense.
 
-## \[Feature [#8895](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8895&sa=D&source=editors&ust=1686086801773816&usg=AOvVaw3JW7_-mcdV6FMhJ5oHSZr4)\] Destructuring Assignment for Hash
+## \[Feature [#8895](https://bugs.ruby-lang.org/issues/8895)\] Destructuring Assignment for Hash
 
 - ko1: elixir does this.
 - shyouhei: maybe 99% use case of hash destruction was already solved by kwargs?
 - akr: the OP propses use case with MatchData.
 - matz: reject this specific one
 
-## \[Bug [#10708](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10708&sa=D&source=editors&ust=1686086801774320&usg=AOvVaw2VPl0imIfs46oRebR7XEwG)\] In a function call, double splat of an empty hash still calls the function with an argument
+## \[Bug [#10708](https://bugs.ruby-lang.org/issues/10708)\] In a function call, double splat of an empty hash still calls the function with an argument
 
 - This is a side-effect of optional hash argument treatment.
 - akr: this should be fixed by abondoning optional hash.
@@ -239,7 +239,7 @@ Milestones
 ## Oniguruma and/or Onigumo situations? (duerst)
 
 - Duerst: oniguruma has updates.
-- naruse: I hadn’t know Oniguruma is on GitHub now [https://github.com/kkos/oniguruma](https://www.google.com/url?q=https://github.com/kkos/oniguruma&sa=D&source=editors&ust=1686086801774940&usg=AOvVaw2hC4rXiREAKvSrZHfL_4Rv). I’ll check it.
+- naruse: I hadn’t know Oniguruma is on GitHub now [https://github.com/kkos/oniguruma](https://github.com/kkos/oniguruma). I’ll check it.
 
 ## \[Bug #12368\] default encoding of Integer#chr
 
@@ -248,21 +248,21 @@ Milestones
 - naruse: script encoding doesn’t work well if the code uses variables.
 - naruse will think about it a bit more.
 
-## \[Feature [#12306](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12306&sa=D&source=editors&ust=1686086801775501&usg=AOvVaw2wiXXqfWSOkhF25_4jVrof)\] Object/String#blank (duerst)
+## \[Feature [#12306](https://bugs.ruby-lang.org/issues/12306)\] Object/String#blank (duerst)
 
-- akr: regexp match without object allocation can be an alternative. (see #[8110](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8110&sa=D&source=editors&ust=1686086801775748&usg=AOvVaw35IGX11fZf_5r8SoTc1NHi))
+- akr: regexp match without object allocation can be an alternative. (see #[8110](https://bugs.ruby-lang.org/issues/8110))
 - akr: How about the name Regexp#match?(str)
 - naruse: blank can be special-cased to be even faster.
 - naruse will write an implementation
 - matz isn’t very positive, but may be okay for String only (for other classes, this will remain the responsibility of Rails)
 
-## \[Feature [#8110](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8110&sa=D&source=editors&ust=1686086801776426&usg=AOvVaw1_dlp4bXoHfJA-j9GCzhNk)\] Regex methods not changing global variables (akr)
+## \[Feature [#8110](https://bugs.ruby-lang.org/issues/8110)\] Regex methods not changing global variables (akr)
 
 - matz: approved.
 - implementation is very easy
 - name: “match?” ?
 
-## \[Feature [#12075](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12075&sa=D&source=editors&ust=1686086801777056&usg=AOvVaw1GBR4zE1XPKwCN-wIbhCo6)\] some container#nonempty? (naruse)
+## \[Feature [#12075](https://bugs.ruby-lang.org/issues/12075)\] some container#nonempty? (naruse)
 
 - matz: I want this in ActiveSupport.
 - matz: Enumerable#any? seems useful.
@@ -278,7 +278,7 @@ Milestones
 
 - matz: OK.
 
-## \[Feature [#12357](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12357&sa=D&source=editors&ust=1686086801778120&usg=AOvVaw1jtU57mVVgA9cbF7G606Rx)\] Random#initialize with a String (nobu)
+## \[Feature [#12357](https://bugs.ruby-lang.org/issues/12357)\] Random#initialize with a String (nobu)
 
 - akr: you can pass bignum to Random.new\_seed
 - naruse: bignum is not useful when people port code from different languages e.g. python
@@ -294,7 +294,7 @@ Milestones
 - nobu: I intend MT and
 - akr: how about split utility methods into a module
 
-## \[Feature [#11735](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11735&sa=D&source=editors&ust=1686086801779323&usg=AOvVaw0Cx7bjFPyikO53rk2nUATy)\] String#squish and String#squish!
+## \[Feature [#11735](https://bugs.ruby-lang.org/issues/11735)\] String#squish and String#squish!
 
 - shyouhei: useful when writing a long SQL
 - nobu: is this unicode aware?

--- a/2016/DevMeeting-2016-06-13.md
+++ b/2016/DevMeeting-2016-06-13.md
@@ -86,7 +86,7 @@ Attendees: Matz (remote), Koichi Sasada, Nobu(yoshi) Nakada, Shyouhei Urabe (hos
 
 ## GSoC achievements report (ko1, Horie-san)
 
-Link to [project description](https://www.google.com/url?q=https://summerofcode.withgoogle.com/organizations/5749695703941120/%234576418910437376&sa=D&source=editors&ust=1686086826654098&usg=AOvVaw0g14O4pYXW3Xk7FNOD5oEI) ([Automatic-selection mechanism for data structures in MRI](https://www.google.com/url?q=https://summerofcode.withgoogle.com/projects/%234576418910437376&sa=D&source=editors&ust=1686086826654469&usg=AOvVaw3wp5-EcpoTD01XEoRYe2hc)). Koichi is a mentor. Report: Started to implement String using Rope. Showing some performance results of initial experiments.
+Link to [project description](https://summerofcode.withgoogle.com/organizations/5749695703941120/#4576418910437376) ([Automatic-selection mechanism for data structures in MRI](https://summerofcode.withgoogle.com/projects/#4576418910437376)). Koichi is a mentor. Report: Started to implement String using Rope. Showing some performance results of initial experiments.
 
 Discussion of suitable application benchmarks, possible problems with implementation,...
 
@@ -106,7 +106,7 @@ This release doesn’t prevent further big changes for Ruby 2.4.
 
 (This release is different from an usual preview1 (even more ‘previewy’))
 
-## \[Misc [#12283](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12283&sa=D&source=editors&ust=1686086826655925&usg=AOvVaw1V_E-bm4yWtswMJZVEpfua)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
+## \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 
 Any progress? → Nothing
 
@@ -119,7 +119,7 @@ A: Use empty commit.
 # How to handle security issues (shugo)
 
 - Pros./Cons. about using GitHub, Slack, HackerOne and etc.
-- Aaron proposed [HackerOne](https://www.google.com/url?q=https://hackerone.com/&sa=D&source=editors&ust=1686086826656926&usg=AOvVaw2y0HYccn4wVgP7bYHoMjod) which is a specialized Web site to discuss security issues. In particular, it doesn’t include actual contents in email notifications, …, and also has a system for bounties.
+- Aaron proposed [HackerOne](https://hackerone.com/) which is a specialized Web site to discuss security issues. In particular, it doesn’t include actual contents in email notifications, …, and also has a system for bounties.
 - We can’t stop Mail address.
 - Current issue
 
@@ -129,7 +129,7 @@ A: Use empty commit.
 - Try this service.
 - Should we decide whether reports are eligible for bounty?
 
-## \[Feature [#12333](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12333&sa=D&source=editors&ust=1686086826657701&usg=AOvVaw1FvhwrnKWfgcUzKqYPJjgs)\] String#concat, Array#concat, String#prepend to take multiple arguments (shyouhei)
+## \[Feature [#12333](https://bugs.ruby-lang.org/issues/12333)\] String#concat, Array#concat, String#prepend to take multiple arguments (shyouhei)
 
 matz: acceptable
 
@@ -160,16 +160,16 @@ ary.delete(:a, :f, :c) #=> ???
 - x, y, z = ary.delete(:a, :f, :c)
 - Especially for Hash#delete (this is out of scope, but we should consier consistency)
 
-## \[Bug [#12295](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12295&sa=D&source=editors&ust=1686086826660239&usg=AOvVaw0hwar7O_qyBzkPdBFgwA9x)\] Ripper not emitting on\_parse\_error for global variable name syntax errors (shyouhei) is this the right design?
+## \[Bug [#12295](https://bugs.ruby-lang.org/issues/12295)\] Ripper not emitting on\_parse\_error for global variable name syntax errors (shyouhei) is this the right design?
 
 Assigned to Minero Aoki.
 
-## \[Feature [#12484](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12484&sa=D&source=editors&ust=1686086826660784&usg=AOvVaw1uo8Lg46TRKmVwMIusOdkT)\] Optimizing Rational (hsbt, mrkn)
+## \[Feature [#12484](https://bugs.ruby-lang.org/issues/12484)\] Optimizing Rational (hsbt, mrkn)
 
 - matz approved to add commit permission to Tadashi-san.
 - mrkn will reivew the proposed patch
 
-## \[Feature [#12281](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12281&sa=D&source=editors&ust=1686086826661465&usg=AOvVaw2dEZ2PXv_iAmh6mgKgRRd5)\] Allow lexically scoped use of refinements with using {} block syntax (shyouhei)
+## \[Feature [#12281](https://bugs.ruby-lang.org/issues/12281)\] Allow lexically scoped use of refinements with using {} block syntax (shyouhei)
 
 Assigned to shugo.
 
@@ -181,7 +181,7 @@ Motivation is replace self and using context.
 
 Matz will comment it.
 
-## \[Feature [#12447](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12447&sa=D&source=editors&ust=1686086826662909&usg=AOvVaw2ZpI0-lpWz4qDN0qZ74i3a)\] Integer#digits for extracting digits of place-value notation in any base (mrkn)
+## \[Feature [#12447](https://bugs.ruby-lang.org/issues/12447)\] Integer#digits for extracting digits of place-value notation in any base (mrkn)
 
 - Q. Endian? #=> Little endian
 - Q. how about negative integers? #=> Math::DomainError
@@ -189,7 +189,7 @@ Matz will comment it.
 
 matz: i’m not sure how it is convinience. but ok.
 
-## \[Feature [#12299](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12299&sa=D&source=editors&ust=1686086826664297&usg=AOvVaw313x6w3Lpw3IeQbvNFuWT4)\] Add Warning module for customized warning handling (jeremyevans)
+## \[Feature [#12299](https://bugs.ruby-lang.org/issues/12299)\] Add Warning module for customized warning handling (jeremyevans)
 
 naruse: it sounds useful with Gem.loaded\_specs\[ gem\_name \].full\_gem\_path.
 
@@ -197,17 +197,17 @@ matz: ok (except naming).
 
 # Supported Platforms (duerst)
 
-h[ttps://bugs.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms&sa=D&source=editors&ust=1686086826666672&usg=AOvVaw3V0qvcsp0fuYrQ2ZFHMHks) says it’s for Ruby 1.9; needs some updating.
+h[ttps://bugs.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms) says it’s for Ruby 1.9; needs some updating.
 
-## \[Feature [#12460](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12460&sa=D&source=editors&ust=1686086826667695&usg=AOvVaw2o73k2frUa5OTnCGcJT7Oa)\] Make Unicode Version directly available in Ruby (duerst)
+## \[Feature [#12460](https://bugs.ruby-lang.org/issues/12460)\] Make Unicode Version directly available in Ruby (duerst)
 
 Approved; name as proposed by Nobu: RbConfig::CONFIG\['UNICODE\_VERSION'\]; implementation: Nobu or Martin.
 
 # Non-ASCII in rdoc comments in C source (duerst)
 
-See [https://github.com/rdoc/rdoc/issues/409](https://www.google.com/url?q=https://github.com/rdoc/rdoc/issues/409&sa=D&source=editors&ust=1686086826669415&usg=AOvVaw2EhluWwZ8TBFyBzz6e43aB). Intent is understandable. May work by just using &#(x)... HTML/XML convention; needs to be checked further.
+See [https://github.com/rdoc/rdoc/issues/409](https://github.com/rdoc/rdoc/issues/409). Intent is understandable. May work by just using &#(x)... HTML/XML convention; needs to be checked further.
 
-## \[Bug [#12427](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12427&sa=D&source=editors&ust=1686086826670082&usg=AOvVaw1Vu8MUVbVbsHHXmO7xY7ib)\] the way that extension libraries know if Integer is integrated (nobu)
+## \[Bug [#12427](https://bugs.ruby-lang.org/issues/12427)\] the way that extension libraries know if Integer is integrated (nobu)
 
 Nobu prepared a patch to show warning for rb\_cFixnum and rb\_cBignum, so developers can recognize this change. However, there are risks to compile broken code (assume passed parameters are Fixnum, but passed BIgnums. In this case, it is difficult to check Fixnum asusmed methods because Bignum may be rare to use, in general).
 

--- a/2016/DevMeeting-2016-07-19.md
+++ b/2016/DevMeeting-2016-07-19.md
@@ -120,10 +120,10 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - sorah:
 
 - It would be useful if binary packages for latest/preview ruby versions were available for some distros. But it would take extra cost to release if we supported them officially.
-- For example, I’m maintaining a Debian package for ruby for my company, and recently moved and open sourced [https://github.com/sorah-rbpkg](https://www.google.com/url?q=https://github.com/sorah-rbpkg&sa=D&source=editors&ust=1686086850665844&usg=AOvVaw2-Phy044TkZ_Btx2qreBoK). I’m currently hosting a debian repository in S3 and upload a deb file to GitHub. I guess other committers are maintaining binary packages for latest releases in-house.
+- For example, I’m maintaining a Debian package for ruby for my company, and recently moved and open sourced [https://github.com/sorah-rbpkg](https://github.com/sorah-rbpkg). I’m currently hosting a debian repository in S3 and upload a deb file to GitHub. I guess other committers are maintaining binary packages for latest releases in-house.
 - Distributing a large file could have bandwidth cost. For Ruby project, we have a Fastly (CDN) account with the OSS plan, so we can use CDN for free.
 - So some committers would be happy if they can use our Fastly account. To do so, I think a distributed package should be distributed by the Ruby core team, not an individual committer.
-- But as I wrote earlier, it would take extra cost to release it as supported. I don’t think it’s good to require extra “sync” for all binary package maintainers when releasing new package. [Like tier-N (N>0) platform,](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms&sa=D&source=editors&ust=1686086850666431&usg=AOvVaw2XLnXj8hOxFSeCW-u4Ytmv) can we release binary packages w/o full support?
+- But as I wrote earlier, it would take extra cost to release it as supported. I don’t think it’s good to require extra “sync” for all binary package maintainers when releasing new package. [Like tier-N (N>0) platform,](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms) can we release binary packages w/o full support?
 - I’m not clear what “support” means, but if we distribute binary packages, we will see some bug reports on a package on bugs.r-l.o. We should decide how we would respond to them.
 
 - it’s a good idea to have such a package.
@@ -138,7 +138,7 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 
 - Call for Feature Proposals? (shyouhei)
 
-- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24&sa=D&source=editors&ust=1686086850667533&usg=AOvVaw02s_bTGarog6LHCsomwHjO)
+- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24)
 
 - Lets do it. (shyouhei)
 
@@ -146,72 +146,72 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 
 - ToDo
 
-- \[Feature [#8526](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8526&sa=D&source=editors&ust=1686086850668026&usg=AOvVaw0EDSVK_ZtgQsOi6Kir8LWE)\] gemify tk (hsbt)
+- \[Feature [#8526](https://bugs.ruby-lang.org/issues/8526)\] gemify tk (hsbt)
 
 ## Carry-over from previous meeting(s)
 
-- \[Misc [#12283](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12283&sa=D&source=editors&ust=1686086850668487&usg=AOvVaw2OH2Kr1vgcm6QzrKcOXSM_)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
+- \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 
 - naruse: no progress.
 - Martin: PLEASE DO!
 
-- \[Feature [#12299](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12299&sa=D&source=editors&ust=1686086850668926&usg=AOvVaw2jYGTuYaGSPUM7Z2Tro5lw)\] Add Warning module for customized warning handling (jeremyevans)
+- \[Feature [#12299](https://bugs.ruby-lang.org/issues/12299)\] Add Warning module for customized warning handling (jeremyevans)
 
 - no progress this month.
 - \---- update: read again.
 - matz: I read the new patch. the implementation seems fine (not sure about the constant name, but the clear separation between core and lib is good).  Is Daniel OK wih this?  I don’t have strong negative feeling to it.
 
-- \[Feature [#12300](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12300&sa=D&source=editors&ust=1686086850669539&usg=AOvVaw0Dj0E4fNCBdKtgm_JObd2f)\] Allow Object#clone to take freeze: false keyword argument to not freeze the clone (jeremyevans)
+- \[Feature [#12300](https://bugs.ruby-lang.org/issues/12300)\] Allow Object#clone to take freeze: false keyword argument to not freeze the clone (jeremyevans)
 
 - shyouhei: no objection.
 - nobu: me too.
-- akr: this one is preferrable over [#12092](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12092&sa=D&source=editors&ust=1686086850670103&usg=AOvVaw37f7wX3fUFTBAv4FPok9SF)
+- akr: this one is preferrable over [#12092](https://bugs.ruby-lang.org/issues/12092)
 - matz: sounds reasonable.
 
-- \[Feature [#11090](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11090&sa=D&source=editors&ust=1686086850670446&usg=AOvVaw3UAFo8ykTnp_RNxJlw8N_n)\] Enumerable#each\_uniq and #each\_uniq\_by (shyouhei)
+- \[Feature [#11090](https://bugs.ruby-lang.org/issues/11090)\] Enumerable#each\_uniq and #each\_uniq\_by (shyouhei)
 
 - akr: the definition of uniq is not clear here.
 - Martin: where is the difference between each\_uniq and each.uniq ?
 - mrkn: Enumerable has no #uniq now.  Isn’t this a problem?
 - matz: Enumerable#uniq sounds reasonable, also Lasy#uniq.
 
-- \[Feature [#12275](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12275&sa=D&source=editors&ust=1686086850671148&usg=AOvVaw2ngXjYe6b7mQbjRvpKodfR)\] String unescape (shyouhei) lets limit the scope to "invert #dump's effect"
+- \[Feature [#12275](https://bugs.ruby-lang.org/issues/12275)\] String unescape (shyouhei) lets limit the scope to "invert #dump's effect"
 
 - akr: thing like this is a good thing to have.
 - Martin: is there a in-core routine to do this already?
 - naruse: no.
 - akr: name? why not undump ?
 
-- \[Feature [#12345](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12345&sa=D&source=editors&ust=1686086850671702&usg=AOvVaw1mktPVnJ7_OTopp6kBNuq1)\] A module's private constants are given with Module#constant(false) (shyouhei) intended behaviour?
+- \[Feature [#12345](https://bugs.ruby-lang.org/issues/12345)\] A module's private constants are given with Module#constant(false) (shyouhei) intended behaviour?
 
 - shyouhei: is this a bug?
 - matz: yes.
 
-- \[Feature [#12138](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12138&sa=D&source=editors&ust=1686086850672133&usg=AOvVaw0RL2foc3lFTUdfey915jfQ)\] Support Kernel#load\_with\_env (shyouhei)
+- \[Feature [#12138](https://bugs.ruby-lang.org/issues/12138)\] Support Kernel#load\_with\_env (shyouhei)
 
 - shyouhei: I understand the needs of such feature, but not this name.
 - ko1: maybe the OP wants C’s #include<...> like token pasting?
 - matz: this name is NG, the passed context info is not sure, and use case?
 
-- \[Feature [#12334](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12334&sa=D&source=editors&ust=1686086850672803&usg=AOvVaw1WaqwcPbU-APn5w2uB7MUD)\] Final/Readonly Support for Fields / Instance Variables (shyouhei)
+- \[Feature [#12334](https://bugs.ruby-lang.org/issues/12334)\] Final/Readonly Support for Fields / Instance Variables (shyouhei)
 
 - shyouhei: in fact it enables some sort of optimizations
 - ko1: we should focus to the feature as a language, not implementation.
 
-- \[Feature [#12350](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12350&sa=D&source=editors&ust=1686086850673259&usg=AOvVaw1SPZGa0ghO3_3LNNIROrz8)\] Introduce Array#find! that raises an error if element not found (shyouhei)
+- \[Feature [#12350](https://bugs.ruby-lang.org/issues/12350)\] Introduce Array#find! that raises an error if element not found (shyouhei)
 
 - naruse: why not fetch ?
 - akr: find and fetch are different in a way they are called.
 - matz: open to such feature but find! naming is wrong.
 
-- \[Feature [#12360](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12360&sa=D&source=editors&ust=1686086850673703&usg=AOvVaw2ufofGsRdDrcZZTh10ket4)\] More useful return values from bang methods (shyouhei)
+- \[Feature [#12360](https://bugs.ruby-lang.org/issues/12360)\] More useful return values from bang methods (shyouhei)
 
 - matz: returning nil for bang methods are intentional; wanted to forbid method chain for bang methods.
 - akr: is it more “useful”? Enough to break backwards compat?
 
 ## From attendees
 
-- \[Misc [#12529](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12529&sa=D&source=editors&ust=1686086850674547&usg=AOvVaw32FoxvFHfpzPFDPvx60q0j)\] LEGAL file covering all the license information within Ruby (shyouhei)
+- \[Misc [#12529](https://bugs.ruby-lang.org/issues/12529)\] LEGAL file covering all the license information within Ruby (shyouhei)
 
 - Martin: Unicode-related files needs updates.  For other files, the LEGAL file should be updated.
 
@@ -219,19 +219,19 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 
 - hsbt: I’ll take care.
 
-- \[Feature [#8526](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8526&sa=D&source=editors&ust=1686086850675021&usg=AOvVaw3r1gIJt1U2VciGY6V5M6Ag)\] gemify tk (hsbt)
+- \[Feature [#8526](https://bugs.ruby-lang.org/issues/8526)\] gemify tk (hsbt)
 
 - shyouhei: is there any contra?
 - akr: what about「let us tentatively gemify; please revert if there is any problem」
 
-- \[Feature [#3187](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/3187&sa=D&source=editors&ust=1686086850675409&usg=AOvVaw0a4O1VcBIwqgbkNYcpsaIv)\] Allow dynamic Fiber stack size (shyouhei)
+- \[Feature [#3187](https://bugs.ruby-lang.org/issues/3187)\] Allow dynamic Fiber stack size (shyouhei)
 
 - ko1: it seems they implemented Thread.new(stack\_size: nnn)
 - matz: but it’s Fiber.
 - ko1: yes but Fiber and Thread are API-compatible now.  Should we break it?
 - matz: I prefer Rubinius way (Fiber.new to eat the kwarg).
 
-- \[Feature [#12543](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12543&sa=D&source=editors&ust=1686086850675935&usg=AOvVaw3ud1qYUn08-RhDd_pWzVdA)\] explicit tail call syntax: foo() then return (shyouhei)
+- \[Feature [#12543](https://bugs.ruby-lang.org/issues/12543)\] explicit tail call syntax: foo() then return (shyouhei)
 
 - naruse: why not tail call by deault?
 - akr: ruby -O0 to disable tail call?
@@ -241,16 +241,16 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - matz: I can accept tail call as transparent optimization but should we encourage such thing?
 - Martin: is there any language where one have to explicitly state “this is a tail call”?
 
-- \[Feature [#11813](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11813&sa=D&source=editors&ust=1686086850676782&usg=AOvVaw0MjSrcvAli6wFpHQRMRBx2)\] Extend safe navigation operator for \[\] and \[\]= with syntax sugar (shyouhei)
+- \[Feature [#11813](https://bugs.ruby-lang.org/issues/11813)\] Extend safe navigation operator for \[\] and \[\]= with syntax sugar (shyouhei)
 
 - rejected
 
-- \[Feature [#12589](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12589&sa=D&source=editors&ust=1686086850677096&usg=AOvVaw3YHlj_sXkIHH8At8pRowJn)\] VM performance improvement proposal (shyouhei)
+- \[Feature [#12589](https://bugs.ruby-lang.org/issues/12589)\] VM performance improvement proposal (shyouhei)
 
 - ko1: Shouldn’t we call him?
 - matz: RA might be able to grant.
 
-- \[Feature [#12481](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12481&sa=D&source=editors&ust=1686086850677552&usg=AOvVaw0fRXhwZENgbFslUdcKcxTV)\] Add Array#view to allow opt-in copy-on-write sharing of Array contents (shyouhei)
+- \[Feature [#12481](https://bugs.ruby-lang.org/issues/12481)\] Add Array#view to allow opt-in copy-on-write sharing of Array contents (shyouhei)
 
 - matz: why Array.new(0) then view?  Why not ary1.view…
 - nurse: possible use case might be Array#each\_cons(3) and such.
@@ -259,26 +259,26 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - nobu: should this be mutatable?
 - mrkn: seems not because of the subject’s containing “CoW”.
 
-- \[Feature [#12057](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12057&sa=D&source=editors&ust=1686086850678421&usg=AOvVaw0sUcjE-TunsVPcvXvwpkDs)\] Allow methods with yield to be called without a block (shyouhei)
+- \[Feature [#12057](https://bugs.ruby-lang.org/issues/12057)\] Allow methods with yield to be called without a block (shyouhei)
 
 - akr: we already have Enumerator.
 - akr: maybe this is automation of enum\_for(\_\_method\_\_) unless block\_given?
 
-- \[Feature [#12297](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12297&sa=D&source=editors&ust=1686086850678838&usg=AOvVaw3sI9DYZAYsbWoECL-EpFVh)\] Ruby stdlib date can parse non-existent date with year 0 (shyouhei)
+- \[Feature [#12297](https://bugs.ruby-lang.org/issues/12297)\] Ruby stdlib date can parse non-existent date with year 0 (shyouhei)
 
-- Wasn't this intentional? cf [https://en.wikipedia.org/wiki/0\_(year)](https://www.google.com/url?q=https://en.wikipedia.org/wiki/0_(year)&sa=D&source=editors&ust=1686086850679091&usg=AOvVaw3zXjT8RTiDUZmQXngGrwQb)
-- [http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/10241](https://www.google.com/url?q=http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/10241&sa=D&source=editors&ust=1686086850679342&usg=AOvVaw1Tm-YH0j_kPdARhg6jIVza)
+- Wasn't this intentional? cf [https://en.wikipedia.org/wiki/0\_(year)](https://en.wikipedia.org/wiki/0_(year))
+- [http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/10241](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/10241)
 
-- \[Feature [#12461](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12461&sa=D&source=editors&ust=1686086850679602&usg=AOvVaw3705VTj_tXHwvLpRLWciEE)\] Hash & keys to make subset. (shyouhei)
+- \[Feature [#12461](https://bugs.ruby-lang.org/issues/12461)\] Hash & keys to make subset. (shyouhei)
 
 - https://bugs.ruby-lang.org/issues/8499
 
-- \[Feature [#12515](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12515&sa=D&source=editors&ust=1686086850679941&usg=AOvVaw3phra5r5PXiv1babWAHsTJ)\] Create "Boolean" superclass of TrueClass / FalseClass (shyouhei)
+- \[Feature [#12515](https://bugs.ruby-lang.org/issues/12515)\] Create "Boolean" superclass of TrueClass / FalseClass (shyouhei)
 
 - hmm…
 - akr: what’s useful with this?
 
-- \[Feature [#12512](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12512&sa=D&source=editors&ust=1686086850680359&usg=AOvVaw14iqWoRyBDiOYEg-ir86r5)\] Import Hash#transform\_values and its destructive version from ActiveSupport (shyouhei, mrkn)
+- \[Feature [#12512](https://bugs.ruby-lang.org/issues/12512)\] Import Hash#transform\_values and its destructive version from ActiveSupport (shyouhei, mrkn)
 
 - shyouhei: no one is against the feature itself but name.
 - akr: should this yield what? → it seems values only.
@@ -287,7 +287,7 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - matz: the naming doesn’t charm me.
 - akr: what about #map\_v?
 
-- \[Feature [#10208](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10208&sa=D&source=editors&ust=1686086850681173&usg=AOvVaw1lIOYbgAwO3g8RG1ausT30)\] Passing block to Enumerable#to\_h (shyouhei)
+- \[Feature [#10208](https://bugs.ruby-lang.org/issues/10208)\] Passing block to Enumerable#to\_h (shyouhei)
 
 - matz: I don’t like the name.
 - shyouhei: knu proposes #to\_h again.
@@ -295,31 +295,31 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - ko1: what about collect\_\*?
 - matz: collect implies Array because it collects something.
 
-- \[Feature [#11741](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11741&sa=D&source=editors&ust=1686086850681862&usg=AOvVaw0J1Dxy9eePXsmHq3i1vGrF)\] Migrate Ruby to Git from Subversion (shyouhei) Situation?
+- \[Feature [#11741](https://bugs.ruby-lang.org/issues/11741)\] Migrate Ruby to Git from Subversion (shyouhei) Situation?
 
 - not updated.
 
-- \[Feature [#12463](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12463&sa=D&source=editors&ust=1686086850682379&usg=AOvVaw3mFyPdnMJoyQd4WRLJLaQF)\] ruby lacks plus-plus (shyouhei)
+- \[Feature [#12463](https://bugs.ruby-lang.org/issues/12463)\] ruby lacks plus-plus (shyouhei)
 
 - shyouhei: explained.
 - ko1 is going to comment
 
-- \[Feature [#12455](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12455&sa=D&source=editors&ust=1686086850682858&usg=AOvVaw0dSYspd315Um0H8LijIbPr)\] Add a way for class String to determine whether it has only numbers / digits or not (shyouhei)
+- \[Feature [#12455](https://bugs.ruby-lang.org/issues/12455)\] Add a way for class String to determine whether it has only numbers / digits or not (shyouhei)
 
 - nobu: use case?
 - zzak: there is no constructor method that takes arguments like this.
 
-- \[Bug [#12577](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12577&sa=D&source=editors&ust=1686086850683267&usg=AOvVaw0Ti_NBLRKktjEeX80MpVyT)\] Is '$' punctuation or not? Inconsistency between us-ascii and UTF-8 (duerst)
+- \[Bug [#12577](https://bugs.ruby-lang.org/issues/12577)\] Is '$' punctuation or not? Inconsistency between us-ascii and UTF-8 (duerst)
 
 - naruse: this is the difference between POSIX’s ispunct(3) and Unicode’s definition.
 - Matz: we can do nothing to it.  This is a matter of Unicode consortium versus POSIX group.
-- cf: [http://pubs.opengroup.org/onlinepubs/9699919799/functions/ispunct.html](https://www.google.com/url?q=http://pubs.opengroup.org/onlinepubs/9699919799/functions/ispunct.html&sa=D&source=editors&ust=1686086850683938&usg=AOvVaw3kmHn8QgLs1ExSDRNxNlrP)
+- cf: [http://pubs.opengroup.org/onlinepubs/9699919799/functions/ispunct.html](http://pubs.opengroup.org/onlinepubs/9699919799/functions/ispunct.html)
 
-- \[Feature [#12546](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12546&sa=D&source=editors&ust=1686086850684179&usg=AOvVaw2BMUOTDLHRxUJ8_mcsOeKM)\] Remove UnicodeNormalize::UNICODE\_VERSION (duerst)
+- \[Feature [#12546](https://bugs.ruby-lang.org/issues/12546)\] Remove UnicodeNormalize::UNICODE\_VERSION (duerst)
 
 - Matz: OK.
 
-- \[Bug [#12547](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12547&sa=D&source=editors&ust=1686086850684541&usg=AOvVaw2Olj0O_I7b_u4-gDOMkyX_)\] Remove ONIG\_UNICODE\_VERSION\_... in enc/unicode/case-folding.rb, casefold.h (duerst)
+- \[Bug [#12547](https://bugs.ruby-lang.org/issues/12547)\] Remove ONIG\_UNICODE\_VERSION\_... in enc/unicode/case-folding.rb, casefold.h (duerst)
 
 - Martin: why is it?
 - nobu: I’d like to check unicode version of each generated file.
@@ -327,30 +327,30 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - Martin: why the C constant everywhere?
 - nobu: we should check in-core Unicode version in enc/unicode.o and lib/unicode\_normalize propagated from common.mk (or command line) each other.
 
-- \[Bug [#12597](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12597&sa=D&source=editors&ust=1686086850685128&usg=AOvVaw2mcMr3evhqU5pVaaqGwC4p)\] Produce test failure if some tests cannot be executed due to lacking data (duerst)
+- \[Bug [#12597](https://bugs.ruby-lang.org/issues/12597)\] Produce test failure if some tests cannot be executed due to lacking data (duerst)
 
 - nobu: this should be skip instead, not failure.
 - akr: skip is silently discarded so not helpful.
 - nobu: false. skip says something when it has message argument.
 
-- \[Feature [#12386](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12386&sa=D&source=editors&ust=1686086850685594&usg=AOvVaw04CUjjUfqCEfWh-O4XyPxr)\] Move definition of ONIG\_CASE\_MAPPING compilation switch outside onigumo files (duerst)
+- \[Feature [#12386](https://bugs.ruby-lang.org/issues/12386)\] Move definition of ONIG\_CASE\_MAPPING compilation switch outside onigumo files (duerst)
 
 - Martin: I’d like to ask nobu where is a proper place to define this macro.
 - naruse: you can simply delete this #ifdef.  This part is ruby-specitic.
 
-- \[Feature [#12578](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12578&sa=D&source=editors&ust=1686086850685983&usg=AOvVaw3kQqdtWvSMML9hTsjQOG61)\] Instance Variables Assigned In parameters ( ala Crystal? ) (duerst)
+- \[Feature [#12578](https://bugs.ruby-lang.org/issues/12578)\] Instance Variables Assigned In parameters ( ala Crystal? ) (duerst)
 
 - nobu: instance variables only? what about global variables?
 - mrkn: block variable also?
 - matz: I’m negative.
 
-- \[Feature [#12419](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12419&sa=D&source=editors&ust=1686086850686419&usg=AOvVaw0LT9Of_9voKWHnS0rjcWzm)\] Improve String#dump for Unicode output (from "\\u{130}" to "\\u0130") (duerst)
+- \[Feature [#12419](https://bugs.ruby-lang.org/issues/12419)\] Improve String#dump for Unicode output (from "\\u{130}" to "\\u0130") (duerst)
 
 - Matz: accepted
 
 ## From non-attendees
 
-- \[Feature [#12086](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12086&sa=D&source=editors&ust=1686086850687042&usg=AOvVaw1kOo0VTFwFQsZADSXtXP3P)\] using: option for instance\_eval etc. (shugo)
+- \[Feature [#12086](https://bugs.ruby-lang.org/issues/12086)\] using: option for instance\_eval etc. (shugo)
 
 - Can I commit it?
 - matz: Charles Nutter must be consulted before committing this.
@@ -358,5 +358,5 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 ## Rope progress (ko1)
 
 - merged to String
-- [https://github.com/spinute/ruby/commits/implement\_ropestring](https://www.google.com/url?q=https://github.com/spinute/ruby/commits/implement_ropestring&sa=D&source=editors&ust=1686086850687747&usg=AOvVaw3mIqzBA_MVVv4lXQvl1trw)
+- [https://github.com/spinute/ruby/commits/implement\_ropestring](https://github.com/spinute/ruby/commits/implement_ropestring)
 - better than String#+, comparable to String#concat

--- a/2016/DevMeeting-2016-08-09.md
+++ b/2016/DevMeeting-2016-08-09.md
@@ -100,7 +100,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - when 7 Sept., 14:00 〜
 - At @tagomoris house?
 
-## Doorkeeperhq account upgrade[¶](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20160809Japan%23Doorkeeperhq-account-upgrade&sa=D&source=editors&ust=1686086875971719&usg=AOvVaw21QOfqXD8V3e3sX7tmFtEX)
+## Doorkeeperhq account upgrade[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20160809Japan#Doorkeeperhq-account-upgrade)
 
 We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 
@@ -112,44 +112,44 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - ko1: isn’t it OK to continue using doorkeeper to support it?
 - naruse: I’ll try redmine.
 
-- [http://ruby.connpass.com/event/37719/](https://www.google.com/url?q=http://ruby.connpass.com/event/37719/&sa=D&source=editors&ust=1686086875972724&usg=AOvVaw1wXJm1S3_xfwJxYoAjUdug)
+- [http://ruby.connpass.com/event/37719/](http://ruby.connpass.com/event/37719/)
 
 ## About 2.4 timeframe
 
 - Read through proposals
-- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24&sa=D&source=editors&ust=1686086875973207&usg=AOvVaw0mf9vYFIjJiHK7MSVpTqzJ)
-- [http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/76640](https://www.google.com/url?q=http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/76640&sa=D&source=editors&ust=1686086875973478&usg=AOvVaw03uLiJ0_i8wzZvbWPjfUtW)
+- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24)
+- [http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/76640](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/76640)
 
-- [https://bugs.ruby-lang.org/issues/6265](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6265&sa=D&source=editors&ust=1686086875973712&usg=AOvVaw13HTA2lMkyK60JA5u1-y3Z)
+- [https://bugs.ruby-lang.org/issues/6265](https://bugs.ruby-lang.org/issues/6265)
 
 - It breaks tests.
 - It’s difficult to introduce in 2.4.
 
-- [https://bugs.ruby-lang.org/issues/4840](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4840&sa=D&source=editors&ust=1686086875974065&usg=AOvVaw0i7dEp-PxeLl-_mHdDAA6S)
+- [https://bugs.ruby-lang.org/issues/4840](https://bugs.ruby-lang.org/issues/4840)
 
 - nobu tried this one before but not successful for technical reasons.
 
-- [https://bugs.ruby-lang.org/issues/8643](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8643&sa=D&source=editors&ust=1686086875974353&usg=AOvVaw2sOP7RxN0hhS9CHBu2wlSE)
+- [https://bugs.ruby-lang.org/issues/8643](https://bugs.ruby-lang.org/issues/8643)
 
 - shouldn’t this be an ERB matter?
 - It is not that easy to modify ERb’s way to handle local variable to directly use a hash because ERb needs to use local variable as a ruby-code fragment.
 
-- [https://bugs.ruby-lang.org/issues/6559](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6559&sa=D&source=editors&ust=1686086875974719&usg=AOvVaw1VJOzdjVdrTDWSjhtP2NtE)
+- [https://bugs.ruby-lang.org/issues/6559](https://bugs.ruby-lang.org/issues/6559)
 
 - naruse: I’ll nudge the assignee
 
 ## Carry-over from previous meeting(s)
 
-- \[Misc [#12283](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12283&sa=D&source=editors&ust=1686086875975207&usg=AOvVaw1MdTuIhIrMkOXKR03vzN7-)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
+- \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 
 - naruse: no progress
 
-- \[Bug [#12466](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12466&sa=D&source=editors&ust=1686086875975535&usg=AOvVaw2NLAzhNtz2vgF-ueKGmaEq)\] Enumerable should yield multiple values when possible (shyouhei)
+- \[Bug [#12466](https://bugs.ruby-lang.org/issues/12466)\] Enumerable should yield multiple values when possible (shyouhei)
 
 - nobu: not easy
 - Matz: reject
 
-- \[Bug [#12402](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12402&sa=D&source=editors&ust=1686086875975927&usg=AOvVaw1-bzBgndH12AjjqL4b5fio)\] Inline rescue behavior inconsistent for method calls with arguments and assignment (shyouhei)
+- \[Bug [#12402](https://bugs.ruby-lang.org/issues/12402)\] Inline rescue behavior inconsistent for method calls with arguments and assignment (shyouhei)
 
 - ko1: var1 is surprising.
 - nobu: it is interpreted as “(var1 = Date.parse var1) rescue nil”
@@ -158,28 +158,28 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - nobu: What happens when you combine rescue\_mod with massign?
 - assigning to nobu.
 
-- \[Bug [#12489](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12489&sa=D&source=editors&ust=1686086875976728&usg=AOvVaw3nF71TiXwn6PKcwlAajc8T)\] hppa problems on Debian GNU/Linux (shyouhei) who to look at it?
+- \[Bug [#12489](https://bugs.ruby-lang.org/issues/12489)\] hppa problems on Debian GNU/Linux (shyouhei) who to look at it?
 
 - nobu: it’s hard to track without actual environment.
 - naruse: make it feedback with no assignee.
 - nobu: the fail log lacks C level backtrace.
 
-- \[Bug [#12497](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12497&sa=D&source=editors&ust=1686086875977178&usg=AOvVaw059AZVga7m4v2NjuJQy-61)\] GMP version of divmod may be slower(shyouhei)
+- \[Bug [#12497](https://bugs.ruby-lang.org/issues/12497)\] GMP version of divmod may be slower(shyouhei)
 
 - assign akr
 
-- \[Feature [#12490](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12490&sa=D&source=editors&ust=1686086875977508&usg=AOvVaw1gU55p5MeXMbsTFyk4NjLA)\] Remove warning on shadowing block params(shyouhei)
+- \[Feature [#12490](https://bugs.ruby-lang.org/issues/12490)\] Remove warning on shadowing block params(shyouhei)
 
 - naruse: negative.  shadowing itself is a bad idea and should be warned.
 - Matz: reject.
 
-- \[Feature [#3511](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/3511&sa=D&source=editors&ust=1686086875977890&usg=AOvVaw1IsnPwm_1df-NjG_9U6Y54)\] rb\_path\_to\_class should call custom const\_defined? methods (shyouhei)
+- \[Feature [#3511](https://bugs.ruby-lang.org/issues/3511)\] rb\_path\_to\_class should call custom const\_defined? methods (shyouhei)
 
 - akr: this is dangerous to implement.
 - ko1: is this backward compatible? akr: it seems.
 - Matz: It seems it hurts than it gains.
 
-- \[Feature [#12508](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12508&sa=D&source=editors&ust=1686086875978320&usg=AOvVaw3dg85BNBRkDWqNDwq4b6SU)\] Integer#mod\_pow(shyouhei)
+- \[Feature [#12508](https://bugs.ruby-lang.org/issues/12508)\] Integer#mod\_pow(shyouhei)
 
 - Matz: 2-argument version of pow is seen in other language (e.g. python)
 - akr: there is no pow method in Ruby sadly
@@ -188,29 +188,29 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - akr: it can even be faster in pure-ruby so gem can be a way
 - mrkn: optimized algorithm is described in Wikipedia.
 - naruse: what about introducing #pow
-- mrkn: Julia has powermod [http://docs.julialang.org/en/latest/stdlib/math/#Base.powermod](https://www.google.com/url?q=http://docs.julialang.org/en/latest/stdlib/math/%23Base.powermod&sa=D&source=editors&ust=1686086875979039&usg=AOvVaw1zX0mxaGlvOcL06yl8MO0U)
+- mrkn: Julia has powermod [http://docs.julialang.org/en/latest/stdlib/math/#Base.powermod](http://docs.julialang.org/en/latest/stdlib/math/#Base.powermod)
 - Matz: accept Integer#pow
 
-- \[Feature [#12521](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12521&sa=D&source=editors&ust=1686086875979347&usg=AOvVaw2GPgzCzOdIT2Ec_MJuP2f_)\] Syntax for retrieving argument without removing it from double-splat catch-all(shyouhei)
+- \[Feature [#12521](https://bugs.ruby-lang.org/issues/12521)\] Syntax for retrieving argument without removing it from double-splat catch-all(shyouhei)
 
 - Matz: what’s good with it?  compared to taking everything with \*\*arg.
 
-- \[Feature [#11195](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11195&sa=D&source=editors&ust=1686086875979668&usg=AOvVaw0YYlx0oaPiBVxNrFfnwaYW)\] Add "no\_proxy" parameter to Net::HTTP.new (shyouhei)
+- \[Feature [#11195](https://bugs.ruby-lang.org/issues/11195)\] Add "no\_proxy" parameter to Net::HTTP.new (shyouhei)
 
 - shyouhei: would like to assign this to someone.
 - akr: what about requesting a patch
 
-- \[Feature [#12142](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12142&sa=D&source=editors&ust=1686086875980086&usg=AOvVaw3a-PsK0Q7WTDn5cLxvpO_4)\] Hash tables with open addressing (shyouhei) merge?
+- \[Feature [#12142](https://bugs.ruby-lang.org/issues/12142)\] Hash tables with open addressing (shyouhei) merge?
 
 - ko1: evaluation undergoing.
 
-- \[Feature [#12586](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12586&sa=D&source=editors&ust=1686086875980388&usg=AOvVaw05iXi0zCHwLXUmzaZ9hMvQ)\] Hash#sample (shyouhei)
+- \[Feature [#12586](https://bugs.ruby-lang.org/issues/12586)\] Hash#sample (shyouhei)
 
 - mrkn: use case?
 - naruse: doesn’t hash\[hash.keys.sample\] make sense?
 - mrkn: I want to see a real-world use case.  Is there a need of to\_h?
 
-- \[Feature [#12553](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12553&sa=D&source=editors&ust=1686086875980824&usg=AOvVaw38eBC2v0DRPgDtdjQViwLL)\] IO.readlines(filename, chomp: true) (shyouhei)
+- \[Feature [#12553](https://bugs.ruby-lang.org/issues/12553)\] IO.readlines(filename, chomp: true) (shyouhei)
 
 - shyouhei: should how the “chomp” work?  Does this work with $/ ?
 - mrkn: readlines itself takes argument to reflect $/
@@ -219,7 +219,7 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - naruse: IO.readlines, IO.foreach, IO#each\_line
 - Matz: accept for those three
 
-- \[Bug [#12548](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12548&sa=D&source=editors&ust=1686086875981499&usg=AOvVaw1wxZcpklQMf_LqwD_9AKVg)\] Rounding modes inconsistency between round versus sprintf (shyouhei) maybe round(mode: "even") or something like that?
+- \[Bug [#12548](https://bugs.ruby-lang.org/issues/12548)\] Rounding modes inconsistency between round versus sprintf (shyouhei) maybe round(mode: "even") or something like that?
 
 - shyouhei: should we “fix” this by modifying #round to be banker’s tie-break, or to add mode to it?
 - akr: I prefer banker’s round
@@ -227,64 +227,64 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - Matz: I have never needed to specify rounding mode
 - conclusion: change default rounding mode to even.
 
-- \[Feature [#12596](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12596&sa=D&source=editors&ust=1686086875982103&usg=AOvVaw0y7sVLiwjnmfD5_4R9XUJj)\] Add Pathname#empty? to be consistent with Dir.empty? and File.empty? (shyouhei)
-- \[Feature [#12573](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12573&sa=D&source=editors&ust=1686086875982373&usg=AOvVaw3RRBmLHXYPRbs-s0g8acww)\] Introduce a straightforward way to discover whether a process is running (nobu)
+- \[Feature [#12596](https://bugs.ruby-lang.org/issues/12596)\] Add Pathname#empty? to be consistent with Dir.empty? and File.empty? (shyouhei)
+- \[Feature [#12573](https://bugs.ruby-lang.org/issues/12573)\] Introduce a straightforward way to discover whether a process is running (nobu)
 
 - Matz : I undertand the mood but it seems not useful
 
-- \[Bug [#9569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9569&sa=D&source=editors&ust=1686086875982716&usg=AOvVaw3tIiBBVAhHvn0sNYHuNB_i)\] SecureRandom should try /dev/urandom first (shyouhei) I'd like to hear other opinions.
-- \[Feature [#7882](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7882&sa=D&source=editors&ust=1686086875983054&usg=AOvVaw2v7kTvElVtvjHPfekemPMZ)\] Allow rescue/else/ensure in do..end
+- \[Bug [#9569](https://bugs.ruby-lang.org/issues/9569)\] SecureRandom should try /dev/urandom first (shyouhei) I'd like to hear other opinions.
+- \[Feature [#7882](https://bugs.ruby-lang.org/issues/7882)\] Allow rescue/else/ensure in do..end
 
 - matz: will respond
 
 ## From attendees
 
-- \[Feature [#11818](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11818&sa=D&source=editors&ust=1686086875983690&usg=AOvVaw3ieNqMKUtkqDnRyepGiLgT)\] Hash#compact (mrkn)
+- \[Feature [#11818](https://bugs.ruby-lang.org/issues/11818)\] Hash#compact (mrkn)
 
 - Matz: accept.
 
-- \[Feature [#3511](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/3511&sa=D&source=editors&ust=1686086875984043&usg=AOvVaw3mSs7koRz5Z2YLXS40xs34)\] rb\_path\_to\_class should call custom const\_defined? methods (shyouhei)
-- \[Feature [#10098](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10098&sa=D&source=editors&ust=1686086875984285&usg=AOvVaw2lv1kH8qQURFmO8UmRU18l)\] \[PATCH\] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
-- \[Feature [#12591](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12591&sa=D&source=editors&ust=1686086875984534&usg=AOvVaw1VlR6lmPkc7Y4VxvhY9Kx4)\] Allow ruby to either catch misspelled "ailas" statements or, possibly more accurately, be more specific in what it reports as an error to the end-user (shyouhei)
-- \[Feature [#12594](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12594&sa=D&source=editors&ust=1686086875984792&usg=AOvVaw1E32APH4NppyhWZSS04Nzg)\] The class does not inherit from a module the modules that were included after the inclusion (shyouhei)
-- \[Feature [#12596](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12596&sa=D&source=editors&ust=1686086875985030&usg=AOvVaw0DAtX-pVwqeQsrle8rBweT)\] Add Pathname#empty? to be consistent with Dir.empty? and File.empty? (shyouhei)
-- \[Feature [#12593](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12593&sa=D&source=editors&ust=1686086875985273&usg=AOvVaw1aQs-YtXgmzvWzLUphXAOd)\] Allow compound assignements to work when destructuring arrays (shyouhei)
+- \[Feature [#3511](https://bugs.ruby-lang.org/issues/3511)\] rb\_path\_to\_class should call custom const\_defined? methods (shyouhei)
+- \[Feature [#10098](https://bugs.ruby-lang.org/issues/10098)\] \[PATCH\] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
+- \[Feature [#12591](https://bugs.ruby-lang.org/issues/12591)\] Allow ruby to either catch misspelled "ailas" statements or, possibly more accurately, be more specific in what it reports as an error to the end-user (shyouhei)
+- \[Feature [#12594](https://bugs.ruby-lang.org/issues/12594)\] The class does not inherit from a module the modules that were included after the inclusion (shyouhei)
+- \[Feature [#12596](https://bugs.ruby-lang.org/issues/12596)\] Add Pathname#empty? to be consistent with Dir.empty? and File.empty? (shyouhei)
+- \[Feature [#12593](https://bugs.ruby-lang.org/issues/12593)\] Allow compound assignements to work when destructuring arrays (shyouhei)
 
 - matz wil respond
 
-- \[Feature [#12602](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12602&sa=D&source=editors&ust=1686086875985578&usg=AOvVaw0ak3SwyXFdTl-hVATb-Mis)\] Add NilClass#to\_d (shyouhei)
-- \[Feature [#12607](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12607&sa=D&source=editors&ust=1686086875985830&usg=AOvVaw0eOJa9gxFRXMlQiU9AT04h)\] Ruby needs an atomic integer (shyouhei)
-- \[Feature [#12608](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12608&sa=D&source=editors&ust=1686086875986062&usg=AOvVaw2uuu-dxx_B_AtN0fMRrQY5)\] Proposal to replace unless in Ruby (shyouhei)
+- \[Feature [#12602](https://bugs.ruby-lang.org/issues/12602)\] Add NilClass#to\_d (shyouhei)
+- \[Feature [#12607](https://bugs.ruby-lang.org/issues/12607)\] Ruby needs an atomic integer (shyouhei)
+- \[Feature [#12608](https://bugs.ruby-lang.org/issues/12608)\] Proposal to replace unless in Ruby (shyouhei)
 
 - Matz: reject
 
-- \[Feature [#12615](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12615&sa=D&source=editors&ust=1686086875986363&usg=AOvVaw16Fx7z3HuosTISPCFnTVOS)\] Pathname#rename does not work across filesystem boundaries. (shyouhei) is this by design or...?
-- \[Feature [#12624](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12624&sa=D&source=editors&ust=1686086875986602&usg=AOvVaw2sbB7D42Mm5Gx96eXx1zpK)\] !== (other) (shyouhei)
+- \[Feature [#12615](https://bugs.ruby-lang.org/issues/12615)\] Pathname#rename does not work across filesystem boundaries. (shyouhei) is this by design or...?
+- \[Feature [#12624](https://bugs.ruby-lang.org/issues/12624)\] !== (other) (shyouhei)
 
 - matz: will respond
 
-- \[Feature [#12625](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12625&sa=D&source=editors&ust=1686086875986918&usg=AOvVaw2Wq43Ls_i3EWNR8752qYTI)\] TypeError.assert, ArgumentError.assert (shyouhei)
-- \[Feature [#12626](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12626&sa=D&source=editors&ust=1686086875987170&usg=AOvVaw07MhKoSnkSKRfftz4p0CiT)\] Add ceiling alias for ceil on Numeric objects (shyouhei)
+- \[Feature [#12625](https://bugs.ruby-lang.org/issues/12625)\] TypeError.assert, ArgumentError.assert (shyouhei)
+- \[Feature [#12626](https://bugs.ruby-lang.org/issues/12626)\] Add ceiling alias for ceil on Numeric objects (shyouhei)
 
 - matz wil respond
 
-- \[Feature [#12623](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12623&sa=D&source=editors&ust=1686086875987502&usg=AOvVaw3Vqi0EZm09WBYBej3JU9l1)\] rescue in blocks without begin/end (shyouhei)
-- \[Feature [#12635](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12635&sa=D&source=editors&ust=1686086875987760&usg=AOvVaw080PjAwgAa9TJ25VPo40Ok)\] Shuffling/Reassigning "namespaces" more easily (shyouhei)
+- \[Feature [#12623](https://bugs.ruby-lang.org/issues/12623)\] rescue in blocks without begin/end (shyouhei)
+- \[Feature [#12635](https://bugs.ruby-lang.org/issues/12635)\] Shuffling/Reassigning "namespaces" more easily (shyouhei)
 
 - matz wil respond
 
-- \[Feature [#12374](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12374&sa=D&source=editors&ust=1686086875988077&usg=AOvVaw1YTsc1f8oM42bH_fZLRBzW)\] SingletonClass (sawa)
+- \[Feature [#12374](https://bugs.ruby-lang.org/issues/12374)\] SingletonClass (sawa)
 
 - ko1: this is GoF’s singleton pattern.
 - sawa: I want to have a reverse of Object#singleton\_class
 - akr: what use case?
 - Matz: this is technically possible, but what poupose?  There is singleton\_class?
 
-- \[Feature [#9704](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9704&sa=D&source=editors&ust=1686086875988576&usg=AOvVaw3f3tRNXCeZZf3YZFhzfQXr)\] Refinements as files instead of modules (shyouhei)
-- \[Feature [#12637](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12637&sa=D&source=editors&ust=1686086875988829&usg=AOvVaw3sdVPstqgp3H0AtwxtR2Kq)\] Unified and consistent method naming for safe and dangerous methods (shyouhei)
-- \[Feature [#8643](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8643&sa=D&source=editors&ust=1686086875989080&usg=AOvVaw1fa2JbX2cFz9PMFZwNblof)\] Add Binding.from\_hash (shyouhei)
-- \[Feature [#12650](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12650&sa=D&source=editors&ust=1686086875989357&usg=AOvVaw2necddIf8ljFwejO_OnKVB)\] Use UTF-8 encoding for ENV on Windows (shyouhei)
-- \[Feature [#12648](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12648&sa=D&source=editors&ust=1686086875989605&usg=AOvVaw1ZPXVopdjtuSZ7oHCIIu4l)\] Enumerable#sort\_by with descending option (shyouhei)
+- \[Feature [#9704](https://bugs.ruby-lang.org/issues/9704)\] Refinements as files instead of modules (shyouhei)
+- \[Feature [#12637](https://bugs.ruby-lang.org/issues/12637)\] Unified and consistent method naming for safe and dangerous methods (shyouhei)
+- \[Feature [#8643](https://bugs.ruby-lang.org/issues/8643)\] Add Binding.from\_hash (shyouhei)
+- \[Feature [#12650](https://bugs.ruby-lang.org/issues/12650)\] Use UTF-8 encoding for ENV on Windows (shyouhei)
+- \[Feature [#12648](https://bugs.ruby-lang.org/issues/12648)\] Enumerable#sort\_by with descending option (shyouhei)
 
 - akr: sort\_by with multiple arguments is odd.
 - shyouhei: I sometimes need secondary sort key
@@ -294,22 +294,22 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - Matz: I understand the needs of reverse sort.
 - sawa: I can settle with sort\_by.reverse
 
-- \[Feature [#12574](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12574&sa=D&source=editors&ust=1686086875990293&usg=AOvVaw0wbUkCaFG33_j7d6mDmFQ4)\] Remove TRUE, FALSE, and NIL (shyouhei)
-- \[Feature [#12655](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12655&sa=D&source=editors&ust=1686086875990545&usg=AOvVaw3YwZHn6FjLkDM4WiZwqkno)\] accessing a method visibility (shyouhei)
-- \[Feature [#9612](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9612&sa=D&source=editors&ust=1686086875990794&usg=AOvVaw0rJrTvNN-5c23cmQ_5PHYZ)\] Gemify OpenSSL (hsbt)
-- \[Feature [#8539](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8539&sa=D&source=editors&ust=1686086875991042&usg=AOvVaw0yQF4qUCM0U1iUixON4s0V)\] Unbundle ext/tk (hsbt)
-- \[Feature [#12512](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12512&sa=D&source=editors&ust=1686086875991296&usg=AOvVaw1Cn7oVdKZodapIsHv4EGbt)\] Import Hash#transform\_values and its destructive version from ActiveSupport
+- \[Feature [#12574](https://bugs.ruby-lang.org/issues/12574)\] Remove TRUE, FALSE, and NIL (shyouhei)
+- \[Feature [#12655](https://bugs.ruby-lang.org/issues/12655)\] accessing a method visibility (shyouhei)
+- \[Feature [#9612](https://bugs.ruby-lang.org/issues/9612)\] Gemify OpenSSL (hsbt)
+- \[Feature [#8539](https://bugs.ruby-lang.org/issues/8539)\] Unbundle ext/tk (hsbt)
+- \[Feature [#12512](https://bugs.ruby-lang.org/issues/12512)\] Import Hash#transform\_values and its destructive version from ActiveSupport
 
 - Matz: accept Enumerable#map\_v
 - Matz: not now for map\_k, map\_kv
 
 ## From non-attendees
 
-- \[Feature [#12299](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12299&sa=D&source=editors&ust=1686086875992061&usg=AOvVaw14ELf7L45DpD7cSFdgvKRb)\] Add Warning module for customized warning handling (jeremyevans)
+- \[Feature [#12299](https://bugs.ruby-lang.org/issues/12299)\] Add Warning module for customized warning handling (jeremyevans)
 
 - Matz: accept the fundamental concept (library needs more consideration)
 
-- \[Feature [#10594](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10594&sa=D&source=editors&ust=1686086875992422&usg=AOvVaw35GgzqTvml5UbZ-bwVRVXf)\] Comparable#clamp (nerdinand)
+- \[Feature [#10594](https://bugs.ruby-lang.org/issues/10594)\] Comparable#clamp (nerdinand)
 
 - shyouhei: shoudl this be a method of Comparable?
 - nobu: can be a method of Range

--- a/2016/DevMeeting-2016-09-07.md
+++ b/2016/DevMeeting-2016-09-07.md
@@ -87,7 +87,7 @@ Attendees: akr, naruse, mrkn, sonots, hsbt, ko1, eregon, zzak, sorah, ktsj, nobu
 
 Venue: TKP Kyoto Shijo-karasuma Conference Center
 
-[https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20160907Japan](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20160907Japan&sa=D&source=editors&ust=1686086903371750&usg=AOvVaw3h-Ezlz0Vufuf0h-KtQA84)
+[https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20160907Japan](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20160907Japan)
 
 ## Next meeting:
 
@@ -98,7 +98,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 
 ## About 2.4 timeframe
 
-- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24&sa=D&source=editors&ust=1686086903372978&usg=AOvVaw1-OfhAwAw8qMeZOdUl3LRj)
+- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24)
 - preview 2 in two days
 
 ## About "ruby committers vs. the world"
@@ -110,41 +110,41 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 
 ## Carry-over from previous meeting(s)
 
-- \[Feature [#10098](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10098&sa=D&source=editors&ust=1686086903374283&usg=AOvVaw2n4SLKv1rUfFtNMPX8a5aO)\] \[PATCH\] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
+- \[Feature [#10098](https://bugs.ruby-lang.org/issues/10098)\] \[PATCH\] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
 
 - naruse: I don’t feel comfortable to its naming.
 - naruse: I think CRYPTO\_memcmp() is a bad interface so I don’t want to introduce it.
 
-- \[Feature [#12591](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12591&sa=D&source=editors&ust=1686086903374788&usg=AOvVaw0wm3NJ3-X8jCPYBMdgPZ_w)\] Allow ruby to either catch misspelled "ailas" statements or, possibly more accurately, be more specific in what it reports as an error to the end-user (shyouhei)
+- \[Feature [#12591](https://bugs.ruby-lang.org/issues/12591)\] Allow ruby to either catch misspelled "ailas" statements or, possibly more accurately, be more specific in what it reports as an error to the end-user (shyouhei)
 
 - matz: use an editor that supports ruby syntax.
 
-- \[Feature [#9704](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9704&sa=D&source=editors&ust=1686086903375178&usg=AOvVaw0m6bHPsjPvF84-cz76s8WC)\] Refinements as files instead of modules (shyouhei) conclusion?
+- \[Feature [#9704](https://bugs.ruby-lang.org/issues/9704)\] Refinements as files instead of modules (shyouhei) conclusion?
 
 - shugo: matz please respond.
 
-- \[Feature [#8643](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8643&sa=D&source=editors&ust=1686086903375523&usg=AOvVaw1tqTPd7LOre1xNN2Sj4XjA)\] Add Binding.from\_hash (shyouhei) conclusion?
+- \[Feature [#8643](https://bugs.ruby-lang.org/issues/8643)\] Add Binding.from\_hash (shyouhei) conclusion?
 
 - ko1: I’ll ask seki-san.
 
-- \[Feature [#12650](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12650&sa=D&source=editors&ust=1686086903375923&usg=AOvVaw3vfT0K-aK_L2vGQxFC4VLN)\] Use UTF-8 encoding for ENV on Windows (shyouhei)
+- \[Feature [#12650](https://bugs.ruby-lang.org/issues/12650)\] Use UTF-8 encoding for ENV on Windows (shyouhei)
 
 - duerst: is it just we dont want to touch this, or we have agreements we would move to UTF-8 later?
 - naruse: I’ll ask usa-san
 
-- \[Bug [#9569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9569&sa=D&source=editors&ust=1686086903376474&usg=AOvVaw2RIruyMnJUk0iVQJtTzovo)\] SecureRandom should try /dev/urandom first (shyouhei) I'd like to hear other opinions.
+- \[Bug [#9569](https://bugs.ruby-lang.org/issues/9569)\] SecureRandom should try /dev/urandom first (shyouhei) I'd like to hear other opinions.
 
 - akr: we can’t but neglect this issue as-is.
 - shyouhei: we have no critical security issue right now.
 
-- \[Misc [#12283](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12283&sa=D&source=editors&ust=1686086903377273&usg=AOvVaw1qFRTEG9zhm4BmpWZziyio)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
+- \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 
 - naruse: no move
 - duerst: PLEASE!
 
 ## From attendees
 
-- \[Feature [#12512](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12512&sa=D&source=editors&ust=1686086903378486&usg=AOvVaw1o8l4iKDDAvXzRna3Uc4ef)\] Import Hash#transform\_values and its destructive version from ActiveSupport (eregon): we should discuss the name and maybe other methods like #map\_keys, #map\_pairs.
+- \[Feature [#12512](https://bugs.ruby-lang.org/issues/12512)\] Import Hash#transform\_values and its destructive version from ActiveSupport (eregon): we should discuss the name and maybe other methods like #map\_keys, #map\_pairs.
 
 - matz: I have a plan to have similar methods also on Enumerable.  In doing so, map\_pairs is problematic because “pairs” does not always fit (they might not be key-value pairs).  This prevents me to introduce map\_keys/values/pairs.
 - matz: OK, I accept #transform\_values.
@@ -152,7 +152,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 - mrkn: Yes.
 - eregon: #map\_values, keys, pairs is intuitive on Hash and has been asked many times. The Enumerable method to create a Hash is a different issue: the input might aready be key-value pairs in which case #to\_h is enough or it might not, in which case we might want a new method (build\_hash, associate ?).
 
-- \[Bug [#12689](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12689&sa=D&source=editors&ust=1686086903379777&usg=AOvVaw1Q5aWqzRt-bIAqhI7ZBUOT)\] Thread isolation of $~ and $\_ (eregon): Who can describe the semantics? Is the current sharing expected?
+- \[Bug [#12689](https://bugs.ruby-lang.org/issues/12689)\] Thread isolation of $~ and $\_ (eregon): Who can describe the semantics? Is the current sharing expected?
 
 - ko1: I intentioanlly made VM this way, to behave simiarly with 1.8.x.
 - ko1: Toplevel $-variables are thread local, others like variables inside of methods are not. They are normal (local) variables, subject to be shared among threads.
@@ -180,7 +180,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
     nil
     #<MatchData "foo">
 
-- \[Feature [#6842](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6842&sa=D&source=editors&ust=1686086903381320&usg=AOvVaw3IFJ3UGSKYzUbW4b7BLZ0M)\] Add Optional Arguments to String#strip (sonots): I am currently working on implementing this, but am wondering about specification for regular expression argument, and arguments for strip
+- \[Feature [#6842](https://bugs.ruby-lang.org/issues/6842)\] Add Optional Arguments to String#strip (sonots): I am currently working on implementing this, but am wondering about specification for regular expression argument, and arguments for strip
 
 - sonots: I want this when I write fluentd’s routing engine.
 - nobu: I think we can have this sort of thing, but #strip is not the right place to add it.
@@ -190,20 +190,20 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 - mrkn: it seems python does not have things like this.
 - matz: please re-submit this with proposing new name.
 
-- \[Feature [#859](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/859&sa=D&source=editors&ust=1686086903382193&usg=AOvVaw1xlrLaTrCe2nKjtI6Yb8Gu)\] open-uri doesn't allow redirection to https (duerst): This seems overdue
+- \[Feature [#859](https://bugs.ruby-lang.org/issues/859)\] open-uri doesn't allow redirection to https (duerst): This seems overdue
 
 - duerst: these days http->https redirects happen more often than before.
 - naruse: I don’t remember where exactly is the specification inside of HTML5 where HTTPS redirection is defined
 - akr: Maybe we should allow http->https by default.
 - akr: Ideally it should be configurable wether redirections are allowed or not but that’s a bit too big.
 - Strawman proposal from Carsten Bormann: make configurable, e.g. as follows:
-    ALLOW\_REDIRECTS = { ["http:ftp"](https://www.google.com/url?q=http://ftp/&sa=D&source=editors&ust=1686086903383234&usg=AOvVaw0Pxk7j141AOjV_uDdhLXIi) => true, "ftp:http" => true, ["http:https"](https://www.google.com/url?q=http://https/&sa=D&source=editors&ust=1686086903383552&usg=AOvVaw1Dw3rn_g3i3NRYcTjURpX8)
+    ALLOW\_REDIRECTS = { ["http:ftp"](http://ftp/) => true, "ftp:http" => true, ["http:https"](http://https/)
     \=> true }
     s1 = uri1.scheme.downcase
     s2 = uri2.scheme.downcase
     s1 == s2 || ALLOW\_REDIRECTS\["#{s1}:#{s2}"\]
 
-- \[Feature [#7418](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7418&sa=D&source=editors&ust=1686086903383847&usg=AOvVaw17J8OnqwtPlU4vaKX6lqlp)\] Kernel#used\_refinements (shugo)
+- \[Feature [#7418](https://bugs.ruby-lang.org/issues/7418)\] Kernel#used\_refinements (shugo)
 
 - shyouhei: what is returned from this method?
 - shugo: list of refinements (modules).
@@ -217,7 +217,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 - akr: I don’t think it should be a global function unless this is very frequently used.
 - matz: accept Module.used\_refinements
 
-- \[Feature [#9451](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9451&sa=D&source=editors&ust=1686086903384797&usg=AOvVaw0E4F0AZusQvrYOXx1P6qNh)\] Refinements and unary & (to\_proc) (shugo)
+- \[Feature [#9451](https://bugs.ruby-lang.org/issues/9451)\] Refinements and unary & (to\_proc) (shugo)
 
 - matz: I started thinking this can be okay.
 - nobu: I doubt if we can do this.
@@ -226,65 +226,65 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 - matz: Object#method\_with\_refinements or something can be possible.
 - matz: for &(proc), it is a good-to-have. if possible.
 
-- \[Bug [#10103](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10103&sa=D&source=editors&ust=1686086903385541&usg=AOvVaw2AJSe7bJoCQO5dLPfv5Cx7)\] Unable to refine class with CONSTANT (shugo)
+- \[Bug [#10103](https://bugs.ruby-lang.org/issues/10103)\] Unable to refine class with CONSTANT (shugo)
 
 - shugo: is it okay to close?
 
-- \[Bug [#11182](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11182&sa=D&source=editors&ust=1686086903385906&usg=AOvVaw3ExRX0MW0fSoN9e65JWwl3)\] Refinement with alias causes strange behavior (shugo)
-- \[Feature [#11476](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11476&sa=D&source=editors&ust=1686086903386188&usg=AOvVaw1B_6SKDBMKdGqn0vANWFnb)\] Methods defined in Refinements cannot be called via send (shugo)
+- \[Bug [#11182](https://bugs.ruby-lang.org/issues/11182)\] Refinement with alias causes strange behavior (shugo)
+- \[Feature [#11476](https://bugs.ruby-lang.org/issues/11476)\] Methods defined in Refinements cannot be called via send (shugo)
 
 - matz: either add Object#refined\_send method or Object#method\_with\_refinements.
 - nobu: or to have a send-like operator.
 - ko1: what’s wrong with send being refinements-aware?
 - matz: how is it difficult to modify send?  I want that way.
 
-- \[Feature [#11525](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11525&sa=D&source=editors&ust=1686086903386714&usg=AOvVaw2_GGguviZvDQHxwAz4mcde)\] Add Module#used (refinement hook) (shugo)
+- \[Feature [#11525](https://bugs.ruby-lang.org/issues/11525)\] Add Module#used (refinement hook) (shugo)
 
 - matz: reject because it is too dynamic.
 
-- \[Bug [#11704](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11704&sa=D&source=editors&ust=1686086903387102&usg=AOvVaw3HRMqf4o3RIswRUGmCwf0I)\] Refinements only get "used" once in loop (shugo)
+- \[Bug [#11704](https://bugs.ruby-lang.org/issues/11704)\] Refinements only get "used" once in loop (shugo)
 
 - akr: this is a problem of benchmark
 - shyouhei: I understand what OP wanted to do
 
-- \[Feature [#12079](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12079&sa=D&source=editors&ust=1686086903387505&usg=AOvVaw03hiMOqF2Aa9a1mdjT53am)\] Loosening the condition for refinement (shugo)
+- \[Feature [#12079](https://bugs.ruby-lang.org/issues/12079)\] Loosening the condition for refinement (shugo)
 
 - duplicated.
 
-- \[Feature [#12086](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12086&sa=D&source=editors&ust=1686086903387865&usg=AOvVaw02MCHo8RV5u-6-U62ax6FL)\] using: option for instance\_eval etc. (shugo)
+- \[Feature [#12086](https://bugs.ruby-lang.org/issues/12086)\] using: option for instance\_eval etc. (shugo)
 
 - waiting for JRuby guys.
 - shugo: please nudge.
 
-- \[Feature [#12533](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12533&sa=D&source=editors&ust=1686086903388313&usg=AOvVaw2uFtEcPXFSJyMBx3-YK8LZ)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shugo)
-- \[Feature [#12534](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12534&sa=D&source=editors&ust=1686086903388593&usg=AOvVaw39HuxMflSB7zo_Tb8iLucn)\] Refinements: refine modules as well (shugo)
+- \[Feature [#12533](https://bugs.ruby-lang.org/issues/12533)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shugo)
+- \[Feature [#12534](https://bugs.ruby-lang.org/issues/12534)\] Refinements: refine modules as well (shugo)
 
 - nobu: why we can’t?
 - shugo: it’s difficult because when “super” is called, module’s method have to seek for proper ICLASS.
 - matz: maybe we can restrict calling super from inside of a refined module?
 
-- \[Feature [#11650](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11650&sa=D&source=editors&ust=1686086903389073&usg=AOvVaw2kRTXGhWHdb5n7pdaUyGCB)\] Add custom error message arg to Timeout.timeout (nobu)
+- \[Feature [#11650](https://bugs.ruby-lang.org/issues/11650)\] Add custom error message arg to Timeout.timeout (nobu)
 
 - nobu: I have no reason to reject this.
 - shugo: does this mean Timeout.timeout to pass its arguments to #new?
 - akr: It is considered an idiom to have message right after exception class.
 - matz: accepted.
 
-- \[Bug [#12548](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12548&sa=D&source=editors&ust=1686086903389660&usg=AOvVaw1-F26HqN1ehlV8ndn2pRVV)\] Rounding modes inconsistency between round versus sprintf (nobu)
+- \[Bug [#12548](https://bugs.ruby-lang.org/issues/12548)\] Rounding modes inconsistency between round versus sprintf (nobu)
 
 - add optional second argument, like BigDecimal, to take symbol.
 
-- \[Bug [#12588](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12588&sa=D&source=editors&ust=1686086903390104&usg=AOvVaw3iq3B-Q7AfBm3piSm9CWXa)\] When an exception is re-raised in the "rescue" clause, the back trace does not contain the line in that clause (nobu)
+- \[Bug [#12588](https://bugs.ruby-lang.org/issues/12588)\] When an exception is re-raised in the "rescue" clause, the back trace does not contain the line in that clause (nobu)
 
 - matz: backtrace can be obtained if raised manually.
 
-- \[Feature [#12690](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12690&sa=D&source=editors&ust=1686086903390500&usg=AOvVaw1PJs-MIhLqTO3TFETUy-yu)\] Improve GC with external library that may use large memory (nobu)
+- \[Feature [#12690](https://bugs.ruby-lang.org/issues/12690)\] Improve GC with external library that may use large memory (nobu)
 
 - ko1: accept.
 
-- \[Feature [#12695](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12695&sa=D&source=editors&ust=1686086903390901&usg=AOvVaw306UgAQnhIJrivCxBTgYWS)\] File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set (nobu)
-- \[Feature [#12700](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12700&sa=D&source=editors&ust=1686086903391374&usg=AOvVaw3b3s_z3wv-rf7yOUsTWnTV)\] regexg heredoc support (nobu)
+- \[Feature [#12695](https://bugs.ruby-lang.org/issues/12695)\] File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set (nobu)
+- \[Feature [#12700](https://bugs.ruby-lang.org/issues/12700)\] regexg heredoc support (nobu)
 
 - matz: rejected
 
-- \[Bug [#12709](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12709&sa=D&source=editors&ust=1686086903391761&usg=AOvVaw3yerVMOXkXcn8A8QXx2i99)\] POSIX-noncompliant setenv (nobu)
+- \[Bug [#12709](https://bugs.ruby-lang.org/issues/12709)\] POSIX-noncompliant setenv (nobu)

--- a/2016/DevMeeting-2016-10-11.md
+++ b/2016/DevMeeting-2016-10-11.md
@@ -139,7 +139,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## About 2.4 timeframe
 
-- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24&sa=D&source=editors&ust=1686086930351083&usg=AOvVaw2L-Zg8RwYhuncyL23DuTct)
+- [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering24)
 - no showstopper
 - what about the Rational renovation?
 
@@ -153,7 +153,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-- \[Misc [#12283](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12283&sa=D&source=editors&ust=1686086930352237&usg=AOvVaw3VIQxUWMRm3isocLvJ__te)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
+- \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 
 - naruse: no move.
 - shyouhei: I write git-style commit log.
@@ -161,111 +161,111 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - Martin: the problem is not commit log, but to auto-generate ChanegLog.
 - naruse: I’ll do this on camp.
 
-- \[Feature [#12695](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12695&sa=D&source=editors&ust=1686086930352946&usg=AOvVaw2P3EnZbXbqOoZZfJ1MjPXZ)\] File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set (shyouhei) conclusion?
+- \[Feature [#12695](https://bugs.ruby-lang.org/issues/12695)\] File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set (shyouhei) conclusion?
 
 - waiting for matz.
 
-- \[Feature [#12733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12733&sa=D&source=editors&ust=1686086930353321&usg=AOvVaw3vxYlQgUvtYgRIpg-bdhcb)\] Bundle bundler to ruby core (shyouhei)
+- \[Feature [#12733](https://bugs.ruby-lang.org/issues/12733)\] Bundle bundler to ruby core (shyouhei)
 
 - hsbt: no progress.
 - hsbt: rubygems master bundles bundler by default.  It sheds some light into its darkness.
 - nobu: it will be merged when rubygems side is OK.
 - hsbt: carefully watching rubygems’ progress.
 
-- \[Feature [#6647](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6647&sa=D&source=editors&ust=1686086930353822&usg=AOvVaw2Yzrz03mx8N-9BeUdhqk1s)\] Exceptions raised in threads should be logged (shyouhei) Look at [\[ruby-core:77259\]](https://www.google.com/url?q=http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/77259&sa=D&source=editors&ust=1686086930354071&usg=AOvVaw2-hrivnRy7J0n0ktxeJVUh)
+- \[Feature [#6647](https://bugs.ruby-lang.org/issues/6647)\] Exceptions raised in threads should be logged (shyouhei) Look at [\[ruby-core:77259\]](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/77259)
 
 - akr: the proposal can be okay, but we currently do not implemnt thread GC mode.
 
-- \[Feature [#12744](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12744&sa=D&source=editors&ust=1686086930354673&usg=AOvVaw2XHZ5ssMRX1s5sXBf7Cud8)\] Add str.reverse\_each\_char and str.reverse\_chars (shyouhei) conclusion?
+- \[Feature [#12744](https://bugs.ruby-lang.org/issues/12744)\] Add str.reverse\_each\_char and str.reverse\_chars (shyouhei) conclusion?
 
 - naruse: I agree this makes things faster a bit, but will it really be needed?
 - Martin: array allocation is avoided in the patch, but each\_char generates lots of strings anyways.
 
-- \[Bug [#11195](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11195&sa=D&source=editors&ust=1686086930355169&usg=AOvVaw1OsPxSKKdvSr_piG0Qe-wp)\] Add "no\_proxy" parameter to Net::HTTP.new (shyouhei) Roman Bigler volunteers.
+- \[Bug [#11195](https://bugs.ruby-lang.org/issues/11195)\] Add "no\_proxy" parameter to Net::HTTP.new (shyouhei) Roman Bigler volunteers.
 
 - akr: +1 to refacor find\_proxy, then use it from Net::HTTP.
 - let’s request a patch, then mentor by naruse.
 
-- \[Bug [#12594](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12594&sa=D&source=editors&ust=1686086930355678&usg=AOvVaw2vDOgVMbC_t02n_f24K-ai)\] The class does not inherit from a module the modules that were included after the inclusion (shyouhei)
+- \[Bug [#12594](https://bugs.ruby-lang.org/issues/12594)\] The class does not inherit from a module the modules that were included after the inclusion (shyouhei)
 
 - nobu: I’ll fix this someday. hopefully before 2.4?
 
 ## From attendees
 
-- \[Bug [#12649](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12649&sa=D&source=editors&ust=1686086930356298&usg=AOvVaw0pycTqt0JiJY7Z2fj5l1cF)\] DateTime method calls hang (shyouhei) seems like a real bug?
+- \[Bug [#12649](https://bugs.ruby-lang.org/issues/12649)\] DateTime method calls hang (shyouhei) seems like a real bug?
 
 - assign nobu.
 
-- \[Bug [#12652](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12652&sa=D&source=editors&ust=1686086930356715&usg=AOvVaw2ZNFuoE2anVbUhNJtOLjvR)\] For Dir.home encode passed user (shyouhei) seems like a real bug?
+- \[Bug [#12652](https://bugs.ruby-lang.org/issues/12652)\] For Dir.home encode passed user (shyouhei) seems like a real bug?
 
 - assign naruse
 
-- \[Bug [#12509](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12509&sa=D&source=editors&ust=1686086930357136&usg=AOvVaw25U_9Ki1xRrmNpL6ng90_X)\] Using qsort\_s in mingw-w64 causes failures (shyouhei) who to handle this?
+- \[Bug [#12509](https://bugs.ruby-lang.org/issues/12509)\] Using qsort\_s in mingw-w64 causes failures (shyouhei) who to handle this?
 
 - assign nobu
 
-- \[Bug [#8996](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8996&sa=D&source=editors&ust=1686086930357542&usg=AOvVaw1Sf1UW-IpZRMwQVG-_eDBy)\] pthread\_mutex\_lock EINVAL (shyouhei) seems like a real bug?
+- \[Bug [#8996](https://bugs.ruby-lang.org/issues/8996)\] pthread\_mutex\_lock EINVAL (shyouhei) seems like a real bug?
 
 - assign ko1
 
-- \[Bug [#12776](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12776&sa=D&source=editors&ust=1686086930357965&usg=AOvVaw3y-eYIl9E2pTlHIOM0GqMC)\] Flaky test case: TestThread#test\_thread\_name (shyouhei) seems like a real bug, or....?
+- \[Bug [#12776](https://bugs.ruby-lang.org/issues/12776)\] Flaky test case: TestThread#test\_thread\_name (shyouhei) seems like a real bug, or....?
 
 - closed, lets backport.
 
-- \[Feature [#12656](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12656&sa=D&source=editors&ust=1686086930358397&usg=AOvVaw27uoe3UpcaCNyogoL7iIi9)\] Expand short paths with File.expand\_path (shyouhei)
+- \[Feature [#12656](https://bugs.ruby-lang.org/issues/12656)\] Expand short paths with File.expand\_path (shyouhei)
 
 - assign cruby-windows
 
-- \[Bug [#7877](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7877&sa=D&source=editors&ust=1686086930358870&usg=AOvVaw2COoSvCj74XtVYyqweFzw5)\] E::Lazy#with\_index should be lazy (shyouhei)
+- \[Bug [#7877](https://bugs.ruby-lang.org/issues/7877)\] E::Lazy#with\_index should be lazy (shyouhei)
 
 - assign nobu
 
-- \[Feature [#12664](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12664&sa=D&source=editors&ust=1686086930359310&usg=AOvVaw3p_t0b_nyZElrXIZxEmR92)\] Multiline pretty-printing of multiline strings (shyouhei)
+- \[Feature [#12664](https://bugs.ruby-lang.org/issues/12664)\] Multiline pretty-printing of multiline strings (shyouhei)
 
 - nudge akr
 
-- \[Feature [#4897](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4897&sa=D&source=editors&ust=1686086930359721&usg=AOvVaw3GyHTWB_6hriztr6-4CL82)\] Define Math::TAU and BigMath.TAU. The "true" circle constant, Tau=2\*Pi. See [http://tauday.com/](https://www.google.com/url?q=http://tauday.com/&sa=D&source=editors&ust=1686086930359946&usg=AOvVaw3OsNcYMEhUzWK_PXDv76hl) (shyouhei)
+- \[Feature [#4897](https://bugs.ruby-lang.org/issues/4897)\] Define Math::TAU and BigMath.TAU. The "true" circle constant, Tau=2\*Pi. See [http://tauday.com/](http://tauday.com/) (shyouhei)
 
 - mrkn: I suggest Math::TWOPI
 - akr: C has PI\_2, but this means π/2
 - wating for matz (or time?)
 
-- \[Bug [#12674](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12674&sa=D&source=editors&ust=1686086930360527&usg=AOvVaw1hqJIxnP2drHmu-0egJeEq)\] io/wait: not handling the case when the socket is closed before doing wait\_readable/writable with timeout (shyouhei) might be a design issue?
+- \[Bug [#12674](https://bugs.ruby-lang.org/issues/12674)\] io/wait: not handling the case when the socket is closed before doing wait\_readable/writable with timeout (shyouhei) might be a design issue?
 
 - assign nobu
 
-- \[Bug [#12678](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12678&sa=D&source=editors&ust=1686086930360934&usg=AOvVaw2x4TvYSIUKDFx-jrv9Le7v)\] No way to set a timeout for TLS handshake when using Net::SMTP (shyouhei) should who handle this?
+- \[Bug [#12678](https://bugs.ruby-lang.org/issues/12678)\] No way to set a timeout for TLS handshake when using Net::SMTP (shyouhei) should who handle this?
 
 - assign shugo
 
-- \[Bug [#6783](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6783&sa=D&source=editors&ust=1686086930361297&usg=AOvVaw2YSeTaukIXaSyXxB7ftddQ)\] Infinite loop in inspect, not overriding inspect, to\_s, and no known circular references. Stepping into inspect in debugger locks it up with 100% CPU. (shyouhei)
+- \[Bug [#6783](https://bugs.ruby-lang.org/issues/6783)\] Infinite loop in inspect, not overriding inspect, to\_s, and no known circular references. Stepping into inspect in debugger locks it up with 100% CPU. (shyouhei)
 
 - akr: I have a conception of ritcher inspection framework that passes-around contexts, but have not implemented yet.
 
-- \[Bug [#10222](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10222&sa=D&source=editors&ust=1686086930361713&usg=AOvVaw2JXdIk6kGmDD6h_6YCwaae)\] require\_relative and require should be compatible with each other (shyouhei)
+- \[Bug [#10222](https://bugs.ruby-lang.org/issues/10222)\] require\_relative and require should be compatible with each other (shyouhei)
 
 - akr: require\_relative expands real path, while require doesn’t.
 - naruse: if we expand realpath on require, we need disk access every time we call require (even when the library is already loaded).
 - naruse: what about adding both real path and expanded path to $LOADED\_FEATURES at once for require?
 - shyouhei: I think for this shown use case b.rb shall not be called twice.
 
-- \[Bug [#12705](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12705&sa=D&source=editors&ust=1686086930362193&usg=AOvVaw356hZ9qUN_ZfSmkDZkoOzY)\] yielding args to a lambda uses block/proc rather than lambda/method semantics (shyouhei)
+- \[Bug [#12705](https://bugs.ruby-lang.org/issues/12705)\] yielding args to a lambda uses block/proc rather than lambda/method semantics (shyouhei)
 
 - akr: I think it’s a bug.  They should be consistent.
 - akr: someone broke here at 2.2.
 - ko1: maybe me.
 
-- \[Bug [#4537](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4537&sa=D&source=editors&ust=1686086930362603&usg=AOvVaw3YgfR6n5vfOGD7EhwMaEFE)\] Incorrectly creating private method via attr\_accessor (shyouhei) cf. \[Bug [#9005](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9005&sa=D&source=editors&ust=1686086930362767&usg=AOvVaw0QL7nL3TIXcjdruCp8qCKO)\]
+- \[Bug [#4537](https://bugs.ruby-lang.org/issues/4537)\] Incorrectly creating private method via attr\_accessor (shyouhei) cf. \[Bug [#9005](https://bugs.ruby-lang.org/issues/9005)\]
 
 - shyouhei: is this fixed already?
 - nobu: seems not.
 - shyouhei: updated ruby -v field.
 
-- \[Feature [#12721](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12721&sa=D&source=editors&ust=1686086930363149&usg=AOvVaw1AG6yED67DWd7rhoGwffga)\] public\_module\_function (shyouhei)
+- \[Feature [#12721](https://bugs.ruby-lang.org/issues/12721)\] public\_module\_function (shyouhei)
 
 - waiting for matz.
 
-- \[Feature [#12732](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12732&sa=D&source=editors&ust=1686086930363437&usg=AOvVaw2rPdExP6u7vze40SW7IBsl)\] An option to pass to Integer, Float, to return nil instead of raise an exception (shyouhei)
+- \[Feature [#12732](https://bugs.ruby-lang.org/issues/12732)\] An option to pass to Integer, Float, to return nil instead of raise an exception (shyouhei)
 
 - akr: it seems there are needs of other conversion methods than to\_i or Integer
 - nobu: they just want to detect validity, not exceptions.
@@ -273,7 +273,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - Martin: but Upcase?() is a new concept.
 - waiting for matz.
 
-- \[Feature [#12745](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12745&sa=D&source=editors&ust=1686086930364089&usg=AOvVaw1tzeHHmpZSPRqTGKwFrijG)\] String#(g)sub(!) should pass a MatchData to the block, not a String (shyouhei)
+- \[Feature [#12745](https://bugs.ruby-lang.org/issues/12745)\] String#(g)sub(!) should pass a MatchData to the block, not a String (shyouhei)
 
 - akr: naming matters.
 - shyouhei: is that we need a new method name?  What about changing gsub behaviour?
@@ -284,19 +284,19 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - shyouhei: it might be possible to extend the passed string to define method that returns $~.
 - akr: adding a new method is the most clean way if we can find good method name.
 
-- \[Feature [#12747](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12747&sa=D&source=editors&ust=1686086930364862&usg=AOvVaw143Gbv7OihK3VYxZ5ZfsCF)\] Add TracePoint#callee\_id (shyouhei)
+- \[Feature [#12747](https://bugs.ruby-lang.org/issues/12747)\] Add TracePoint#callee\_id (shyouhei)
 
 - assign ko1.
 
-- \[Feature [#12755](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12755&sa=D&source=editors&ust=1686086930365190&usg=AOvVaw0ZYMrFPkd4QllFbXdRXLXY)\] optimize instruction sequence (shyouhei)
+- \[Feature [#12755](https://bugs.ruby-lang.org/issues/12755)\] optimize instruction sequence (shyouhei)
 
 - waiting matz.
 
-- \[Bug [#12780](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12780&sa=D&source=editors&ust=1686086930365477&usg=AOvVaw2Lw0F5nFcBk5q7MIgHnkHN)\] BigDecimal#round returns different types depending on argument (shyouhei)
+- \[Bug [#12780](https://bugs.ruby-lang.org/issues/12780)\] BigDecimal#round returns different types depending on argument (shyouhei)
 
 - assign mrkn
 
-- \[Feature [#12790](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12790&sa=D&source=editors&ust=1686086930365763&usg=AOvVaw0a_Awcs8vXJ0lnLj4uh9e5)\] Better inspect for stdlib classes (shyouhei)
+- \[Feature [#12790](https://bugs.ruby-lang.org/issues/12790)\] Better inspect for stdlib classes (shyouhei)
 
 - akr: I can’t read the output.
 - mrkn: yes.  I’ll fix this.  But it’s not that simple.
@@ -316,7 +316,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 - nobu: lets see RC1’s response.
 
-- \[Bug [#12828](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12828&sa=D&source=editors&ust=1686086930366756&usg=AOvVaw1c5m8QmSFb81a83FEQB4AO)\] Check whether macro RUBY is okay for protecting ruby-specific onigumo extensions (duerst)
+- \[Bug [#12828](https://bugs.ruby-lang.org/issues/12828)\] Check whether macro RUBY is okay for protecting ruby-specific onigumo extensions (duerst)
 
 - nobu: RUBY is already defined at defines.h
 - naruse: doesn’t anyone want to use vanilla onigumo someday?
@@ -326,7 +326,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 Write your name and your interest (what do you want to ask and to whom?) please.
 
-- \[Feature [#12760](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12760&sa=D&source=editors&ust=1686086930367484&usg=AOvVaw2YVQ5SLKojV8JdEyR088Zm)\] Optional block argument for itself (Victor Shepelev)
+- \[Feature [#12760](https://bugs.ruby-lang.org/issues/12760)\] Optional block argument for itself (Victor Shepelev)
 
 - “itself” doesn’t sound right
 - nobu: if itself takes block it should behave like tap.

--- a/2016/DevMeeting-2016-11-25.md
+++ b/2016/DevMeeting-2016-11-25.md
@@ -149,14 +149,14 @@ RC1? at 12/1
 
 Issues
 
-- \[Bug [#12958](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12958&sa=D&source=editors&ust=1686086982357143&usg=AOvVaw0NDpSqKnj-yfX0tPogEifH)\] Breaking change in how #round works (yui-knk listed on this agenda) Is there any migration path for changing behavior of round? For example only warning on Ruby 2.4 and chnage behavior on Ruby 2.5.
+- \[Bug [#12958](https://bugs.ruby-lang.org/issues/12958)\] Breaking change in how #round works (yui-knk listed on this agenda) Is there any migration path for changing behavior of round? For example only warning on Ruby 2.4 and chnage behavior on Ruby 2.5.
 
 - mrkn: what problem are there?
 - yui-knk(behind shyouhei): want to know how ruby-core thinks abot the incompatibility.
 - shyouhei: it seems the rails breakage is about ActionView
 - naruse: it’s better for rails to have a dedicated method to round a float.
 
-- \[Feature [#12963](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12963&sa=D&source=editors&ust=1686086982358050&usg=AOvVaw3cwEmrnvvy00w3HPtYY8l6)\] ?string longer than one char
+- \[Feature [#12963](https://bugs.ruby-lang.org/issues/12963)\] ?string longer than one char
 
 - matz: I feel not confident with : :
 - shyouhei: “::” vs “: :” are different in meaning.
@@ -173,19 +173,19 @@ Issues
 - mrkn: x.round(half::"up") -> x.round(half: :"up")
 - nobu: x.round(half:: "up") -> NG
 
-- \[Feature [#12953](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12953&sa=D&source=editors&ust=1686086982359288&usg=AOvVaw3V9ygz-hsVvt_swmL2zw5y)\] (Float, Integer, Rational)#round(half: :down)
+- \[Feature [#12953](https://bugs.ruby-lang.org/issues/12953)\] (Float, Integer, Rational)#round(half: :down)
 
 - mrkn: I think it’s OK
 - matz: seems nobody is against it.
 
-- \[Feature [#12063](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12063&sa=D&source=editors&ust=1686086982359763&usg=AOvVaw1yJrkhp1xX6JkDo-FW0cUT)\] KeyError#receiver and KeyError#name
+- \[Feature [#12063](https://bugs.ruby-lang.org/issues/12063)\] KeyError#receiver and KeyError#name
 
 - shyouhei: I’m not sure about the patch but the feature itself seems OK
 - nobu: I see no problem on the patch.
 - ko1: it’s not a child of ArgumentError.
 - matz: Ruby’s exceptions classes are not well considered… Anyway Python used KeyError.
 
-- \[Bug [#11929](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11929&sa=D&source=editors&ust=1686086982360357&usg=AOvVaw09ORi3MJDKhyp-t7eNo4Is)\] No programatic way to check ability to dup/clone an object (duerst)
+- \[Bug [#11929](https://bugs.ruby-lang.org/issues/11929)\] No programatic way to check ability to dup/clone an object (duerst)
 
 - matz: respond\_to? is insufficient to check if it can be dup’ed, because it could raise exceptions.
 - matz: There is no way to change identity of a fixnum.
@@ -193,46 +193,46 @@ Issues
 - duerst: I’d prefer failing silently.
 - matz: I want a separate proposal for that.
 
-- \[Bug [#12831](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12831&sa=D&source=editors&ust=1686086982361004&usg=AOvVaw3wxnsNV7JXzrEAU2jh6bKs)\] /\\X/ (extended grapheme cluster) can't pass unicode.org's GraphemeBreakTest
+- \[Bug [#12831](https://bugs.ruby-lang.org/issues/12831)\] /\\X/ (extended grapheme cluster) can't pass unicode.org's GraphemeBreakTest
 
 - duerst: not currently implemented.
 - naruse: I’ll take a look.
 
-- \[Feature [#12695](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12695&sa=D&source=editors&ust=1686086982361455&usg=AOvVaw333VB1MV_A4CvVMy91FLww)\] File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set
+- \[Feature [#12695](https://bugs.ruby-lang.org/issues/12695)\] File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set
 
 - matz: OK
 
-- \[Feature [#4897](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4897&sa=D&source=editors&ust=1686086982361810&usg=AOvVaw3Wf38x3K9dIZPW0PyAj2aD)\] Define Math::TAU and BigMath.TAU. The "true" circle constant, Tau=2\*Pi. See [http://tauday.com/](https://www.google.com/url?q=http://tauday.com/&sa=D&source=editors&ust=1686086982362018&usg=AOvVaw07n4iBP3yKDVQR7gDx-cLf)
+- \[Feature [#4897](https://bugs.ruby-lang.org/issues/4897)\] Define Math::TAU and BigMath.TAU. The "true" circle constant, Tau=2\*Pi. See [http://tauday.com/](http://tauday.com/)
 
 - mrkn: last time I suggested TWO\_PI.
 - matz: I don’t think TWO\_PI satisfies TAU fans.
 - matz: I want to leave it rejected.
 
-- \[Feature [#12721](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12721&sa=D&source=editors&ust=1686086982362503&usg=AOvVaw1odhJ7Cmx7SbV7S8HsHV4W)\] public\_module\_function
+- \[Feature [#12721](https://bugs.ruby-lang.org/issues/12721)\] public\_module\_function
 
 - nurse: わかる
 - matz: I’m not sure what benefits are there.
 
-- \[Feature [#12732](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12732&sa=D&source=editors&ust=1686086982362909&usg=AOvVaw1mh-_HNvXSsZG5HaAIkDg5)\] An option to pass to Integer, Float, to return nil instead of raise an exception
+- \[Feature [#12732](https://bugs.ruby-lang.org/issues/12732)\] An option to pass to Integer, Float, to return nil instead of raise an exception
 
-- also: \[Feature [#12968](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12968&sa=D&source=editors&ust=1686086982363374&usg=AOvVaw3h8J-mCeo6Ex66gNqQTde5)\] Allow default value via block for Integer(), Float() and Rational()
+- also: \[Feature [#12968](https://bugs.ruby-lang.org/issues/12968)\] Allow default value via block for Integer(), Float() and Rational()
 
 - naruse: what’s wrong with rescue?
 - shyouhei: raising exception then rescueing is too big compared to what’s needed here; we only need to convert a string to an integer.
 
-- \[Feature [#12745](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12745&sa=D&source=editors&ust=1686086982363808&usg=AOvVaw3jAV6P5jU9u5OWGashJ7YI)\] String#(g)sub(!) should pass a MatchData to the block, not a String
+- \[Feature [#12745](https://bugs.ruby-lang.org/issues/12745)\] String#(g)sub(!) should pass a MatchData to the block, not a String
 
 - matz: 1 is NG. I prefer 4 -> 2 -> 3
 - ko1: I fear there should be considerable amount of overheads in 3.
 - naruse: scan should also be handled. 4 and 2 are  not applicablte.
 
-- \[Feature [#12753](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12753&sa=D&source=editors&ust=1686086982364280&usg=AOvVaw0ZgRlBJB9A0DQLR22QUtIG)\] Useful operator to check bit-flag is true or false
+- \[Feature [#12753](https://bugs.ruby-lang.org/issues/12753)\] Useful operator to check bit-flag is true or false
 
 - shyouhei: what is wanted is to check if certain bit is set or not.  &==0 is a bit too operational.
 - matz: name? “and?” seems wrong.
 - naruse: what about “bittest?”
 
-- \[Feature [#12979](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12979&sa=D&source=editors&ust=1686086982364759&usg=AOvVaw339X5hZEVqiBmZJatKc-Xf)\] Avoid exception for #dup on Integer (and similar cases)
+- \[Feature [#12979](https://bugs.ruby-lang.org/issues/12979)\] Avoid exception for #dup on Integer (and similar cases)
 
 - matz: OK.
 
@@ -240,11 +240,11 @@ Issues
 
 - assign mrkn
 
-- \[Feature [#12754](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12754&sa=D&source=editors&ust=1686086982365227&usg=AOvVaw3KjK8rg1wT0zr4ilOUaz3M)\] Want to use prepared buffer with Array#pack
+- \[Feature [#12754](https://bugs.ruby-lang.org/issues/12754)\] Want to use prepared buffer with Array#pack
 
 - matz: sounds reasonable.
 
-- \[Feature [#12752](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12752&sa=D&source=editors&ust=1686086982365649&usg=AOvVaw0ruGcRHSrgB5Zy4CKMKKpr)\] Unpacking a value from a binary requires additional '.first'
+- \[Feature [#12752](https://bugs.ruby-lang.org/issues/12752)\] Unpacking a value from a binary requires additional '.first'
 
 - matz: I would prefer keyword arguments but index:0 doesn’t much differ from .first
 - naruse: write”(‘C’)\[0\]” and let the interpreter optimize.
@@ -254,44 +254,44 @@ Issues
 - extra argument
 - .first
 
-- \[Feature [#12746](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12746&sa=D&source=editors&ust=1686086982366330&usg=AOvVaw33nDawYeIELvxVxVyMscpu)\] class Array: alias .prepend to .unshift ?
+- \[Feature [#12746](https://bugs.ruby-lang.org/issues/12746)\] class Array: alias .prepend to .unshift ?
 
 - mrkn: is “prepend” a valid english word?
 - shyouhei: they say it’s more natural
 - matz: OK
 
-- \[Feature [#11815](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11815&sa=D&source=editors&ust=1686086982366807&usg=AOvVaw3B4a-E_npjc6Xa0QVGdKiE)\] Proposal for method Array#difference
+- \[Feature [#11815](https://bugs.ruby-lang.org/issues/11815)\] Proposal for method Array#difference
 
 - shyouhei: real-world example is shown (poker bot)
 
-- \[Feature [#12978](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12978&sa=D&source=editors&ust=1686086982367200&usg=AOvVaw2PQtd3fWx38Z2qvD28OvpL)\] Symbol after keyword
+- \[Feature [#12978](https://bugs.ruby-lang.org/issues/12978)\] Symbol after keyword
 
 - matz: reject. I can’t but read this being a String, not Symbol.
 
-- \[Feature [#12770](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12770&sa=D&source=editors&ust=1686086982367570&usg=AOvVaw2LXlj5eXh9xPsU6SDmPoI5)\] Hash#left\_merge
+- \[Feature [#12770](https://bugs.ruby-lang.org/issues/12770)\] Hash#left\_merge
 
 - akira: Rails has reverse\_merge.
 - naruse: the proposed functionality is not the identical to reverse\_merge.
 - ko1: chechk if hash entry is nil, is something new (not orignal behaviour of merge)
 
-- \[Feature [#12760](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12760&sa=D&source=editors&ust=1686086982368038&usg=AOvVaw17Kpd7_0cotPmd5XdqZywX)\] Optional block argument for itself
+- \[Feature [#12760](https://bugs.ruby-lang.org/issues/12760)\] Optional block argument for itself
 
 - matz: object.{|x|...} is NG.
 
-- \[Feature [#12775](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12775&sa=D&source=editors&ust=1686086982368441&usg=AOvVaw14Fvb6nvjcltuy9qWxJ22m)\] Random subset of array
+- \[Feature [#12775](https://bugs.ruby-lang.org/issues/12775)\] Random subset of array
 
 - mrkn: random length array does not make sense to me.
 - shyouhei: it seems the OP uses this for test.
 
-- \[Bug [#10290](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10290&sa=D&source=editors&ust=1686086982368872&usg=AOvVaw2imE3M1XBhmWGzOwUgi2mi)\] segfault when calling a lambda recursively after rescuing SystemStackError
+- \[Bug [#10290](https://bugs.ruby-lang.org/issues/10290)\] segfault when calling a lambda recursively after rescuing SystemStackError
 
 - nudge nobu
 
-- \[Bug [#12688](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12688&sa=D&source=editors&ust=1686086982369228&usg=AOvVaw2NVTNMkIgJk1UGSg-BXRbq)\] Thread unsafety in autoload
+- \[Bug [#12688](https://bugs.ruby-lang.org/issues/12688)\] Thread unsafety in autoload
 
 - assign ko1
 
-- \[Feature [#12786](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12786&sa=D&source=editors&ust=1686086982369570&usg=AOvVaw32s4bddE8q0B53POLPDuTa)\] String#casecmp?
+- \[Feature [#12786](https://bugs.ruby-lang.org/issues/12786)\] String#casecmp?
 
 - naruse: There could be cases where downcase strings are equal, while upcase strings arent.
 - duerst: This feature might be implemented similarily like //i, or upcase(downcase()) == upcase(downcase()); string.downcase(:fold) is (almost?) completely identical to string.upcase.downcase
@@ -299,38 +299,38 @@ Issues
 - matz: is “casecmp?” OK?
 - shyouhei: to me yes.
 
-- \[Feature [#12612](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12612&sa=D&source=editors&ust=1686086982370168&usg=AOvVaw0wuKzX3vReQbShIonFL-le)\] Switch Range#=== to use cover? instead of include?
+- \[Feature [#12612](https://bugs.ruby-lang.org/issues/12612)\] Switch Range#=== to use cover? instead of include?
 
 - naruse: instead of cover?, we should define dedicated Range#===, with optimization for integer (&co.) cases. It can keep compatibility.
 - ko1: maybe akr is interested in it.
 - shyouhei: introducing incompatibility only because it is inefficient is kind of weak.
 
-- \[Bug [#9244](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9244&sa=D&source=editors&ust=1686086982370660&usg=AOvVaw2rVxUdqnDG76EduDEHeGJH)\] unexpected behaviour of 'require' when $LOAD\_PATH gets changed
+- \[Bug [#9244](https://bugs.ruby-lang.org/issues/9244)\] unexpected behaviour of 'require' when $LOAD\_PATH gets changed
 
 - matz: I don’t immediately think it’s a bug.
 
-- \[Feature [#12719](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12719&sa=D&source=editors&ust=1686086982371037&usg=AOvVaw1EJfRZWAhZoGksKipFYnjn)\] Struct#merge for partial updates
+- \[Feature [#12719](https://bugs.ruby-lang.org/issues/12719)\] Struct#merge for partial updates
 
 - matz: “merge” sounds wrong.
 - akira: “assign”?
 - shyouhei: what about the feature itself, apart from the naming thing?
 - matz: use case not clear to me.
 
-- \[Feature [#12715](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12715&sa=D&source=editors&ust=1686086982371642&usg=AOvVaw1gC8BUWQE1yLs-vVN31XED)\] Allow ruby hackers to omit having to specify class or module mandatory, if they know exactly what they want to do
+- \[Feature [#12715](https://bugs.ruby-lang.org/issues/12715)\] Allow ruby hackers to omit having to specify class or module mandatory, if they know exactly what they want to do
 
 - matz wants feedback from OP.
 
-- \[Feature [#12698](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12698&sa=D&source=editors&ust=1686086982372057&usg=AOvVaw1aCJ-80xOQKNbBSMks9OUy)\] Method to delete a substring by regex match
+- \[Feature [#12698](https://bugs.ruby-lang.org/issues/12698)\] Method to delete a substring by regex match
 
 - duerst: what about allowing String#delete to accept regexps? (this would be instead of gremove)
 - mrkn: the OP does not tell us what is wrong with gsub.
 
-- \[Feature [#12697](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12697&sa=D&source=editors&ust=1686086982372498&usg=AOvVaw13frj5syIrtTMiq0OQbafi)\] Why shouldn't Module meta programming methods be public?
+- \[Feature [#12697](https://bugs.ruby-lang.org/issues/12697)\] Why shouldn't Module meta programming methods be public?
 
-- \[Feature [#12780](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12780&sa=D&source=editors&ust=1686086982372792&usg=AOvVaw2sYLrGMHy3xse0fAsBcU3R)\] BigDecimal#round returns different types depending on argument
+- \[Feature [#12780](https://bugs.ruby-lang.org/issues/12780)\] BigDecimal#round returns different types depending on argument
 
-- \[Feature [#12813](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12813&sa=D&source=editors&ust=1686086982373088&usg=AOvVaw1kM8Xujo60PJPyfkxA0q52)\] Calling chunk\_while, slice\_after, slice\_before, slice\_when with no block
+- \[Feature [#12813](https://bugs.ruby-lang.org/issues/12813)\] Calling chunk\_while, slice\_after, slice\_before, slice\_when with no block
 
 - matz will think about it.
 
-- \[Feature [#12882](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12882&sa=D&source=editors&ust=1686086982373487&usg=AOvVaw2q87y_tcLG47HqB4YgZNPX)\] Add caller/file/line information to internal Kernel#warn calls
+- \[Feature [#12882](https://bugs.ruby-lang.org/issues/12882)\] Add caller/file/line information to internal Kernel#warn calls

--- a/2016/DevMeeting-2016-12-21.md
+++ b/2016/DevMeeting-2016-12-21.md
@@ -149,22 +149,22 @@ Issues
 
 ## Blocker for 2.4 release
 
-- \[Feature [#12944](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12944&sa=D&source=editors&ust=1686087025517939&usg=AOvVaw0l66G9v3cGQo_Y3KqNc258)\] Change Kernel#warn to call Warning.warn (shyouhei)
+- \[Feature [#12944](https://bugs.ruby-lang.org/issues/12944)\] Change Kernel#warn to call Warning.warn (shyouhei)
 
 - nobu: nobody is against to call Warning.warn but there are pitfalls
 - akr: what about stringify given arguments, then pass to Warning.warn?
 - akr: is adding “\\n” to the given argument Kernel#warn’s duty or Warning.warn’s?
 - akr: we want to change spec of Kernel#warn.  In order to do so we should avoid rushing this to 2.4.
 
-- \[Feature [#13017](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13017&sa=D&source=editors&ust=1686087025518591&usg=AOvVaw1xn8hbJ0pXjo3ujHlqchpx)\] Switch SipHash from SipHash24 to SipHash13(?)
+- \[Feature [#13017](https://bugs.ruby-lang.org/issues/13017)\] Switch SipHash from SipHash24 to SipHash13(?)
 
 - it should be safe to remain SipHash24.
 
-- \[Bug [#13019](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13019&sa=D&source=editors&ust=1686087025518906&usg=AOvVaw3IRDmWvgkwPfUj5JwA6dTe)\] related? (shyouhei)
+- \[Bug [#13019](https://bugs.ruby-lang.org/issues/13019)\] related? (shyouhei)
 
 - nobu: no opinion against it
 
-- \[Feature [#12142](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12142&sa=D&source=editors&ust=1686087025519234&usg=AOvVaw0NLl0DwIwxLeNa1vuvWql2)\] Hash tables with open addressing (shyouehi) it seems ruby-core:78558 must be looked at.
+- \[Feature [#12142](https://bugs.ruby-lang.org/issues/12142)\] Hash tables with open addressing (shyouehi) it seems ruby-core:78558 must be looked at.
 
 - nobu: it is done.
 
@@ -172,114 +172,114 @@ Issues
 
 - Bugs that seems forgotten (shyouhei) assign who?
 
-- \[Bug [#12666](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12666&sa=D&source=editors&ust=1686087025519690&usg=AOvVaw0rPTc23jnCGAam3u_ex-x6)\] Fatal error: glibc detected an invalid stdio handle
+- \[Bug [#12666](https://bugs.ruby-lang.org/issues/12666)\] Fatal error: glibc detected an invalid stdio handle
 
 - akr: why not use ldd(1)?
 
-- \[Bug [#12945](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12945&sa=D&source=editors&ust=1686087025520005&usg=AOvVaw0LBxReHVxNNCx1yAIP-rK-)\] Use-after-free in vm\_trace.c
+- \[Bug [#12945](https://bugs.ruby-lang.org/issues/12945)\] Use-after-free in vm\_trace.c
 
 - nobu: I think I fixed this
 
-- \[Bug [#12961](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12961&sa=D&source=editors&ust=1686087025520280&usg=AOvVaw19HRXtPJKW0RfupKIhqhoX)\] Bad value for range using infinity for Date or Time
+- \[Bug [#12961](https://bugs.ruby-lang.org/issues/12961)\] Bad value for range using infinity for Date or Time
 
 - nobu: is this a problem of coerce?
 - matz: the problem is what receiver is this.
 
-- \[Bug [#12809](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12809&sa=D&source=editors&ust=1686087025520616&usg=AOvVaw3MjzP4A581xysw0ZAz-XqM)\] passing a proc to Kernel#lambda does not create a lambda
+- \[Bug [#12809](https://bugs.ruby-lang.org/issues/12809)\] passing a proc to Kernel#lambda does not create a lambda
 
 - akr: it is by design.
 
-- \[Bug [#12551](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12551&sa=D&source=editors&ust=1686087025520908&usg=AOvVaw2Zfzq3KrcolTD192vAgnPm)\] Exception accessing file with long path on windows
+- \[Bug [#12551](https://bugs.ruby-lang.org/issues/12551)\] Exception accessing file with long path on windows
 
 - nobu it’s already assigned.
 
-- \[Bug [#12907](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12907&sa=D&source=editors&ust=1686087025521195&usg=AOvVaw2H0oNqyrRIYORgi7WxF6nw)\] rb\_respond\_to() return value is incorrect
+- \[Bug [#12907](https://bugs.ruby-lang.org/issues/12907)\] rb\_respond\_to() return value is incorrect
 
 - matz: this is a bug.
 - assign nagachika
 
-- \[Bug [#13000](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13000&sa=D&source=editors&ust=1686087025521624&usg=AOvVaw2eIeZGClsU6fiAm91Ye60c)\] Implement Set#include? with Hash#include?
+- \[Bug [#13000](https://bugs.ruby-lang.org/issues/13000)\] Implement Set#include? with Hash#include?
 
 - akr: is this a bug?
 
-- \[Bug [#13018](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13018&sa=D&source=editors&ust=1686087025521969&usg=AOvVaw0bCLD_4qzVuOvrI-_DdEyK)\] end of file reached (EOFError) from SMTP
+- \[Bug [#13018](https://bugs.ruby-lang.org/issues/13018)\] end of file reached (EOFError) from SMTP
 
 - assign shugo
 
-- \[Bug [#13030](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13030&sa=D&source=editors&ust=1686087025522321&usg=AOvVaw0mN7WDnf-6t9sDp8EZh26B)\] Unexpected T\_IMEMO object when building with VMDEBUG
+- \[Bug [#13030](https://bugs.ruby-lang.org/issues/13030)\] Unexpected T\_IMEMO object when building with VMDEBUG
 
 - assign ko1
 
-- \[Bug [#13043](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13043&sa=D&source=editors&ust=1686087025522608&usg=AOvVaw3vR5esVQ0xSn7AbXE_4WEJ)\] Exception#cause can become recursive/infinite
+- \[Bug [#13043](https://bugs.ruby-lang.org/issues/13043)\] Exception#cause can become recursive/infinite
 
 - akira: what is wrong with recusive cause?
 - mrkn: what’s the expected cause in this case?
 
-- \[Feature [#12732](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12732&sa=D&source=editors&ust=1686087025523040&usg=AOvVaw23A6wHhAtzORVDtCpBs7J-)\] An option to pass to Integer, Float, to return nil instead of raise an exception (shyouhei) conclusion?
+- \[Feature [#12732](https://bugs.ruby-lang.org/issues/12732)\] An option to pass to Integer, Float, to return nil instead of raise an exception (shyouhei) conclusion?
 
 - shyouhei: naruse and tenderlove wrote their opinions.
 
-- \[Feature [#12745](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12745&sa=D&source=editors&ust=1686087025523494&usg=AOvVaw3ITuZYogBOLf1oi6mKd9Ct)\] String#(g)sub(!) should pass a MatchData to the block, not a String (shyouhei) conclusion?
+- \[Feature [#12745](https://bugs.ruby-lang.org/issues/12745)\] String#(g)sub(!) should pass a MatchData to the block, not a String (shyouhei) conclusion?
 
 - akr: #sg or #gs, matz’s original proposal should be accepted I think
 - nobu: how about String#sed
 
-- \[Feature [#12753](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12753&sa=D&source=editors&ust=1686087025523852&usg=AOvVaw24ibQdA68_fbnsqwswQQQj)\] Useful operator to check bit-flag is true or false (shyouhei)
+- \[Feature [#12753](https://bugs.ruby-lang.org/issues/12753)\] Useful operator to check bit-flag is true or false (shyouhei)
 
 - seems discussion is going on
 
-- \[Feature [#11815](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11815&sa=D&source=editors&ust=1686087025524137&usg=AOvVaw0oysyp-isxS95lKKUlMTgd)\] Proposal for method Array#difference (shyouhei) Matz is thinking about this.
+- \[Feature [#11815](https://bugs.ruby-lang.org/issues/11815)\] Proposal for method Array#difference (shyouhei) Matz is thinking about this.
 
 - mrkn: what about Array#delete with multiple arguments?
 
-- \[Feature [#2074](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/2074&sa=D&source=editors&ust=1686087025524457&usg=AOvVaw3Sx3i7gtl_x0R30_WKTIRq)\] json の j や jj は module\_function にするべき？
+- \[Feature [#2074](https://bugs.ruby-lang.org/issues/2074)\] json の j や jj は module\_function にするべき？
 
 - akr: This is a 3PI
 
-- \[Feature [#9209](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9209&sa=D&source=editors&ust=1686087025524797&usg=AOvVaw2SLH2d4uNBHpFcnz-ApTJ5)\]\[Feature [#11925](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11925&sa=D&source=editors&ust=1686087025524981&usg=AOvVaw0dMzyG5GJad9_tbaepkGsQ)\] Struct instances creatable with named args (nobu)
+- \[Feature [#9209](https://bugs.ruby-lang.org/issues/9209)\]\[Feature [#11925](https://bugs.ruby-lang.org/issues/11925)\] Struct instances creatable with named args (nobu)
 
 - akr: naming issue.
 
-- \[Feature [#12802](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12802&sa=D&source=editors&ust=1686087025525307&usg=AOvVaw1Em7h1dgKo_3zYbbVoA3Ak)\] Add BLAKE2 support to Digest (nobu)
+- \[Feature [#12802](https://bugs.ruby-lang.org/issues/12802)\] Add BLAKE2 support to Digest (nobu)
 
 - naruse: do we need this?  no actual use yet.  SHA3 has chance.
 - naruse: just let people use OpenSSL directly.
 - akira: seems Tony does not demand this but saying “if someone has interest …”
 
-- \[Feature [#12861](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12861&sa=D&source=editors&ust=1686087025525778&usg=AOvVaw0r-_d01Qlh-wPTXJfstNWp)\] Lexically scoped super (nobu)
+- \[Feature [#12861](https://bugs.ruby-lang.org/issues/12861)\] Lexically scoped super (nobu)
 
 - nobu: define\_method is the cause of evil
 - matz: I’m not sure if lexically-scoped super would actually get used or not.
 
-- \[Bug [#12812](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12812&sa=D&source=editors&ust=1686087025526171&usg=AOvVaw3HsLH3HnHTvKkqXX9v8CUS)\] Added Coverage#result= (shyuohei)
+- \[Bug [#12812](https://bugs.ruby-lang.org/issues/12812)\] Added Coverage#result= (shyuohei)
 
 - mame is assigned, let him handle this
 
-- \[Feature [#12180](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12180&sa=D&source=editors&ust=1686087025526441&usg=AOvVaw3xUkZ3JdAvi7RLdW_AmuID)\] switch id\_table.c variant (shyouhei) ko1?
+- \[Feature [#12180](https://bugs.ruby-lang.org/issues/12180)\] switch id\_table.c variant (shyouhei) ko1?
 
 - is it OK?
 
-- \[Feature [#8158](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8158&sa=D&source=editors&ust=1686087025526722&usg=AOvVaw01uCJMsTZrzWhuSGkn7NfS)\] lightweight structure for loaded features index (shyouhei)
+- \[Feature [#8158](https://bugs.ruby-lang.org/issues/8158)\] lightweight structure for loaded features index (shyouhei)
 
 - naruse: not for 2.4 but seems OK for 2.5.
 
-- \[Feature [#12839](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12839&sa=D&source=editors&ust=1686087025527031&usg=AOvVaw1SsnjRgbs1FmDjkv-dRWdi)\] CSV - Give not nil but empty strings for empty fields (shyouhei) assign who?
+- \[Feature [#12839](https://bugs.ruby-lang.org/issues/12839)\] CSV - Give not nil but empty strings for empty fields (shyouhei) assign who?
 
 - CSV has no maintenar
 
-- \[Feature [#12854](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12854&sa=D&source=editors&ust=1686087025527315&usg=AOvVaw33QEJI_vrivRRwJG2fbnJu)\] Proc#curry should return an instance of the class, not Proc (shyouhei)
+- \[Feature [#12854](https://bugs.ruby-lang.org/issues/12854)\] Proc#curry should return an instance of the class, not Proc (shyouhei)
 
 - akr: we are not sure if it is safe, because curry is something very conceptual.
 
-- \[Bug [#12855](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12855&sa=D&source=editors&ust=1686087025527592&usg=AOvVaw0g14MhEiIp1P0kWO-vO347)\] Inconsistent keys identity in compare\_by\_identity Hash when using literals (shyouhei) bug or...?
+- \[Bug [#12855](https://bugs.ruby-lang.org/issues/12855)\] Inconsistent keys identity in compare\_by\_identity Hash when using literals (shyouhei) bug or...?
 
 - akr: this is an over-optimization.
 
-- \[Feature [#12882](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12882&sa=D&source=editors&ust=1686087025527878&usg=AOvVaw2hJzJlBGpUmsYA-Imsgzjn)\] Add caller/file/line information to internal Kernel#warn calls (shyouhei)
+- \[Feature [#12882](https://bugs.ruby-lang.org/issues/12882)\] Add caller/file/line information to internal Kernel#warn calls (shyouhei)
 
 - matz will respond
 
-- \[Feature [#7360](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7360&sa=D&source=editors&ust=1686087025528162&usg=AOvVaw0fjdkFGb0e4apD-0mn6_cO)\] Adding Pathname#glob (shyouhei)
+- \[Feature [#7360](https://bugs.ruby-lang.org/issues/7360)\] Adding Pathname#glob (shyouhei)
 
 - akr: I understand the needs but the implementation is wrong.
 
@@ -287,22 +287,22 @@ Issues
 2. then implement.
 3. then this ticket should use that.
 
-- \[Feature [#11286](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11286&sa=D&source=editors&ust=1686087025528618&usg=AOvVaw1qBAErUaseywWyGrT2lgUC)\] \[PATCH\] Add case equality arity to Enumerable's sequence predicates. (shyouhei)
+- \[Feature [#11286](https://bugs.ruby-lang.org/issues/11286)\] \[PATCH\] Add case equality arity to Enumerable's sequence predicates. (shyouhei)
 
 - shyouhei: seems the OP wants some variant of grep
 - akr: regexp might be straight-forward to read but?
 - matz: positive, but might be better in another name?
 
-- \[Feature [#5446](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5446&sa=D&source=editors&ust=1686087025529063&usg=AOvVaw27xZZoMy7S9V1yuTZg1sN9)\] at\_fork callback API (shyouhei)
+- \[Feature [#5446](https://bugs.ruby-lang.org/issues/5446)\] at\_fork callback API (shyouhei)
 
 - what about make it as a pure-ruby gem?
 
-- \[Feature [#12780](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12780&sa=D&source=editors&ust=1686087025529347&usg=AOvVaw2omqQaVzyVZJDqtSrNUlIk)\] BigDecimal#round returns different types depending on argument (shyouhei)
-- \[Feature [#11428](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11428&sa=D&source=editors&ust=1686087025529582&usg=AOvVaw1TtlNf-ByA5NWmaPdKL5Ya)\] system/exec/etc. should to\_s their argument to restore Pathname functionality as it was in 1.8 (shyouhei)
-- \[Feature [#12180](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12180&sa=D&source=editors&ust=1686087025529823&usg=AOvVaw2_Qz-bciReU5a159C6sOGi)\] switch id\_table.c variant (shyouhei)
+- \[Feature [#12780](https://bugs.ruby-lang.org/issues/12780)\] BigDecimal#round returns different types depending on argument (shyouhei)
+- \[Feature [#11428](https://bugs.ruby-lang.org/issues/11428)\] system/exec/etc. should to\_s their argument to restore Pathname functionality as it was in 1.8 (shyouhei)
+- \[Feature [#12180](https://bugs.ruby-lang.org/issues/12180)\] switch id\_table.c variant (shyouhei)
 
-- \[Feature [#5481](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5481&sa=D&source=editors&ust=1686087025530168&usg=AOvVaw0dMvc72gkndUJXzfhkz312)\] [https://bugs.ruby-lang.org/issues/5481](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5481&sa=D&source=editors&ust=1686087025530336&usg=AOvVaw20-SKt9brqJq1xtqL201HA)
+- \[Feature [#5481](https://bugs.ruby-lang.org/issues/5481)\] [https://bugs.ruby-lang.org/issues/5481](https://bugs.ruby-lang.org/issues/5481)
 
-- \[Bug [#12998](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12998&sa=D&source=editors&ust=1686087025530586&usg=AOvVaw3l6Z1iphbBYwqvARaNJNV-)[\] paragraph mode inconsistency between](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5481&sa=D&source=editors&ust=1686087025530739&usg=AOvVaw2i-dXikal8PzKssJyjbToa) [IO#each\_line](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5481&sa=D&source=editors&ust=1686087025530890&usg=AOvVaw2i38krbsWj5CuQgvvmqEXS) [and](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5481&sa=D&source=editors&ust=1686087025531044&usg=AOvVaw0CF2dsG_a9EsDo8RfVLF_r) [String#each\_line](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5481&sa=D&source=editors&ust=1686087025531192&usg=AOvVaw2LimIsnSqBvNRWdHv5w247)[(nobu)](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5481&sa=D&source=editors&ust=1686087025531329&usg=AOvVaw0NyIKzJn4pRZ6VgPfbeewt)
+- \[Bug [#12998](https://bugs.ruby-lang.org/issues/12998)[\] paragraph mode inconsistency between](https://bugs.ruby-lang.org/issues/5481) [IO#each\_line](https://bugs.ruby-lang.org/issues/5481) [and](https://bugs.ruby-lang.org/issues/5481) [String#each\_line](https://bugs.ruby-lang.org/issues/5481)[(nobu)](https://bugs.ruby-lang.org/issues/5481)
 
 - akr: String#each\_line should be fixed in 2.5.

--- a/2017/DevMeeting-2017-01-19.md
+++ b/2017/DevMeeting-2017-01-19.md
@@ -122,11 +122,11 @@ Time: 14:00- 19:00 (JST)
 
 Place: Money Forward inc. Headquarter
 
-Sign-up: [https://ruby.connpass.com/event/47745/](https://www.google.com/url?q=https://ruby.connpass.com/event/47745/&sa=D&source=editors&ust=1686087044830088&usg=AOvVaw2B0DL05cV44uXU8QKfN8mH)
+Sign-up: [https://ruby.connpass.com/event/47745/](https://ruby.connpass.com/event/47745/)
 
-log edit: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/edit&sa=D&source=editors&ust=1686087044830657&usg=AOvVaw298Tt8wyJIEKNVp5Uggbco)
+log edit: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/edit](https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/edit)
 
-log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/pub](https://www.google.com/url?q=https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/pub&sa=D&source=editors&ust=1686087044830974&usg=AOvVaw1cb_v2sBjaj9Kfi8Bkk_SM)
+log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/pub](https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB2vTv8/pub)
 
 ## Next meeting
 
@@ -135,7 +135,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 
 ## About 2.5 timeframe
 
-## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087044831669&usg=AOvVaw30sTnRuPz45NYawvPNCGNa)
+## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25)
 
 - 合宿
 
@@ -154,7 +154,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 
 ## Carry-over from previous meeting(s)
 
-## \[Feature [#12180](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12180&sa=D&source=editors&ust=1686087044832934&usg=AOvVaw2M0hU6Px9QdrZEATwOmvrL)\] switch id\_table.c variant (shyouhei)
+## \[Feature [#12180](https://bugs.ruby-lang.org/issues/12180)\] switch id\_table.c variant (shyouhei)
 
 
 - ko1: funny-falcon’s open addressing hash is beating mine.
@@ -163,7 +163,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: isn’t it too big for a new comer?
 - ko1: I see. I’ll do.
 
-## \[Feature [#12944](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12944&sa=D&source=editors&ust=1686087044833660&usg=AOvVaw3HKVzTUjTWaORCM9KWWa8r)\] Change Kernel#warn to call Warning.warn (shyouhei)
+## \[Feature [#12944](https://bugs.ruby-lang.org/issues/12944)\] Change Kernel#warn to call Warning.warn (shyouhei)
 
 
 - nobu: what spec?
@@ -171,7 +171,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: compatibility concern?
 - matz: why not just try it.
 
-## \[Feature [#13124](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13124&sa=D&source=editors&ust=1686087044834227&usg=AOvVaw3Egmi16N6KEpmfjjVqbPM8)\] Should #puts convert to external encoding? (shyouhei)
+## \[Feature [#13124](https://bugs.ruby-lang.org/issues/13124)\] Should #puts convert to external encoding? (shyouhei)
 
 
 - shyouhei: what’s this?
@@ -182,7 +182,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: I think it’s OK for particular IO that needs encoding, it’s convenient to have such feature.
 - naruse: OK, I’ll respond.
 
-## \[Feature [#13017](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13017&sa=D&source=editors&ust=1686087044835003&usg=AOvVaw2yCBZNtgVUPqe80GD_ojHN)\] Switch SipHash from SipHash24 to SipHash13 (shyouhei)
+## \[Feature [#13017](https://bugs.ruby-lang.org/issues/13017)\] Switch SipHash from SipHash24 to SipHash13 (shyouhei)
 
 
 - shyouhei: I'm confident it's OK to go to 2.5.
@@ -191,7 +191,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - shyouhei: I will
 - matz: go ahead.
 
-## \[Bug [#12998](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12998&sa=D&source=editors&ust=1686087044835786&usg=AOvVaw3tDHLY2fuUMM2uyCv557po)\] paragraph mode inconsistency between IO#each\_line and String#each\_line(nobu)
+## \[Bug [#12998](https://bugs.ruby-lang.org/issues/12998)\] paragraph mode inconsistency between IO#each\_line and String#each\_line(nobu)
 
 
 - ko1: ideal behaviour?
@@ -199,7 +199,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - matz: (nod)
 - nobu: I already merged this.
 
-## \[Feature [#8158](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8158&sa=D&source=editors&ust=1686087044836528&usg=AOvVaw3nDaN7kMfCgJujkMQhipau)\] lightweight structure for loaded features index (shyouhei)
+## \[Feature [#8158](https://bugs.ruby-lang.org/issues/8158)\] lightweight structure for loaded features index (shyouhei)
 
 
 - ko1: nobody but nobu can say if it’s OK.
@@ -207,7 +207,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - hsbt: why not let funny-falcon merge this?
 - matz: I take the idea.
 
-## \[Feature [#12854](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12854&sa=D&source=editors&ust=1686087044837109&usg=AOvVaw2jaCwfSENi9_-M71iAcw9c)\] Proc#curry should return an instance of the class, not Proc (shyouhei)
+## \[Feature [#12854](https://bugs.ruby-lang.org/issues/12854)\] Proc#curry should return an instance of the class, not Proc (shyouhei)
 
 
 - ko1: general idea?
@@ -216,7 +216,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - matz: seems they are different proposals than applications of #curry.
 - matz: I’ll ask for use cases.
 
-## \[Feature [#5481](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5481&sa=D&source=editors&ust=1686087044837835&usg=AOvVaw3a8LfDLz3x0H0X8zavV596)\] Gemifying Ruby standard library (hsbt)
+## \[Feature [#5481](https://bugs.ruby-lang.org/issues/5481)\] Gemifying Ruby standard library (hsbt)
 
 
 - hsbt: Waiting approval of Matz
@@ -234,7 +234,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: I see concerns of dependency hell.
 - hsbt: it’s OK we create separate ML threads for each library to discuss.
 
-## \[Feature [#12901](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12901&sa=D&source=editors&ust=1686087044838946&usg=AOvVaw2kwRfNIyCYGSXlD-tc0Sil)\] Anonymous functions without scope lookup overhead (shyouhei)
+## \[Feature [#12901](https://bugs.ruby-lang.org/issues/12901)\] Anonymous functions without scope lookup overhead (shyouhei)
 
 
 - ko1: matz said we should automatically optimize procs when possible, not explicitly stating like this.
@@ -250,7 +250,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 
 - matz will respond, ko1 to create a new ticket that refer this one.
 
-## \[Feature [#12906](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12906&sa=D&source=editors&ust=1686087044839948&usg=AOvVaw2YI7HFfXjQwSY_DmThuuQy)\] do/end blocks work with ensure/rescue/else (shyouhei)
+## \[Feature [#12906](https://bugs.ruby-lang.org/issues/12906)\] do/end blocks work with ensure/rescue/else (shyouhei)
 
 
 - shyouhei: OP is wise because he do not talk about { … }
@@ -261,7 +261,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: generally speaking it is good to reduce indent.
 - matz: Let me think about it. -> OK
 
-## \[Feature [#12926](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12926&sa=D&source=editors&ust=1686087044840939&usg=AOvVaw3tvJjHLJu4c926W41uXycr)\] -l flag for line end processing should use chomp! instead of chop! (shyouhei)
+## \[Feature [#12926](https://bugs.ruby-lang.org/issues/12926)\] -l flag for line end processing should use chomp! instead of chop! (shyouhei)
 
 
 - nobu: perl behaves like chomp.
@@ -270,7 +270,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: chomp is ruby1.1+, \-l already exists in ruby 0.95
 - matz: OK.
 
-## \[Feature [#12912](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12912&sa=D&source=editors&ust=1686087044841795&usg=AOvVaw12psrHLdrkKGFtjvYZhNGE)\] An endless range (1..) (shyouhei)
+## \[Feature [#12912](https://bugs.ruby-lang.org/issues/12912)\] An endless range (1..) (shyouhei)
 
 
 - shyouhei: what about opossite side ...1?
@@ -285,13 +285,13 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - nobu: (1..) seems visually odd.
 - akr: for now, use step and drop.
 
-## \[Feature [#12933](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12933&sa=D&source=editors&ust=1686087044843060&usg=AOvVaw0keM6i4xTY8lmU5azdAraJ)\] Add Some and Optional (shyouhei)
+## \[Feature [#12933](https://bugs.ruby-lang.org/issues/12933)\] Add Some and Optional (shyouhei)
 
 
 - nobu: start as a gem.
 - matz: agree.
 
-## \[Feature [#12931](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12931&sa=D&source=editors&ust=1686087044843720&usg=AOvVaw1TRT60YZv5rwfwj4QCqZlk)\] Add support for Binding#instance\_eval (shyouhei)
+## \[Feature [#12931](https://bugs.ruby-lang.org/issues/12931)\] Add support for Binding#instance\_eval (shyouhei)
 
 
 - shyouhei: what is needed ultimately is to pass a block to Binding#eval
@@ -299,7 +299,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - nobu: I think it’s not faster, if not impossible.
 - nobu will reject.
 
-## \[Feature [#12929](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12929&sa=D&source=editors&ust=1686087044844592&usg=AOvVaw0-MTVCgzZMqz0MjyNEWQmL)\] ternary should look ahead w/in a block (and not care about newlines) (shyouhei)
+## \[Feature [#12929](https://bugs.ruby-lang.org/issues/12929)\] ternary should look ahead w/in a block (and not care about newlines) (shyouhei)
 
 
 - naruse: perl people tends to write it.
@@ -307,14 +307,14 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - shyouhei: Martin says we already look-ahead for periods.
 - matz: Python ignores newlines inside of parens.
 
-## \[Misc [#12935](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12935&sa=D&source=editors&ust=1686087044845395&usg=AOvVaw1n_0zBk9KpmPISUdRLC2Jv)\] Webrick: Update HTTP Status codes, share them (shyouhei)
+## \[Misc [#12935](https://bugs.ruby-lang.org/issues/12935)\] Webrick: Update HTTP Status codes, share them (shyouhei)
 
 
 - nobu: is it Webrick?
 - akr: Webrick has this code but no one wants to require the whole.
 - akira: nobody looks at anywhere but Rack.
 
-## \[Feature [#12962](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12962&sa=D&source=editors&ust=1686087044846104&usg=AOvVaw38o3XVryvBzaqbBXuxxujV)\] Feature Proposal: Extend 'protected' to support module friendship (shyouhei)
+## \[Feature [#12962](https://bugs.ruby-lang.org/issues/12962)\] Feature Proposal: Extend 'protected' to support module friendship (shyouhei)
 
 
 - akr: use of protected is discouraged.
@@ -323,31 +323,31 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - naruse: I think it’s RuboCop’s duty to warn such thing.
 - akr: it’s a good thing anyway to update rdoc to discourage usages.
 
-## \[Feature [#12957](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12957&sa=D&source=editors&ust=1686087044846988&usg=AOvVaw0w142OIQA-do77B8UGCdRy)\] A more OO way to create lambda Procs (shyouhei)
+## \[Feature [#12957](https://bugs.ruby-lang.org/issues/12957)\] A more OO way to create lambda Procs (shyouhei)
 
 
 - akr: I don’t understand the OP’s intension.
 - shyouhei: I think they want a subclass of lambda.  that’s not possible today.
 - akr: it is possible. complicated though. ->  commented.
 
-## \[Feature [#12966](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12966&sa=D&source=editors&ust=1686087044847638&usg=AOvVaw0TeErYg--zJl6KLHKHHhoD)\] net/ftp to include fxp support? (shyouhei) who's going to handle this?
+## \[Feature [#12966](https://bugs.ruby-lang.org/issues/12966)\] net/ftp to include fxp support? (shyouhei) who's going to handle this?
 
 
 - shugo is handling.
 
-## \[Feature [#12967](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12967&sa=D&source=editors&ust=1686087044848140&usg=AOvVaw04PGoz0T9D1OHWYq27P9Vn)\] Add a default for RUBY\_GC\_HEAP\_GROWTH\_MAX\_SLOTS out-of-the-box (shyouhei)
+## \[Feature [#12967](https://bugs.ruby-lang.org/issues/12967)\] Add a default for RUBY\_GC\_HEAP\_GROWTH\_MAX\_SLOTS out-of-the-box (shyouhei)
 
 
 - ko1: I’m not sure if this parameter is a sane default.
 - ko1: also, I think there should be a comprehensive approach to parameterize GC, not individually like this.
 
-## \[Feature [#12969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12969&sa=D&source=editors&ust=1686087044848725&usg=AOvVaw1Tr_Bmpl_tsm9mZnfc5PfV)\] Allow optional parameter in String#strip and related (shyouhei)
+## \[Feature [#12969](https://bugs.ruby-lang.org/issues/12969)\] Allow optional parameter in String#strip and related (shyouhei)
 
 
 - naruse: I think regexp is the best for this purpose.
 - naruse: I don’t like the tr-like argument string.
 
-## \[Feature [#13016](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13016&sa=D&source=editors&ust=1686087044849359&usg=AOvVaw3ofGy1w8lZq-Kbh8QeoM6G)\] String#gsub(hash) (shyouhei)
+## \[Feature [#13016](https://bugs.ruby-lang.org/issues/13016)\] String#gsub(hash) (shyouhei)
 
 
 - akr: what’s wrong with union?
@@ -357,49 +357,49 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - shyouhei: understand that point.
 - naruse: you have to sort by length before union. Otherwise カ can match before ガ.
 
-## \[Bug [#8241](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8241&sa=D&source=editors&ust=1686087044850256&usg=AOvVaw3maXB-A1V_oKnE2iCJyQ8o)\] If uri host-part has underscore ( '\_' ), 'URI#parse' raise 'URI::InvalidURIError' (shyouhei)
+## \[Bug [#8241](https://bugs.ruby-lang.org/issues/8241)\] If uri host-part has underscore ( '\_' ), 'URI#parse' raise 'URI::InvalidURIError' (shyouhei)
 
 
 - naruse: I think this is done.
 
-## \[Bug [#8826](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8826&sa=D&source=editors&ust=1686087044850670&usg=AOvVaw2XNggg9fOKI6Umf6b27sJN)\] BigDecimal#div and #quo different behavior and inconsistencies (shyouhei) status?>mrkn
+## \[Bug [#8826](https://bugs.ruby-lang.org/issues/8826)\] BigDecimal#div and #quo different behavior and inconsistencies (shyouhei) status?>mrkn
 
 
 - mkrn: I'll start to fix it as soon as possible.
 
-## \[Feature [#13048](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13048&sa=D&source=editors&ust=1686087044851085&usg=AOvVaw3SSTmLdydOmQFj75lPqiFO)\] Better way to do Regexp.new(Regexp.escape("some string")) (shyouhei)
+## \[Feature [#13048](https://bugs.ruby-lang.org/issues/13048)\] Better way to do Regexp.new(Regexp.escape("some string")) (shyouhei)
 
 
 - naruse: quick look at the github result seems every usage of Regexp.new(Regexp.escape()) are bad.
 - akr: Regexp.exact() ?
 
-## \[Bug [#13111](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13111&sa=D&source=editors&ust=1686087044851579&usg=AOvVaw3hk7M3LSn1Ia1G6YYdWTDA)\] Degraded performance for delegated methods through Forwardable module (shyouhei) assign who?
+## \[Bug [#13111](https://bugs.ruby-lang.org/issues/13111)\] Degraded performance for delegated methods through Forwardable module (shyouhei) assign who?
 
 
 - nobu: I did this already I think.
 
-## \[Bug [#13098](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13098&sa=D&source=editors&ust=1686087044851959&usg=AOvVaw2PVcqG3dkj4MmA3qVFZhIE)\] miniruby fails with SEGV on NetBSD/powerpc (shyouhei) look at the backtarce (shyouhei)
+## \[Bug [#13098](https://bugs.ruby-lang.org/issues/13098)\] miniruby fails with SEGV on NetBSD/powerpc (shyouhei) look at the backtarce (shyouhei)
 
 
 - nobu: will take a look.
 
-## \[Bug [#13125](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13125&sa=D&source=editors&ust=1686087044852369&usg=AOvVaw2gujwfPf71ta-jbKElTVRp)\] MRI has too much Qtrue : Qfalse; (shyouhei)
+## \[Bug [#13125](https://bugs.ruby-lang.org/issues/13125)\] MRI has too much Qtrue : Qfalse; (shyouhei)
 
 
 - nobu: nobody is against the needs of macro but the name?
 - shyouhei: will update the ticket.
 
-## \[Bug [#13127](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13127&sa=D&source=editors&ust=1686087044852919&usg=AOvVaw1LLHgzk8OKi1d_2sVVZ7gr)\] DRb \`load': connection closed (DRb::DRbConnError) when client exit's from within a loop iterating over remote objects (shyouhei)
+## \[Bug [#13127](https://bugs.ruby-lang.org/issues/13127)\] DRb \`load': connection closed (DRb::DRbConnError) when client exit's from within a loop iterating over remote objects (shyouhei)
 
 
 - assign seki
 
-## \[Feature [#13067](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13067&sa=D&source=editors&ust=1686087044853423&usg=AOvVaw1iqYejPjiQA7MoCw1gFevk)\] TrueClass,FalseClass to provide \=== to match truthy/falsy values. (shyouhei)
+## \[Feature [#13067](https://bugs.ruby-lang.org/issues/13067)\] TrueClass,FalseClass to provide \=== to match truthy/falsy values. (shyouhei)
 
 
 - matz: I give up.
 
-## \[Bug [#13064](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13064&sa=D&source=editors&ust=1686087044853890&usg=AOvVaw3-c0qgyUEi8ZRBoniVnAbn)\] Inconsistent behavior with next inside begin/end across different implementations. (shyouhei) spec or...?
+## \[Bug [#13064](https://bugs.ruby-lang.org/issues/13064)\] Inconsistent behavior with next inside begin/end across different implementations. (shyouhei) spec or...?
 
 
 - ko1: it’s 1 to me.
@@ -407,12 +407,12 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - ko1:  it is.  Because you can’t place next here statically.
 - akr: should the JIS/ISO specify as such?
 
-## \[Bug [#13104](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13104&sa=D&source=editors&ust=1686087044854726&usg=AOvVaw2eEiMm67gOw-jGbIVhc4Wj)\] math.rb affects Rational literals (nobu)
+## \[Bug [#13104](https://bugs.ruby-lang.org/issues/13104)\] math.rb affects Rational literals (nobu)
 
 
 - matz: it’s ugly, but mathn is ugly by nature.
 
-## \[Bug [#9569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9569&sa=D&source=editors&ust=1686087044855248&usg=AOvVaw33OUNjR8XTKHqw5QZE4B7O)\] SecureRandom should try /dev/urandom first (shyouhei) I now think it's OK
+## \[Bug [#9569](https://bugs.ruby-lang.org/issues/9569)\] SecureRandom should try /dev/urandom first (shyouhei) I now think it's OK
 
 
 - shyouhei: I will

--- a/2017/DevMeeting-2017-03-13.md
+++ b/2017/DevMeeting-2017-03-13.md
@@ -109,9 +109,9 @@ Time: 14:00- 19:00 (JST)
 
 Place: Money Forward inc. Headquarter
 
-Sign-up: [https://ruby.connpass.com/event/47745/](https://www.google.com/url?q=https://ruby.connpass.com/event/47745/&sa=D&source=editors&ust=1686087099212572&usg=AOvVaw2H69ZGcgNYVH87pcL_SNae)
+Sign-up: [https://ruby.connpass.com/event/47745/](https://ruby.connpass.com/event/47745/)
 
-log edit: [https://docs.google.com/document/d/1fZPbRMn2zjVAflvLz1IFWs3Kdijnm2Um4uNLammqURE/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1fZPbRMn2zjVAflvLz1IFWs3Kdijnm2Um4uNLammqURE/edit&sa=D&source=editors&ust=1686087099212956&usg=AOvVaw252KatT_TiaZG1EV8OMs74)
+log edit: [https://docs.google.com/document/d/1fZPbRMn2zjVAflvLz1IFWs3Kdijnm2Um4uNLammqURE/edit](https://docs.google.com/document/d/1fZPbRMn2zjVAflvLz1IFWs3Kdijnm2Um4uNLammqURE/edit)
 
 log: TBD
 
@@ -123,7 +123,7 @@ log: TBD
 
 ## About 2.5 timeframe
 
-## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087099213820&usg=AOvVaw3vacAuKsyIn9qLjxob6FaO)
+## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25)
 
 - 合宿
 
@@ -152,7 +152,7 @@ log: TBD
 
 ## Carry-over from previous meeting(s)
 
-- \[Feature [#13110](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13110&sa=D&source=editors&ust=1686087099215238&usg=AOvVaw0xN5gKnOxOoMJuPSR-6tHp)\] Byte-based operations for String (shugo)
+- \[Feature [#13110](https://bugs.ruby-lang.org/issues/13110)\] Byte-based operations for String (shugo)
 
 - matz: OK for byteoffset.
 - akr: destructive modification using bytesplice may cause string rescan because it can break validity of the string.
@@ -160,7 +160,7 @@ log: TBD
 - naruse: that is byteoffset here.
 - akr: byteindex may have problem for inter-codepoint index.
 
-- \[Bug [#13105](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13105&sa=D&source=editors&ust=1686087099215908&usg=AOvVaw0O3GiFFJWC56gM1ogTVdTU)\] String#to\_f and String#to\_r don't stop successive underscores (nobu)
+- \[Bug [#13105](https://bugs.ruby-lang.org/issues/13105)\] String#to\_f and String#to\_r don't stop successive underscores (nobu)
 
 - nobu: is this intentional?
 - ko1: ignore all underscores?
@@ -175,17 +175,17 @@ log: TBD
 
 - matz: OK, lets make it as we do as literals.
 
-- \[Feature [#13109](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13109&sa=D&source=editors&ust=1686087099216861&usg=AOvVaw0erPIxct6YD7y0abLysVr_)\] using in refinements is required to be physically placed before the refined method call (shyouhei)
+- \[Feature [#13109](https://bugs.ruby-lang.org/issues/13109)\] using in refinements is required to be physically placed before the refined method call (shyouhei)
 
 - matz: I don’t think it’s a bug. It’s intentional.  But we may allow this as an extension.
 
-- \[Bug [#12705](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12705&sa=D&source=editors&ust=1686087099217332&usg=AOvVaw1qMyEnb2Nd3sHYLjJBe1IP)\] yielding args to a lambda uses block/proc rather than lambda/method semantics (shyouhei) status?
+- \[Bug [#12705](https://bugs.ruby-lang.org/issues/12705)\] yielding args to a lambda uses block/proc rather than lambda/method semantics (shyouhei) status?
 
 - ko1: we should fix the interpreter
 - ko1: we introduced ad-hoc change to lambda creation but that turned out to be a mistake, and observed here.
 - ko1: to be fixed in 2.5.
 
-- \[Feature [#13095](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13095&sa=D&source=editors&ust=1686087099217859&usg=AOvVaw066oj3PgFXySVobuckLeqT)\] \[PATCH\] io.c (rb\_f\_syscall): remove deprecation notice (shyouhei)
+- \[Feature [#13095](https://bugs.ruby-lang.org/issues/13095)\] \[PATCH\] io.c (rb\_f\_syscall): remove deprecation notice (shyouhei)
 
 - shyouhei: do we want to remove system calls?
 - akr: yes.
@@ -195,12 +195,12 @@ log: TBD
 - akr: current situation is too difficult to use properly, too easy to get used.
 - akr: my suggestion is to move it to ext/syscall.
 
-- \[Feature [#13122](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13122&sa=D&source=editors&ust=1686087099218630&usg=AOvVaw1SRRvSfqN5fhvIzq0wOpNs)\] Special syntax for Hash#default\_proc (shyouhei)
+- \[Feature [#13122](https://bugs.ruby-lang.org/issues/13122)\] Special syntax for Hash#default\_proc (shyouhei)
 
 - tal: not only default proc, but also there are default values.
 - matz: reject
 
-- \[Feature [#12650](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12650&sa=D&source=editors&ust=1686087099219093&usg=AOvVaw3JpLnOerj1nUKGqvRnIddj)\] Use UTF-8 encoding for ENV on Windows (duerst)
+- \[Feature [#12650](https://bugs.ruby-lang.org/issues/12650)\] Use UTF-8 encoding for ENV on Windows (duerst)
 
 - nobu: ENV is about inter-process, we cannot change alone.
 - shyouhei: seems they need something like “UTF-8 mode”
@@ -214,7 +214,7 @@ log: TBD
 - duerst: when a PC is used by only one person ENV tends to remain single encoding but when people share a PC, ENV is shared across users. (cp437?)
 - nobu: system-wide.
 
-- \[Feature [#6284](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6284&sa=D&source=editors&ust=1686087099220048&usg=AOvVaw3Gp66fHVpk497QngalvDcR)\] Add composition for procs (shyouhei)
+- \[Feature [#6284](https://bugs.ruby-lang.org/issues/6284)\] Add composition for procs (shyouhei)
 
 - ko1: is it a matter of speed?
 - shyouhei: it seems composition is faster now
@@ -223,36 +223,36 @@ log: TBD
 - matz: I have no strong opinion on it.
 - matz: I’ll respond.
 
-- \[Feature [#13137](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13137&sa=D&source=editors&ust=1686087099220749&usg=AOvVaw2tyFZZiP8em3CshXFSwAhR)\] Hash Shorthand (shyouhei)
+- \[Feature [#13137](https://bugs.ruby-lang.org/issues/13137)\] Hash Shorthand (shyouhei)
 
 - matz: reject
 
-- \[Feature [#13166](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13166&sa=D&source=editors&ust=1686087099221148&usg=AOvVaw3p_MXSXFgsq6Tez2JmQmdh)\] Feature Request: Byte Arrays for Ruby 3 (shyouhei)
+- \[Feature [#13166](https://bugs.ruby-lang.org/issues/13166)\] Feature Request: Byte Arrays for Ruby 3 (shyouhei)
 
 - akr: I’m for this but I don’t think I can persuade matz.
 - matz: exactly.
 - akr: so I proposed setbit/getbit, in order for the OP to create a dedicated class on top of it.
 
-- \[Feature [#9116](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9116&sa=D&source=editors&ust=1686087099221706&usg=AOvVaw3aDTz3pGyxRcgoODBkm5S5)\] String#rsplit missing (shyouhei)
+- \[Feature [#9116](https://bugs.ruby-lang.org/issues/9116)\] String#rsplit missing (shyouhei)
 
 - akr: what’s this?
 - shyouhei: they say python’s
 - naruse: use case?
 - tal: rsplit(...,2) can be generally written using regexp. ohter cases when we cant do this using regexp?
 
-- \[Feature [#4532](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4532&sa=D&source=editors&ust=1686087099222269&usg=AOvVaw22AvqSOLdUchLTL9e7lFeZ)\] \[PATCH\] add IO#pread and IO#pwrite methods (shyouhei)
+- \[Feature [#4532](https://bugs.ruby-lang.org/issues/4532)\] \[PATCH\] add IO#pread and IO#pwrite methods (shyouhei)
 
 - akr: portability concern? This is POSIX but added recently.
 - shyouhei: POSIX issue 5
 - akr: at least 2001 version has this.
 - matz: OK.
 
-- \[Bug [#13146](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13146&sa=D&source=editors&ust=1686087099222840&usg=AOvVaw3WNO4EjCXfize9UXRWvo6g)\] Float::NANs in Hashes are confusing (more than usual). (mrkn)
+- \[Bug [#13146](https://bugs.ruby-lang.org/issues/13146)\] Float::NANs in Hashes are confusing (more than usual). (mrkn)
 
 - nobu: prohibit inserting NaNs into hashs?
 - naruse: that’s nonsense.
 
-- \[Bug [#13134](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13134&sa=D&source=editors&ust=1686087099223330&usg=AOvVaw2yJhRMDxlA9rZvFUhUd4T2)\] Rational() inconsistency (nobu)
+- \[Bug [#13134](https://bugs.ruby-lang.org/issues/13134)\] Rational() inconsistency (nobu)
 
 - matz: OK.
 
@@ -273,39 +273,39 @@ log: TBD
 - naruse: should we backport this?
 - matz: I don’t think so.
 
-- \[Bug [#13181](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13181&sa=D&source=editors&ust=1686087099224731&usg=AOvVaw3okPfUXFVXkMR5SaSRY92E)\] Unexpected line in rescue backtrace (shyouhei) what's this?
+- \[Bug [#13181](https://bugs.ruby-lang.org/issues/13181)\] Unexpected line in rescue backtrace (shyouhei) what's this?
 - this week's "assign whom?" section (shyouhei)
 
-- \[Bug [#13271](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13271&sa=D&source=editors&ust=1686087099225128&usg=AOvVaw1Q_aL-8NGjVp5naOGCDFXV)\] Clarifications on refinement spec
-- \[Bug [#13269](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13269&sa=D&source=editors&ust=1686087099225464&usg=AOvVaw30DhA6egfHkXns4BDqf6qh)\] test/readline/test\_readline.rb and mingw
-- \[Bug [#13298](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13298&sa=D&source=editors&ust=1686087099225792&usg=AOvVaw3dS_w_JXpYWF2BSbdwwB5A)\] mingw SEGV TestEnumerable#test\_callcc
-- \[Bug [#13280](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13280&sa=D&source=editors&ust=1686087099226145&usg=AOvVaw0P-SRVBHUjjIH72HqyMfB3)\] net/ftp: Putbinaryfile (on Windows) requires blocksize equal to file size
-- \[Bug [#13276](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13276&sa=D&source=editors&ust=1686087099226481&usg=AOvVaw3zLCJauTJZiuP4wc1QLgsi)\] Dir.glob returns empty array when OS has no more file handles (expected exception)
+- \[Bug [#13271](https://bugs.ruby-lang.org/issues/13271)\] Clarifications on refinement spec
+- \[Bug [#13269](https://bugs.ruby-lang.org/issues/13269)\] test/readline/test\_readline.rb and mingw
+- \[Bug [#13298](https://bugs.ruby-lang.org/issues/13298)\] mingw SEGV TestEnumerable#test\_callcc
+- \[Bug [#13280](https://bugs.ruby-lang.org/issues/13280)\] net/ftp: Putbinaryfile (on Windows) requires blocksize equal to file size
+- \[Bug [#13276](https://bugs.ruby-lang.org/issues/13276)\] Dir.glob returns empty array when OS has no more file handles (expected exception)
 
 - nobu: this one predates 1.0. should we backport?
 - matz: I don’t think so.
 
-- \[Bug [#13284](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13284&sa=D&source=editors&ust=1686087099226976&usg=AOvVaw2_Lcw6Gi_iZL6aqA2Zzlhx)\] IA64 ruby 2.4 miniruby segfault
-- \[Bug [#13286](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13286&sa=D&source=editors&ust=1686087099227307&usg=AOvVaw3yn5GrUj7YbWxIQ-14lwzY)\] Segfault when using rb\_debug\_inspector\_open / rb\_debug\_inspector\_frame\_binding\_get with Fiddle, but not when directly from C extension
-- \[Bug [#13305](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13305&sa=D&source=editors&ust=1686087099227770&usg=AOvVaw3HvtlaXIObiYNKqFKvsqaR)\] Occasional segfaults after defining methods while running coverage
-- \[Bug [#13307](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13307&sa=D&source=editors&ust=1686087099228139&usg=AOvVaw1PSKobRb61Cfs3xHkyy8dH)\] Changing scheme from http to https for the URI does not change the port number
+- \[Bug [#13284](https://bugs.ruby-lang.org/issues/13284)\] IA64 ruby 2.4 miniruby segfault
+- \[Bug [#13286](https://bugs.ruby-lang.org/issues/13286)\] Segfault when using rb\_debug\_inspector\_open / rb\_debug\_inspector\_frame\_binding\_get with Fiddle, but not when directly from C extension
+- \[Bug [#13305](https://bugs.ruby-lang.org/issues/13305)\] Occasional segfaults after defining methods while running coverage
+- \[Bug [#13307](https://bugs.ruby-lang.org/issues/13307)\] Changing scheme from http to https for the URI does not change the port number
 
-- \[Bug [#13282](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13282&sa=D&source=editors&ust=1686087099228488&usg=AOvVaw2jT5DReNaQ_n1_l91tKSdk)\] opt\_str\_freeze does not always dedupe (shyouhei)
+- \[Bug [#13282](https://bugs.ruby-lang.org/issues/13282)\] opt\_str\_freeze does not always dedupe (shyouhei)
 
 - shyouhei: this is about power\_assert
 - akr: what’s wrong with it?
 - shyouhei: seems tracepoint?
 - ko1: don’t know the exact reason.
 
-- \[Feature [#13295](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13295&sa=D&source=editors&ust=1686087099229087&usg=AOvVaw0hVUyyVTliR_h4mRAkD2K8)\] \[PATCH\] compile.c: apply opt\_str\_freeze to String#-@ (uminus) (shyohei) seems OK to me as well
+- \[Feature [#13295](https://bugs.ruby-lang.org/issues/13295)\] \[PATCH\] compile.c: apply opt\_str\_freeze to String#-@ (uminus) (shyohei) seems OK to me as well
 
 - ko1: this is buggy.  Can’t redefine \-@ in this patch.
 
-- \[Feature [#13179](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13179&sa=D&source=editors&ust=1686087099229616&usg=AOvVaw2fbLLS3REYDZqKKfKagYeM)\] Deep Hash Update Method (shyouhei)
+- \[Feature [#13179](https://bugs.ruby-lang.org/issues/13179)\] Deep Hash Update Method (shyouhei)
 
 - nobu: #bury has already been rejected, no update since then.
 
-- \[Misc [#13283](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13283&sa=D&source=editors&ust=1686087099230046&usg=AOvVaw02OXNlusTuXTa80ArSAdy9)\] Disable \`&' interpreted as argument prefix warning when passing symbol to Enumerable#map (duerst)
+- \[Misc [#13283](https://bugs.ruby-lang.org/issues/13283)\] Disable \`&' interpreted as argument prefix warning when passing symbol to Enumerable#map (duerst)
 
 - duerst: the warning is older than Symbol#to\_proc
 - shyouhei: why not suppress the warning for symbol literals, not for variables
@@ -314,18 +314,18 @@ log: TBD
 - matz: mruby won’t warn this case?
 - nobu: it does.
 
-- \[Feature [#13290](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13290&sa=D&source=editors&ust=1686087099230847&usg=AOvVaw31bT8lwmHBx028wsbHRvoj)\] A method to use a hash like in a case construction (duerst)
+- \[Feature [#13290](https://bugs.ruby-lang.org/issues/13290)\] A method to use a hash like in a case construction (duerst)
 
 - matz: I don’t understand the usage.  Let me ask the OP.
 
-- \[Feature [#13077](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13077&sa=D&source=editors&ust=1686087099231274&usg=AOvVaw3OZ8EPm61NmRL-PRfnrsKP)\] \[PATCH\] introduce String#fstring method (ko1) some discussions on twitter they don't like \-'str' notation.
+- \[Feature [#13077](https://bugs.ruby-lang.org/issues/13077)\] \[PATCH\] introduce String#fstring method (ko1) some discussions on twitter they don't like \-'str' notation.
 
 - shyouhei: we can add other stylish names later. \-@ is “for the time being”.
 - matz: if you have opinions, have a separate issue.
 
 ## From non-attendees
 
-- \[Bug [#13223](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13223&sa=D&source=editors&ust=1686087099232038&usg=AOvVaw1rr2yUj5QHpJ9FbbtUdbmo)\] What should the behavior of File.join be when File::SEPARATOR is set? Can I apply this patch? (tenderlove)
+- \[Bug [#13223](https://bugs.ruby-lang.org/issues/13223)\] What should the behavior of File.join be when File::SEPARATOR is set? Can I apply this patch? (tenderlove)
 
 - ko1: this is a bug.
 - nobu: this is either we fix the document to allow other separators or not.

--- a/2017/DevMeeting-2017-04-17.md
+++ b/2017/DevMeeting-2017-04-17.md
@@ -128,9 +128,9 @@ Time: 14:00- 19:00 (JST)
 
 Place: Cookpad Inc. Headquarter
 
-Sign-up: [https://ruby.connpass.com/event/53124/](https://www.google.com/url?q=https://ruby.connpass.com/event/53124/&sa=D&source=editors&ust=1686087122714817&usg=AOvVaw3a19jCb1ija_qokyu5Q5Tj)
+Sign-up: [https://ruby.connpass.com/event/53124/](https://ruby.connpass.com/event/53124/)
 
-log edit: [https://docs.google.com/document/d/1\_tWfg7\_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1_tWfg7_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit&sa=D&source=editors&ust=1686087122715256&usg=AOvVaw3HWhoiEjigR-s344HlZvby)
+log edit: [https://docs.google.com/document/d/1\_tWfg7\_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit](https://docs.google.com/document/d/1_tWfg7_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit)
 
 log: TBD
 
@@ -142,7 +142,7 @@ log: TBD
 
 ## About 2.5 timeframe
 
-## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087122716162&usg=AOvVaw1NHej4Qvc-yFM-fEqLMqsg)
+## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25)
 
 - Previrew 1 in June?
 - 合宿
@@ -157,39 +157,39 @@ log: TBD
 
 ## Carry-over from previous meeting(s)
 
-- \[Bug [#13257](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13257&sa=D&source=editors&ust=1686087122717130&usg=AOvVaw3Yl_NmZhZZ9FG6_giUNPjB)\] Symbol#respond\_to?(:singleton\_class) should be false (naruse)
+- \[Bug [#13257](https://bugs.ruby-lang.org/issues/13257)\] Symbol#respond\_to?(:singleton\_class) should be false (naruse)
 
 - akr: I feel it’s OK to undef them.
 - matz: I doubt to check behaviours using respond\_to?
 - nalsh: class << obj; creates a singleton class if not.  This is not good.
 - nobu: It seems what OP wants is actually a list of extended modules, which is not currently obtainable.
 
-- \[Misc [#13163](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13163&sa=D&source=editors&ust=1686087122717673&usg=AOvVaw1IZ57-EVL30reHOPM1MTzw)\] Uncaught exceptions may not be reported when Thread#report\_on\_exception=true and Thread#abort\_on\_exception=true (naruse)
+- \[Misc [#13163](https://bugs.ruby-lang.org/issues/13163)\] Uncaught exceptions may not be reported when Thread#report\_on\_exception=true and Thread#abort\_on\_exception=true (naruse)
 
 - nobu: OK to me.
 
-- \[Bug [#13181](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13181&sa=D&source=editors&ust=1686087122718015&usg=AOvVaw0u5gK9S1SaXGDkoKUb0XOb)\] Unexpected line in rescue backtrace (shyouhei) what's this?
+- \[Bug [#13181](https://bugs.ruby-lang.org/issues/13181)\] Unexpected line in rescue backtrace (shyouhei) what's this?
 
 - assign ko1
 
-- \[Feature [#8263](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8263&sa=D&source=editors&ust=1686087122718367&usg=AOvVaw3CI5ixgYjvqJ1jWi2mFqYW)\] Support discovering yield state of individual Fibers (shyouhei)
+- \[Feature [#8263](https://bugs.ruby-lang.org/issues/8263)\] Support discovering yield state of individual Fibers (shyouhei)
 
 - assign ko1
 
-- \[Feature [#8576](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8576&sa=D&source=editors&ust=1686087122718747&usg=AOvVaw2ZpGuPGQVRusMrUFsJ0m6b)\] Add optimized method type for constant value methods (shyouhei)
+- \[Feature [#8576](https://bugs.ruby-lang.org/issues/8576)\] Add optimized method type for constant value methods (shyouhei)
 
 - assign ko1
 
-- \[Bug [#13188](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13188&sa=D&source=editors&ust=1686087122719067&usg=AOvVaw0nCRireWQg6PBH9B5SGEor)\] Reinitialize Ruby VM. (shyouhei) New C API ...?
+- \[Bug [#13188](https://bugs.ruby-lang.org/issues/13188)\] Reinitialize Ruby VM. (shyouhei) New C API ...?
 
 - assign ko1
 
-- \[Feature [#2740](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/2740&sa=D&source=editors&ust=1686087122719374&usg=AOvVaw1XLgx4NhP2WYFLWsw0uSZP)\] Extend const\_missing to pass in the nesting (shyouhei)
+- \[Feature [#2740](https://bugs.ruby-lang.org/issues/2740)\] Extend const\_missing to pass in the nesting (shyouhei)
 
 - matz: does this still work?
 - matz: also, I don’t like autoloading in general.
 
-- \[Feature [#13211](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13211&sa=D&source=editors&ust=1686087122719754&usg=AOvVaw1dp4lOPhhTfEuXSjSw4dCr)\] Hash#delete taking a splat (shyouhei)
+- \[Feature [#13211](https://bugs.ruby-lang.org/issues/13211)\] Hash#delete taking a splat (shyouhei)
 
 - mrkn: I once wanted this too
 - akr: return value? array for arity >= 2?
@@ -199,87 +199,87 @@ log: TBD
 - mrkn: That’s Hash#extract!
 - akr: seems what is requested is not a good design, compared to what is wanted.
 
-- \[Bug [#11567](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11567&sa=D&source=editors&ust=1686087122720399&usg=AOvVaw2Wpy7Pj_d1s-lFn7srmp8t)\] Segmentation fault CFUNC :gets (shyouhei)
+- \[Bug [#11567](https://bugs.ruby-lang.org/issues/11567)\] Segmentation fault CFUNC :gets (shyouhei)
 
 - nobu: it seems race between read and close
 - shyouhei: seems fixed.
 
-- \[Feature [#13172](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13172&sa=D&source=editors&ust=1686087122720851&usg=AOvVaw13_IQxwS5ux-FtfsZFvV49)\] Method that yields object to block and returns result (shyouhei) new name candidate
+- \[Feature [#13172](https://bugs.ruby-lang.org/issues/13172)\] Method that yields object to block and returns result (shyouhei) new name candidate
 
 - shyouhei: #pass is proposed.
 - matz: It doesn’t sound nice.
 
-- \[Feature [#13224](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13224&sa=D&source=editors&ust=1686087122721227&usg=AOvVaw1VN_BA5tsjD_NfcypGNzwv)\] Add FrozenError as a subclass of RuntimeError (shyouhei)
+- \[Feature [#13224](https://bugs.ruby-lang.org/issues/13224)\] Add FrozenError as a subclass of RuntimeError (shyouhei)
 
 - matz: I don’t want to have infinite number of exceptions but this seems OK.
 
-- \[Misc [#13230](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13230&sa=D&source=editors&ust=1686087122721526&usg=AOvVaw0iiLv4H6E-YYemH6dbKDG0)\] Better Do ... while structure (shyouhei)
+- \[Misc [#13230](https://bugs.ruby-lang.org/issues/13230)\] Better Do ... while structure (shyouhei)
 
 - shyouhei: I don’t understand this.
 - matz: reject
 
-- \[Feature [#13245](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13245&sa=D&source=editors&ust=1686087122721872&usg=AOvVaw3l7GE0SIGs4jPRTAlmPx2X)\] \[PATCH\] reject inter-thread TLS modification (shyouhei)
+- \[Feature [#13245](https://bugs.ruby-lang.org/issues/13245)\] \[PATCH\] reject inter-thread TLS modification (shyouhei)
 
 - ko1: we would like to forbid this in a future.
 - shyouhei: what about adding warning.
 - akr: is this need?  We have no problem right now.  Is this worth introducing backwards incompatibility?
 
-- \[Feature [#13252](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13252&sa=D&source=editors&ust=1686087122722338&usg=AOvVaw0pu8e0KMmwJ6RTgwRoGkKs)\] C API for creating strings without copying (shyouhei)
+- \[Feature [#13252](https://bugs.ruby-lang.org/issues/13252)\] C API for creating strings without copying (shyouhei)
 
 - ko1: the proposal is not doable
 - nobu: maybe we need to have separate deallocator
 - assign ko1
 
-- \[Bug [#13249](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13249&sa=D&source=editors&ust=1686087122722755&usg=AOvVaw003p3ZYWUzscqo_a1oyODI)\] Access modifiers don't have an effect inside class methods in Ruby >= 2.3 (shyouhei) design issue or bug?
+- \[Bug [#13249](https://bugs.ruby-lang.org/issues/13249)\] Access modifiers don't have an effect inside class methods in Ruby >= 2.3 (shyouhei) design issue or bug?
 
 - naruse: wasn’t this intentional?
 - ko1: no idea.
 - matz: It’s OK to me to deprecate this, if we can warn this.
 
-- \[Feature [#13265](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13265&sa=D&source=editors&ust=1686087122723252&usg=AOvVaw0Lslt4sN1A9Hudnyo2yUzm)\] TracePoint for basic operation redefinition (shyouhei)
+- \[Feature [#13265](https://bugs.ruby-lang.org/issues/13265)\] TracePoint for basic operation redefinition (shyouhei)
 
 - assign ko1
 
-- \[Bug [#12834](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12834&sa=D&source=editors&ust=1686087122723543&usg=AOvVaw36zBIrc7vQR1uqY3j9M3OV)\] prepend getting prepended even if it already exists in the ancestors chain (shyouhei)
+- \[Bug [#12834](https://bugs.ruby-lang.org/issues/12834)\] prepend getting prepended even if it already exists in the ancestors chain (shyouhei)
 
 - akr: doesn’t this loop forever?
 - ko1: no. I fixed that loop.
 - matz: I wanted to change include’s behaviour in 1.9 but not successful then.
 - matz: I started thinking prepend shall be applied many times. For include..?
 
-- \[Bug [#7976](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7976&sa=D&source=editors&ust=1686087122724088&usg=AOvVaw2p-KtWbppMpYV_kPxrkhEP)\] TracePoint call is at call point, not call site (shyouhei)
+- \[Bug [#7976](https://bugs.ruby-lang.org/issues/7976)\] TracePoint call is at call point, not call site (shyouhei)
 
 - ko1: わかる
 - assign ko1
 
-- \[Feature [#12901](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12901&sa=D&source=editors&ust=1686087122724435&usg=AOvVaw2B47DTJgvTqndFMevZAOMW)\] Anonymous functions without scope lookup overhead (shyouhei) status?
+- \[Feature [#12901](https://bugs.ruby-lang.org/issues/12901)\] Anonymous functions without scope lookup overhead (shyouhei) status?
 
 - pass this time.
 
-- \[Feature [#12573](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12573&sa=D&source=editors&ust=1686087122724726&usg=AOvVaw2FRbUZ8LDKn090Oj2eN_Qi)\] Introduce a straightforward way to discover whether a process is running (shyouhei)
+- \[Feature [#12573](https://bugs.ruby-lang.org/issues/12573)\] Introduce a straightforward way to discover whether a process is running (shyouhei)
 
 - akr: locked pidfile does not need this method.
 
-- \[Feature [#13263](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13263&sa=D&source=editors&ust=1686087122725023&usg=AOvVaw0hrAzvMDvkye9S6_wHonE3)\] Add companion integer nth-root method to recent Integer#isqrt (shyouhei)
+- \[Feature [#13263](https://bugs.ruby-lang.org/issues/13263)\] Add companion integer nth-root method to recent Integer#isqrt (shyouhei)
 
 - shyouhei: I have no idea when this is used.
 - akr: same as above.
 - mrkn: what about asking the OP?
 
-- \[Feature [#9453](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9453&sa=D&source=editors&ust=1686087122725413&usg=AOvVaw0x9NWsSDTLaeLvtHEG4qO8)\] Return symbols of defined methods for attr and friends (shyouhei) look at the last comment
+- \[Feature [#9453](https://bugs.ruby-lang.org/issues/9453)\] Return symbols of defined methods for attr and friends (shyouhei) look at the last comment
 
 - shyouhei: the last comment says the situation changed.
 - akr: that sounds reasonable…
 - matz: but definition of multiple methods at once is something special here.
 - matz: will respond.
 
-- \[Feature [#13302](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13302&sa=D&source=editors&ust=1686087122725940&usg=AOvVaw2seQ-DVeSjCGyST5deqfor)\] Provide a (force) --enable-openssl switch for ruby ./configure (or similar) (shyouhei)
+- \[Feature [#13302](https://bugs.ruby-lang.org/issues/13302)\] Provide a (force) --enable-openssl switch for ruby ./configure (or similar) (shyouhei)
 
 - shyouhei: openssl needs miniruby and doesn’t stop if absent.
 - naruse: --enable-openssl sounds strange, it should be --with-openssl
 - nobu: what about let --with-ext=openssl to abort if absent.
 
-- \[Feature [#13303](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13303&sa=D&source=editors&ust=1686087122726359&usg=AOvVaw1U0mFhxOZCRQvorvRkWLq_)\] String#any? as !String#empty? (shyouhei)
+- \[Feature [#13303](https://bugs.ruby-lang.org/issues/13303)\] String#any? as !String#empty? (shyouhei)
 
 - matz: I don’t like any? because Enumerable#any? cannot be applied to String straight-forward.
 - matz: str.not\_empty? seems inferior than !str.empty?
@@ -293,81 +293,81 @@ log: TBD
 
 ## From attendees
 
-- \[Feature [#13334](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13334&sa=D&source=editors&ust=1686087122727138&usg=AOvVaw3-81xF28oFa1wyObik1N--)\] Removed deprecated mathn extentions. (hsbt)
+- \[Feature [#13334](https://bugs.ruby-lang.org/issues/13334)\] Removed deprecated mathn extentions. (hsbt)
 
 - matz: OK.
 
 - Assign who? section (shyouhei)
 
-- \[Bug [#13228](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13228&sa=D&source=editors&ust=1686087122727516&usg=AOvVaw3OrGcAYZ0djovpk7gdSTEU)\] s\[i\]=c(assigning a character) for String is slower than Array on Linux
+- \[Bug [#13228](https://bugs.ruby-lang.org/issues/13228)\] s\[i\]=c(assigning a character) for String is slower than Array on Linux
 
 - shyouhei: that search\_nonascii is unavoidable
 - naruse: 5x slower on my machine
 - nobu: no difference on my macine
 - shyouhei: what’s the cause?
 
-- \[Bug [#13264](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13264&sa=D&source=editors&ust=1686087122728004&usg=AOvVaw1GUEhDi9aC9VySoQM2DfU7)\] Binding#irb does not work in context of frozen object
-- \[Bug [#12642](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12642&sa=D&source=editors&ust=1686087122728243&usg=AOvVaw2henhyrMNVVFzpaQaO3fYj)\] Net::HTTP populates host header incorrectly when using an IPv6 Address
-- \[Bug [#13196](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13196&sa=D&source=editors&ust=1686087122728472&usg=AOvVaw3gQOrI1i15WYSdG17rNx0U)\] Improve keyword argument errors when non-keyword arguments given
-- \[Bug [#13320](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13320&sa=D&source=editors&ust=1686087122728702&usg=AOvVaw3uGH5geBofyKPtxaeWwwcB)\] rescue blocks get an entry in backtrace locations
-- \[Bug [#13324](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13324&sa=D&source=editors&ust=1686087122728936&usg=AOvVaw0KuqeaDG90KRvRMkGIsLPK)\] IRB Segmentation Fault from eval infinite loop
-- \[Bug [#13330](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13330&sa=D&source=editors&ust=1686087122729161&usg=AOvVaw3t-3l5uoG_aVGKuBzd6ZJ3)\] Array.include? is slow for symbols
-- \[Bug [#13336](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13336&sa=D&source=editors&ust=1686087122729380&usg=AOvVaw2vWsjbotLVHIrIf03NcnWc)\] Default Parameters don't work
-- \[Bug [#13337](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13337&sa=D&source=editors&ust=1686087122729600&usg=AOvVaw022wLG4nTHcFP5bzHwT4BE)\] Eval and Later Defined Local Variables
-- \[Bug [#13338](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13338&sa=D&source=editors&ust=1686087122729825&usg=AOvVaw2Jz6C_XVAV2dEkbJWWLYUK)\] MinGW SEGV in test/ruby/test\_keyword.rb svn 58034, ok in svn 58021.
-- \[Bug [#13390](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13390&sa=D&source=editors&ust=1686087122730101&usg=AOvVaw3L0KetkjBjV389m7xBb63e)\] MinGW build test-all SEGV, issue in test framework or error recovery?
-- \[Bug [#13350](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13350&sa=D&source=editors&ust=1686087122730360&usg=AOvVaw3GWGiD7UMBP_qBgAQ81YHp)\] File.read :newline option not respected on Linux
-- \[Feature [#13362](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13362&sa=D&source=editors&ust=1686087122730596&usg=AOvVaw2y5VyOtAy1FEoT9XuuD6LU)\] \[PATCH\] socket: avoid fcntl for read/write\_nonblock on Linux
-- \[Bug [#13351](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13351&sa=D&source=editors&ust=1686087122730894&usg=AOvVaw1agye7Y672JRS_iNelwxjv)\] net/http: Net::HTTP.start sets wrong default arg value
+- \[Bug [#13264](https://bugs.ruby-lang.org/issues/13264)\] Binding#irb does not work in context of frozen object
+- \[Bug [#12642](https://bugs.ruby-lang.org/issues/12642)\] Net::HTTP populates host header incorrectly when using an IPv6 Address
+- \[Bug [#13196](https://bugs.ruby-lang.org/issues/13196)\] Improve keyword argument errors when non-keyword arguments given
+- \[Bug [#13320](https://bugs.ruby-lang.org/issues/13320)\] rescue blocks get an entry in backtrace locations
+- \[Bug [#13324](https://bugs.ruby-lang.org/issues/13324)\] IRB Segmentation Fault from eval infinite loop
+- \[Bug [#13330](https://bugs.ruby-lang.org/issues/13330)\] Array.include? is slow for symbols
+- \[Bug [#13336](https://bugs.ruby-lang.org/issues/13336)\] Default Parameters don't work
+- \[Bug [#13337](https://bugs.ruby-lang.org/issues/13337)\] Eval and Later Defined Local Variables
+- \[Bug [#13338](https://bugs.ruby-lang.org/issues/13338)\] MinGW SEGV in test/ruby/test\_keyword.rb svn 58034, ok in svn 58021.
+- \[Bug [#13390](https://bugs.ruby-lang.org/issues/13390)\] MinGW build test-all SEGV, issue in test framework or error recovery?
+- \[Bug [#13350](https://bugs.ruby-lang.org/issues/13350)\] File.read :newline option not respected on Linux
+- \[Feature [#13362](https://bugs.ruby-lang.org/issues/13362)\] \[PATCH\] socket: avoid fcntl for read/write\_nonblock on Linux
+- \[Bug [#13351](https://bugs.ruby-lang.org/issues/13351)\] net/http: Net::HTTP.start sets wrong default arg value
 - watson's
 
-- \[Bug [#13341](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13341&sa=D&source=editors&ust=1686087122731174&usg=AOvVaw3vJ6t3wO8Q2y04WuX3aREV)\] Improve performance of implicit type conversion
-- \[Bug [#13342](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13342&sa=D&source=editors&ust=1686087122731399&usg=AOvVaw27ukCh-R931VFwE2UkaR4v)\] Improve yielding block performance
-- \[Bug [#13354](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13354&sa=D&source=editors&ust=1686087122731628&usg=AOvVaw0JRmZ6VawTuwrVyH7rtVKd)\] Improve Time#<=> performance
-- \[Bug [#13357](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13357&sa=D&source=editors&ust=1686087122731856&usg=AOvVaw0MLZ4oAZSFGuaay_8Ng72V)\] Improve Time#+ & Time#- performance
-- \[Bug [#13365](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13365&sa=D&source=editors&ust=1686087122732081&usg=AOvVaw3Sdh0751gPOaztmvprXucs)\] Improve performance of rb\_equal() with special constants
-- \[Bug [#13368](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13368&sa=D&source=editors&ust=1686087122732296&usg=AOvVaw3EMl45Dx7j_0iSH8a1cPVJ)\] Improve performance of Array#sum with float elements
-- \[Bug [#13374](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13374&sa=D&source=editors&ust=1686087122732523&usg=AOvVaw0Bzq-BKS1sGumzB90PYZ47)\] Fix one of performance regressions in method calling
+- \[Bug [#13341](https://bugs.ruby-lang.org/issues/13341)\] Improve performance of implicit type conversion
+- \[Bug [#13342](https://bugs.ruby-lang.org/issues/13342)\] Improve yielding block performance
+- \[Bug [#13354](https://bugs.ruby-lang.org/issues/13354)\] Improve Time#<=> performance
+- \[Bug [#13357](https://bugs.ruby-lang.org/issues/13357)\] Improve Time#+ & Time#- performance
+- \[Bug [#13365](https://bugs.ruby-lang.org/issues/13365)\] Improve performance of rb\_equal() with special constants
+- \[Bug [#13368](https://bugs.ruby-lang.org/issues/13368)\] Improve performance of Array#sum with float elements
+- \[Bug [#13374](https://bugs.ruby-lang.org/issues/13374)\] Fix one of performance regressions in method calling
 - nobu: I call him for a volunteer.
 
-- \[Bug [#13373](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13373&sa=D&source=editors&ust=1686087122732863&usg=AOvVaw1Zzt66ekSUc5p5MhnuLsgH)\] FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
-- \[Bug [#13101](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13101&sa=D&source=editors&ust=1686087122733155&usg=AOvVaw0S6WzfImSZKHBDIk6T71v1)\] Date#rfc2822 and Time#rfc2822 don't return the same format
-- \[Bug [#13312](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13312&sa=D&source=editors&ust=1686087122733397&usg=AOvVaw0NvGAiVJTkuITHACuYV474)\] String#casecmp raises TypeError instead of returning nil
-- \[Bug [#12684](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12684&sa=D&source=editors&ust=1686087122733647&usg=AOvVaw1B71EWK5X0wYFW0kJZ5h-Y)\] Delegator#eql? missing
-- \[Feature [#13389](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13389&sa=D&source=editors&ust=1686087122733885&usg=AOvVaw3qhJYmeXdT91A7QSw523Aq)\] \[PATCH\] POP3 support timeout for TLS handshake
-- \[Bug [#13319](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13319&sa=D&source=editors&ust=1686087122734124&usg=AOvVaw3Qk_84H8GKog-iocFGXCUq)\] GC issues seen with GCC7
-- \[Bug [#13404](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13404&sa=D&source=editors&ust=1686087122734368&usg=AOvVaw1Fj8gboJGtZqr96R1tuN7W)\] Hash#any? yields arguments to lambdas with proc semantics
-- \[Bug [#13406](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13406&sa=D&source=editors&ust=1686087122734594&usg=AOvVaw2etzx_RXQvnPD950Wa6FJW)\] URI.parse
-- \[Bug [#13413](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13413&sa=D&source=editors&ust=1686087122734818&usg=AOvVaw10EVTXSJqb3Cfjp3eNXRNm)\] --with-static-linked-ext doesn't install extension files on make install
-- \[Bug [#13420](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13420&sa=D&source=editors&ust=1686087122735076&usg=AOvVaw0tcHdRALnLpYGaPzvootlR)\] Integer#{round,floor,ceil,truncate} should always return an integer, not a float
-- \[Bug [#13429](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13429&sa=D&source=editors&ust=1686087122735308&usg=AOvVaw1BBOXe0clUmoEpBomguCe2)\] Net::SMTP has no read timeout when connexion over TLS
+- \[Bug [#13373](https://bugs.ruby-lang.org/issues/13373)\] FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
+- \[Bug [#13101](https://bugs.ruby-lang.org/issues/13101)\] Date#rfc2822 and Time#rfc2822 don't return the same format
+- \[Bug [#13312](https://bugs.ruby-lang.org/issues/13312)\] String#casecmp raises TypeError instead of returning nil
+- \[Bug [#12684](https://bugs.ruby-lang.org/issues/12684)\] Delegator#eql? missing
+- \[Feature [#13389](https://bugs.ruby-lang.org/issues/13389)\] \[PATCH\] POP3 support timeout for TLS handshake
+- \[Bug [#13319](https://bugs.ruby-lang.org/issues/13319)\] GC issues seen with GCC7
+- \[Bug [#13404](https://bugs.ruby-lang.org/issues/13404)\] Hash#any? yields arguments to lambdas with proc semantics
+- \[Bug [#13406](https://bugs.ruby-lang.org/issues/13406)\] URI.parse
+- \[Bug [#13413](https://bugs.ruby-lang.org/issues/13413)\] --with-static-linked-ext doesn't install extension files on make install
+- \[Bug [#13420](https://bugs.ruby-lang.org/issues/13420)\] Integer#{round,floor,ceil,truncate} should always return an integer, not a float
+- \[Bug [#13429](https://bugs.ruby-lang.org/issues/13429)\] Net::SMTP has no read timeout when connexion over TLS
 
-- \[Feature [#13309](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13309&sa=D&source=editors&ust=1686087122735562&usg=AOvVaw1rGW67kwupctHy1kyijQfa)\] Locale paramter for Integer(), Float(), Rational() (shyouhei)
-- \[Feature [#12733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12733&sa=D&source=editors&ust=1686087122735890&usg=AOvVaw2tobSod-IAIf2rr87LCe_J)\] Bundle bundler to ruby core (shyouhei) updates?
-- \[Feature [#11302](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11302&sa=D&source=editors&ust=1686087122736152&usg=AOvVaw02HbM97bM7N9nUbBdiJY0s)\] Dir.entries and Dir.foreach without [".", ".."](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby/wiki/shyouhei&sa=D&source=editors&ust=1686087122736354&usg=AOvVaw3-W3en2lWsHTPSDYFndQxH)
-- \[Feature [#13332](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13332&sa=D&source=editors&ust=1686087122736579&usg=AOvVaw0pe0UheK0Fwp9xHdqLXO7f)\] Forwardable#def\_instance\_delegator nil (shyouhei)
-- \[Feature [#13334](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13334&sa=D&source=editors&ust=1686087122736821&usg=AOvVaw00taDTe9RfdTfOrVwdTMNk)\] Removed deprecated mathn extentions. (shyouhei)
-- \[Bug [#12921](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12921&sa=D&source=editors&ust=1686087122737071&usg=AOvVaw3d94DzH7HwfCeq06BwXy8M)\] Retrieve user and password for proxy from env (shyouhei)
+- \[Feature [#13309](https://bugs.ruby-lang.org/issues/13309)\] Locale paramter for Integer(), Float(), Rational() (shyouhei)
+- \[Feature [#12733](https://bugs.ruby-lang.org/issues/12733)\] Bundle bundler to ruby core (shyouhei) updates?
+- \[Feature [#11302](https://bugs.ruby-lang.org/issues/11302)\] Dir.entries and Dir.foreach without [".", ".."](https://bugs.ruby-lang.org/projects/ruby/wiki/shyouhei)
+- \[Feature [#13332](https://bugs.ruby-lang.org/issues/13332)\] Forwardable#def\_instance\_delegator nil (shyouhei)
+- \[Feature [#13334](https://bugs.ruby-lang.org/issues/13334)\] Removed deprecated mathn extentions. (shyouhei)
+- \[Bug [#12921](https://bugs.ruby-lang.org/issues/12921)\] Retrieve user and password for proxy from env (shyouhei)
 
 - akr: what about whitelisting OSes? modern ones should work.
 
-- \[Feature [#13333](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13333&sa=D&source=editors&ust=1686087122737363&usg=AOvVaw0RO799t-dpJ57QUR8uv1a8)\] block to yield (shyouhei)
-- \[Feature [#13378](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13378&sa=D&source=editors&ust=1686087122737613&usg=AOvVaw0VLNl2HUo3YRd71ELvsvcS)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
-- \[Feature [#13381](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13381&sa=D&source=editors&ust=1686087122737914&usg=AOvVaw0ZzPuneHgL-5dhXt4Y63dA)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
-- \[Bug [#13315](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13315&sa=D&source=editors&ust=1686087122738143&usg=AOvVaw20FjCYC07kPJH1fh2oviWj)\] Single "%" at the end of printf format string appears in the result (shyouhei)
-- \[Feature [#13385](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13385&sa=D&source=editors&ust=1686087122738482&usg=AOvVaw1i69spS9hplpKcgcoRqaQh)\] \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
-- \[Feature [#13383](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13383&sa=D&source=editors&ust=1686087122738775&usg=AOvVaw169MO9VP2ms4nQ0xDwde3H)\] \[PATCH\] Module#source\_location (shyouhei)
-- \[Feature [#12063](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12063&sa=D&source=editors&ust=1686087122739055&usg=AOvVaw2WROCb0I75VVt8B1BnCm8J)\] KeyError#receiver and KeyError#name (shyouhei) status?
-- \[Bug [#13397](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13397&sa=D&source=editors&ust=1686087122739290&usg=AOvVaw09O6cDZV4CRPYn0UnilTVq)\] #object\_id should not be signed (shyouhei)
-- \[Feature [#13396](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13396&sa=D&source=editors&ust=1686087122739524&usg=AOvVaw0BHIX0J88T-fi08ousH9Fa)\] Net::HTTP has no write timeout (shyouhei)
-- \[Bug [#13407](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13407&sa=D&source=editors&ust=1686087122739763&usg=AOvVaw2aEUIT4URByDcPOJdGnrxe)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
-- \[Feature [#13395](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13395&sa=D&source=editors&ust=1686087122740027&usg=AOvVaw23iF5bw-l5ysjWDsR9DhFc)\] Add a method to check for not nil (shyouhei)
+- \[Feature [#13333](https://bugs.ruby-lang.org/issues/13333)\] block to yield (shyouhei)
+- \[Feature [#13378](https://bugs.ruby-lang.org/issues/13378)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+- \[Feature [#13381](https://bugs.ruby-lang.org/issues/13381)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+- \[Bug [#13315](https://bugs.ruby-lang.org/issues/13315)\] Single "%" at the end of printf format string appears in the result (shyouhei)
+- \[Feature [#13385](https://bugs.ruby-lang.org/issues/13385)\] \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
+- \[Feature [#13383](https://bugs.ruby-lang.org/issues/13383)\] \[PATCH\] Module#source\_location (shyouhei)
+- \[Feature [#12063](https://bugs.ruby-lang.org/issues/12063)\] KeyError#receiver and KeyError#name (shyouhei) status?
+- \[Bug [#13397](https://bugs.ruby-lang.org/issues/13397)\] #object\_id should not be signed (shyouhei)
+- \[Feature [#13396](https://bugs.ruby-lang.org/issues/13396)\] Net::HTTP has no write timeout (shyouhei)
+- \[Bug [#13407](https://bugs.ruby-lang.org/issues/13407)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+- \[Feature [#13395](https://bugs.ruby-lang.org/issues/13395)\] Add a method to check for not nil (shyouhei)
 
 ## From non-attendees
 
-- \[Feature [#12886](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12886&sa=D&source=editors&ust=1686087122740552&usg=AOvVaw32R8CY3zlSZzr_NRQLzNHP)\] URI#merge doesn't handle paths correctly (hsbt)
+- \[Feature [#12886](https://bugs.ruby-lang.org/issues/12886)\] URI#merge doesn't handle paths correctly (hsbt)
 
-- hsbt: cf [https://github.com/ruby/ruby/pull/1469](https://www.google.com/url?q=https://github.com/ruby/ruby/pull/1469&sa=D&source=editors&ust=1686087122740944&usg=AOvVaw1P7511zXU7IWMhMorJbG0r)
+- hsbt: cf [https://github.com/ruby/ruby/pull/1469](https://github.com/ruby/ruby/pull/1469)
 - hsbt: the fix seems partial. status?
 - nobu: the fix did not change behaviours.
 - hsbt: what about this issue then?

--- a/2017/DevMeeting-2017-05-19.md
+++ b/2017/DevMeeting-2017-05-19.md
@@ -140,7 +140,7 @@ Place: Speee Inc. Headquarter
 
 Sign-up: https://ruby.connpass.com/event/55487/
 
-log edit: [https://docs.google.com/document/d/1XolSYFFvBOj\_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1XolSYFFvBOj_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit&sa=D&source=editors&ust=1686087156478680&usg=AOvVaw3OMGEHJuo3NAojETLp_5NU)
+log edit: [https://docs.google.com/document/d/1XolSYFFvBOj\_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit](https://docs.google.com/document/d/1XolSYFFvBOj_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit)
 
 log: TBD
 
@@ -152,7 +152,7 @@ log: TBD
 
 ## About 2.5 timeframe
 
-## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087156480146&usg=AOvVaw0VF_ATzWdeZPXffCleFlIC)
+## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25)
 
 - Previrew 1 in June?
 
@@ -172,190 +172,190 @@ log: TBD
 
 - Previous bugs that were not assigned
 
-- \[Bug [#13196](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13196&sa=D&source=editors&ust=1686087156482105&usg=AOvVaw3Yo7tKZQmQV723le4d_SCL)\] Improve keyword argument errors when non-keyword arguments given
+- \[Bug [#13196](https://bugs.ruby-lang.org/issues/13196)\] Improve keyword argument errors when non-keyword arguments given
 
 - ko1: isn’t it too long?
 - shyouhei: that depends.
 - matz: it’s a good idea to make errors descriptive.
 
-- \[Bug [#13320](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13320&sa=D&source=editors&ust=1686087156482880&usg=AOvVaw2JDGt2gZgKOZmhQ2j62qOv)\] rescue blocks get an entry in backtrace locations
+- \[Bug [#13320](https://bugs.ruby-lang.org/issues/13320)\] rescue blocks get an entry in backtrace locations
 
 - shyouhei: can you look at it? > nobu
 - ko1: there are other corner cases in backtraces where \_unexpected\_-ish backtrace situation.
 - mrkn: does it cause any problems? is it worth deleting?
 - ko1: I tried this and the “bar” line seems indicating the method bar, not raise.
 
-- \[Bug [#13324](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13324&sa=D&source=editors&ust=1686087156483626&usg=AOvVaw1bE2X8qLYGazqxy-jZQJIH)\] IRB Segmentation Fault from eval infinite loop
+- \[Bug [#13324](https://bugs.ruby-lang.org/issues/13324)\] IRB Segmentation Fault from eval infinite loop
 
 - akr: this is a infinite loop.
 - akr: isn’t it possible to extend guard page?
 - ko1: it is technically impossible to rewind stack overflow.
 
-- \[Bug [#13330](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13330&sa=D&source=editors&ust=1686087156484237&usg=AOvVaw0qfAi2jIPCsi6VAEWaMsVo)\] Array.include? is slow for symbols
+- \[Bug [#13330](https://bugs.ruby-lang.org/issues/13330)\] Array.include? is slow for symbols
 
 - assign ko1
 
-- \[Bug [#13336](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13336&sa=D&source=editors&ust=1686087156484703&usg=AOvVaw2uZATeXdtJ0oUbe3lVregb)\] Default Parameters don't work
+- \[Bug [#13336](https://bugs.ruby-lang.org/issues/13336)\] Default Parameters don't work
 
 - ko1: would like to hear from mame.
 
-- \[Bug [#13337](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13337&sa=D&source=editors&ust=1686087156485229&usg=AOvVaw3tjKJAUjAs3XsieghWipll)\] Eval and Later Defined Local Variables
+- \[Bug [#13337](https://bugs.ruby-lang.org/issues/13337)\] Eval and Later Defined Local Variables
 
 - akr: this is by design.
 - shyouhei: doc issue?
 
-- \[Bug [#13390](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13390&sa=D&source=editors&ust=1686087156485769&usg=AOvVaw0bkxXWseBCShXuoKIdXzUx)\] MinGW build test-all SEGV, issue in test framework or error recovery?
+- \[Bug [#13390](https://bugs.ruby-lang.org/issues/13390)\] MinGW build test-all SEGV, issue in test framework or error recovery?
 
 - nobu: I’m working on it
 - naruse: OK, assign to you.
 
-- \[Bug [#13350](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13350&sa=D&source=editors&ust=1686087156486332&usg=AOvVaw0OL0VFd6FpdF9sar8yqwSo)\] File.read :newline option not respected on Linux
+- \[Bug [#13350](https://bugs.ruby-lang.org/issues/13350)\] File.read :newline option not respected on Linux
 
 - shyouhei: this is a bug.
 - nobu: Windows situation is done by the runtime.
 
-- \[Bug [#13351](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13351&sa=D&source=editors&ust=1686087156486908&usg=AOvVaw06cbnnkbCI1kAY9k3IgD5T)\] net/http: Net::HTTP.start sets wrong default arg value
+- \[Bug [#13351](https://bugs.ruby-lang.org/issues/13351)\] net/http: Net::HTTP.start sets wrong default arg value
 
 - akr: is it possible to simulate old behavior, when we change the default?
 - shyouhei: yes.
 
-- \[Bug [#13373](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13373&sa=D&source=editors&ust=1686087156487498&usg=AOvVaw1hkV0QH-vkftklmSoBDN_a)\] FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
+- \[Bug [#13373](https://bugs.ruby-lang.org/issues/13373)\] FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
 
 - matz: reproducible code?
 
-- \[Bug [#13101](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13101&sa=D&source=editors&ust=1686087156487951&usg=AOvVaw3J49qqgtIk9YVXvn1Tk_Ua)\] Date#rfc2822 and Time#rfc2822 don't return the same format
+- \[Bug [#13101](https://bugs.ruby-lang.org/issues/13101)\] Date#rfc2822 and Time#rfc2822 don't return the same format
 
 - akr: technically they are both true.
 - nobu: the patch also includes -0000 change
 - shyouhei: that’s a problem.
 
-- \[Bug [#13312](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13312&sa=D&source=editors&ust=1686087156488678&usg=AOvVaw0IP2Tibp_sVfj4hlOHJ_2n)\] String#casecmp raises TypeError instead of returning nil
+- \[Bug [#13312](https://bugs.ruby-lang.org/issues/13312)\] String#casecmp raises TypeError instead of returning nil
 
 - nobu: I think it’s OK to fix.
 - hsbt: assign stomer
 
-- \[Bug [#12684](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12684&sa=D&source=editors&ust=1686087156489198&usg=AOvVaw0-gaLT34QgLJnczTM9AuZ9)\] Delegator#eql? missing
+- \[Bug [#12684](https://bugs.ruby-lang.org/issues/12684)\] Delegator#eql? missing
 
 - shyouhei: it ends with “nobu: seems fine”.
 - nobu: will look at it again.
 
-- \[Feature [#13389](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13389&sa=D&source=editors&ust=1686087156489703&usg=AOvVaw3UAc2VLGvjLJGeVATXtx96)\] \[PATCH\] POP3 support timeout for TLS handshake
+- \[Feature [#13389](https://bugs.ruby-lang.org/issues/13389)\] \[PATCH\] POP3 support timeout for TLS handshake
 
 - assign who?
 - seems no one is active.
 - nobu: why not just merge it?
 
-- \[Bug [#13404](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13404&sa=D&source=editors&ust=1686087156490332&usg=AOvVaw0nDnfQmQzf4iuobhMoSASw)\] Hash#any? yields arguments to lambdas with proc semantics
+- \[Bug [#13404](https://bugs.ruby-lang.org/issues/13404)\] Hash#any? yields arguments to lambdas with proc semantics
 
 - nobu: #13391 is blocking this issue.
 
-- \[Bug [#13413](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13413&sa=D&source=editors&ust=1686087156490850&usg=AOvVaw1jtNFgFhXOE5WRqMBrDW5U)\] --with-static-linked-ext doesn't install extension files on make install
+- \[Bug [#13413](https://bugs.ruby-lang.org/issues/13413)\] --with-static-linked-ext doesn't install extension files on make install
 
 - assign nobu
 
-- \[Bug [#13429](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13429&sa=D&source=editors&ust=1686087156491355&usg=AOvVaw3dRqRqIMWEKA7b6JjM4_ct)\] Net::SMTP has no read timeout when connexion over TLS
+- \[Bug [#13429](https://bugs.ruby-lang.org/issues/13429)\] Net::SMTP has no read timeout when connexion over TLS
 
 - assign shugo
 
-- \[Feature [#13309](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13309&sa=D&source=editors&ust=1686087156491786&usg=AOvVaw1agut7TpHNRQ3wcMNxID6A)\] Locale paramter for Integer(), Float(), Rational() (shyouhei)
+- \[Feature [#13309](https://bugs.ruby-lang.org/issues/13309)\] Locale paramter for Integer(), Float(), Rational() (shyouhei)
 
 - nobu: This should start as a gem.
 
-- \[Feature [#12733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12733&sa=D&source=editors&ust=1686087156492263&usg=AOvVaw0XQpOQUyMziOg6FlAsILlE)\] Bundle bundler to ruby core (shyouhei) updates?
-- \[Feature [#11302](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11302&sa=D&source=editors&ust=1686087156492604&usg=AOvVaw0nDkpvFwx_POGpajeQCQHw)\] Dir.entries and Dir.foreach without [".", ".."](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby/wiki/shyouhei&sa=D&source=editors&ust=1686087156492895&usg=AOvVaw3OBe57vNKsMf_ATnZ0N4OI)
+- \[Feature [#12733](https://bugs.ruby-lang.org/issues/12733)\] Bundle bundler to ruby core (shyouhei) updates?
+- \[Feature [#11302](https://bugs.ruby-lang.org/issues/11302)\] Dir.entries and Dir.foreach without [".", ".."](https://bugs.ruby-lang.org/projects/ruby/wiki/shyouhei)
 
 - matz: OK.
 
-- \[Feature [#13332](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13332&sa=D&source=editors&ust=1686087156493326&usg=AOvVaw1_kzKnDDMkBrcOKrbpMnbe)\] Forwardable#def\_instance\_delegator nil (shyouhei)
-- \[Feature [#13333](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13333&sa=D&source=editors&ust=1686087156493785&usg=AOvVaw2hHHe_xqEmSzddHE_tTvzy)\] block to yield (shyouhei)
+- \[Feature [#13332](https://bugs.ruby-lang.org/issues/13332)\] Forwardable#def\_instance\_delegator nil (shyouhei)
+- \[Feature [#13333](https://bugs.ruby-lang.org/issues/13333)\] block to yield (shyouhei)
 
 - nobu: because we can.
 - ko1: I’m afraid there can be places where this breaks something in-core.
 
-- \[Feature [#13378](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13378&sa=D&source=editors&ust=1686087156494351&usg=AOvVaw0WKGt3JtNvayGUYVAZRdYQ)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
-- \[Feature [#13381](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13381&sa=D&source=editors&ust=1686087156494730&usg=AOvVaw0BMZUadcCXBfbJCCiUq0LV)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
-- \[Bug [#13315](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13315&sa=D&source=editors&ust=1686087156495152&usg=AOvVaw1ecD5ezwSkySAflvN4VgDC)\] Single "%" at the end of printf format string appears in the result (shyouhei)
-- \[Feature [#13385](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13385&sa=D&source=editors&ust=1686087156495600&usg=AOvVaw1HGYyO6BJ_jHeJcaXPto3W)\] \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
-- \[Feature [#13383](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13383&sa=D&source=editors&ust=1686087156495967&usg=AOvVaw0q7PPXoJ1A8asn8ROwOeBq)\] \[PATCH\] Module#source\_location (shyouhei)
-- \[Feature [#12063](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12063&sa=D&source=editors&ust=1686087156496344&usg=AOvVaw2CtN3dqBFbnsEvtCYMIJmX)\] KeyError#receiver and KeyError#name (shyouhei) status?
-- \[Bug [#13397](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13397&sa=D&source=editors&ust=1686087156496693&usg=AOvVaw0LrtXRQ_88mu7aXuTziKVQ)\] #object\_id should not be signed (shyouhei)
-- \[Feature [#13396](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13396&sa=D&source=editors&ust=1686087156497048&usg=AOvVaw09p-UD2axNXzbK4vNbHNfA)\] Net::HTTP has no write timeout (shyouhei)
-- \[Bug [#13407](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13407&sa=D&source=editors&ust=1686087156497394&usg=AOvVaw2FaC6UP2MitQeAfP9d5b-X)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
-- \[Feature [#13395](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13395&sa=D&source=editors&ust=1686087156497736&usg=AOvVaw3tmSS73OsQBuqp1ui4vBFd)\] Add a method to check for not nil (shyouhei)
+- \[Feature [#13378](https://bugs.ruby-lang.org/issues/13378)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+- \[Feature [#13381](https://bugs.ruby-lang.org/issues/13381)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+- \[Bug [#13315](https://bugs.ruby-lang.org/issues/13315)\] Single "%" at the end of printf format string appears in the result (shyouhei)
+- \[Feature [#13385](https://bugs.ruby-lang.org/issues/13385)\] \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
+- \[Feature [#13383](https://bugs.ruby-lang.org/issues/13383)\] \[PATCH\] Module#source\_location (shyouhei)
+- \[Feature [#12063](https://bugs.ruby-lang.org/issues/12063)\] KeyError#receiver and KeyError#name (shyouhei) status?
+- \[Bug [#13397](https://bugs.ruby-lang.org/issues/13397)\] #object\_id should not be signed (shyouhei)
+- \[Feature [#13396](https://bugs.ruby-lang.org/issues/13396)\] Net::HTTP has no write timeout (shyouhei)
+- \[Bug [#13407](https://bugs.ruby-lang.org/issues/13407)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+- \[Feature [#13395](https://bugs.ruby-lang.org/issues/13395)\] Add a method to check for not nil (shyouhei)
 
 ## From attendees
 
-- \[Feature [#13483](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13483&sa=D&source=editors&ust=1686087156498294&usg=AOvVaw3wehzK0inW8VtKzeeR1Exd)\] TracePoint#enable with block for thread-local trace (ko1)
+- \[Feature [#13483](https://bugs.ruby-lang.org/issues/13483)\] TracePoint#enable with block for thread-local trace (ko1)
 
 - ko1: I want to make trace thread local
 - shyouhei: is there a way to emulate old behaviour?
 - ko1: ThracePoint.enable will do.
 
-- \[Bug [#13249](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13249&sa=D&source=editors&ust=1686087156499012&usg=AOvVaw2YoPSETbfcRi7LzKtJs3HA)\] Access modifiers don't have an effect inside class methods in Ruby >= 2.3 (ko1, ask the approach)
+- \[Bug [#13249](https://bugs.ruby-lang.org/issues/13249)\] Access modifiers don't have an effect inside class methods in Ruby >= 2.3 (ko1, ask the approach)
 
 - shyouhei: we want to prohibit private with zero arity inside of a singleton method.
 
 - watson continues to request pulling his ideas
 
-- \[Bug [#13436](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13436&sa=D&source=editors&ust=1686087156499600&usg=AOvVaw2pgVRdoyZhRe4KIb0NYmnY)\] Improve performance of Array#<=> with Fixnum/Float/String elements
-- \[Bug [#13437](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13437&sa=D&source=editors&ust=1686087156499976&usg=AOvVaw22P1wkLUWAT6OSDoKzhWm5)\] Improve performance of Enumerable#{sort\_by,min\_by,max\_by,minmax\_by}
-- \[Bug [#13443](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13443&sa=D&source=editors&ust=1686087156500366&usg=AOvVaw3uzkASks7qI6UNC3KVVrLE)\] Improve performance of Range#{min,max}
-- \[Bug [#13482](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13482&sa=D&source=editors&ust=1686087156500796&usg=AOvVaw2Kv3qcBxDYPIZOug5MEtxb)\] Improve performance of "set instance variable"
-- \[Bug [#13447](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13447&sa=D&source=editors&ust=1686087156501151&usg=AOvVaw2Iyb8Y8dIeiQ-itEZGWemd)\] Improve performance of rb\_eql()
-- \[Bug [#13503](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13503&sa=D&source=editors&ust=1686087156501553&usg=AOvVaw3ofWEuQ01nKoXEyigOoFPp)\] Improve performance of some Time & Rational methods
-- \[Bug [#13506](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13506&sa=D&source=editors&ust=1686087156501938&usg=AOvVaw1TYWnB_KvI4UzYtFnbVkxj)\] Improve performance of Complex#{+,-,,/,\*,abs2}
-- \[Bug [#13519](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13519&sa=D&source=editors&ust=1686087156502369&usg=AOvVaw3nil-_WaPKS2pd8ST0B9y8)\] Improve performance of some Time methods
-- \[Bug [#13507](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13507&sa=D&source=editors&ust=1686087156502724&usg=AOvVaw3jbehw0HVf5ThYtJXf4a5O)\] Improve performance of some Complex methods where call Numeric#real? internally
-- \[Bug [#13553](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13553&sa=D&source=editors&ust=1686087156503081&usg=AOvVaw3vpDy6mnSwX51rdUEQ1nQ0)\] Improve performance in where push the element into non shared Array object
+- \[Bug [#13436](https://bugs.ruby-lang.org/issues/13436)\] Improve performance of Array#<=> with Fixnum/Float/String elements
+- \[Bug [#13437](https://bugs.ruby-lang.org/issues/13437)\] Improve performance of Enumerable#{sort\_by,min\_by,max\_by,minmax\_by}
+- \[Bug [#13443](https://bugs.ruby-lang.org/issues/13443)\] Improve performance of Range#{min,max}
+- \[Bug [#13482](https://bugs.ruby-lang.org/issues/13482)\] Improve performance of "set instance variable"
+- \[Bug [#13447](https://bugs.ruby-lang.org/issues/13447)\] Improve performance of rb\_eql()
+- \[Bug [#13503](https://bugs.ruby-lang.org/issues/13503)\] Improve performance of some Time & Rational methods
+- \[Bug [#13506](https://bugs.ruby-lang.org/issues/13506)\] Improve performance of Complex#{+,-,,/,\*,abs2}
+- \[Bug [#13519](https://bugs.ruby-lang.org/issues/13519)\] Improve performance of some Time methods
+- \[Bug [#13507](https://bugs.ruby-lang.org/issues/13507)\] Improve performance of some Complex methods where call Numeric#real? internally
+- \[Bug [#13553](https://bugs.ruby-lang.org/issues/13553)\] Improve performance in where push the element into non shared Array object
 
 - assign who? corner (shyouhei)
 
-- \[Bug [#13432](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13432&sa=D&source=editors&ust=1686087156503577&usg=AOvVaw2erUAboxhD4hfImQDZZZTy)\] set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
-- \[Bug [#13446](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13446&sa=D&source=editors&ust=1686087156503966&usg=AOvVaw20tzVK2SBDSsFv9bASZKDQ)\] refinements with prepend for module has strange behavior
-- \[Bug [#13492](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13492&sa=D&source=editors&ust=1686087156504341&usg=AOvVaw3fyt3wqL8OX2EXbWS9INzy)\] Integer#prime? and Prime.each might produce false positives
+- \[Bug [#13432](https://bugs.ruby-lang.org/issues/13432)\] set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
+- \[Bug [#13446](https://bugs.ruby-lang.org/issues/13446)\] refinements with prepend for module has strange behavior
+- \[Bug [#13492](https://bugs.ruby-lang.org/issues/13492)\] Integer#prime? and Prime.each might produce false positives
 
 - akr: the patch seems ok.
 
-- \[Bug [#13498](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13498&sa=D&source=editors&ust=1686087156504793&usg=AOvVaw1i3ZJhZ1vXBaiq-NlQ--Wl)\] Weakref, Weakmap and define\_finalizer don't work on frozen objects
-- \[Bug [#13513](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13513&sa=D&source=editors&ust=1686087156505148&usg=AOvVaw1IPiit_S6X1pM1SEVhfRoG)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
-- \[Bug [#13501](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13501&sa=D&source=editors&ust=1686087156505512&usg=AOvVaw3LWyvmdb0eq4S-yZi6gZ_F)\] Process.kill behaviour for negative pid is not documented and may be wrong
-- \[Bug [#13515](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13515&sa=D&source=editors&ust=1686087156505881&usg=AOvVaw37_gLDUbCciX62u8Fpd3jI)\] Pathname#join doesn't add separator on UNC paths
-- \[Bug [#13521](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13521&sa=D&source=editors&ust=1686087156506254&usg=AOvVaw2XwNDf0uUiRU0WK_C7Q9z9)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
-- \[Bug [#13537](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13537&sa=D&source=editors&ust=1686087156506590&usg=AOvVaw2SqObIX5GRNMQnFaky39J5)\] ruby crash in rb\_gc\_mark
-- \[Bug [#13545](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13545&sa=D&source=editors&ust=1686087156506931&usg=AOvVaw3hbe0du98A3AVWlpXjz9HV)\] Ruby built by clang 4.0.0 parses Float literal wrongly
+- \[Bug [#13498](https://bugs.ruby-lang.org/issues/13498)\] Weakref, Weakmap and define\_finalizer don't work on frozen objects
+- \[Bug [#13513](https://bugs.ruby-lang.org/issues/13513)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
+- \[Bug [#13501](https://bugs.ruby-lang.org/issues/13501)\] Process.kill behaviour for negative pid is not documented and may be wrong
+- \[Bug [#13515](https://bugs.ruby-lang.org/issues/13515)\] Pathname#join doesn't add separator on UNC paths
+- \[Bug [#13521](https://bugs.ruby-lang.org/issues/13521)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
+- \[Bug [#13537](https://bugs.ruby-lang.org/issues/13537)\] ruby crash in rb\_gc\_mark
+- \[Bug [#13545](https://bugs.ruby-lang.org/issues/13545)\] Ruby built by clang 4.0.0 parses Float literal wrongly
 
 - naruse: OK but I think this is a day-to-day fix.
 
-- \[Bug [#13548](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13548&sa=D&source=editors&ust=1686087156507356&usg=AOvVaw0DLPlt4d0_wSCwvLIcEqsk)\] miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
-- \[Bug [#13555](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13555&sa=D&source=editors&ust=1686087156507751&usg=AOvVaw30MBcwqRKLgiDPCQJEARRs)\] Disable TestTrace#test\_trace\_stackoverflow
-- \[Bug [#13524](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13524&sa=D&source=editors&ust=1686087156508106&usg=AOvVaw2m-4FemFV2XV5SNz0eeMAw)\] miniruby: \[BUG\] Segmentation fault at 0x0055e487e00230 ruby 2.4.1p111 (2017-03-22 revision 58053) \[x86\_64-li
-- \[Bug [#13557](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13557&sa=D&source=editors&ust=1686087156508446&usg=AOvVaw3CgU_8VCATlR60oVBDokEf)\] there's no way to pass backtrace locations as a massaged backtrace
-- \[Bug [#10290](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10290&sa=D&source=editors&ust=1686087156508796&usg=AOvVaw2DnEr7eU7hak0qhLHezgxP)\] segfault when calling a lambda recursively after rescuing SystemStackError
+- \[Bug [#13548](https://bugs.ruby-lang.org/issues/13548)\] miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
+- \[Bug [#13555](https://bugs.ruby-lang.org/issues/13555)\] Disable TestTrace#test\_trace\_stackoverflow
+- \[Bug [#13524](https://bugs.ruby-lang.org/issues/13524)\] miniruby: \[BUG\] Segmentation fault at 0x0055e487e00230 ruby 2.4.1p111 (2017-03-22 revision 58053) \[x86\_64-li
+- \[Bug [#13557](https://bugs.ruby-lang.org/issues/13557)\] there's no way to pass backtrace locations as a massaged backtrace
+- \[Bug [#10290](https://bugs.ruby-lang.org/issues/10290)\] segfault when calling a lambda recursively after rescuing SystemStackError
 
 - Fix confirmed?
 
-- \[Feature [#10674](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10674&sa=D&source=editors&ust=1686087156509213&usg=AOvVaw0oS1ixlUMQPG-GHsjeFkHi)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
-- \[Bug [#13542](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13542&sa=D&source=editors&ust=1686087156509541&usg=AOvVaw1hIzDfQ9KoGXLPX026cCTr)\] MinGW trunk Builds - Summary of Issues
+- \[Feature [#10674](https://bugs.ruby-lang.org/issues/10674)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
+- \[Bug [#13542](https://bugs.ruby-lang.org/issues/13542)\] MinGW trunk Builds - Summary of Issues
 
-- \[Bug [#13549](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13549&sa=D&source=editors&ust=1686087156509873&usg=AOvVaw0-NsVNCuUVQI52uD_VCqb0)\] MinGW / Windows encoding - Two issues
-- \[Bug [#13556](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13556&sa=D&source=editors&ust=1686087156510264&usg=AOvVaw2eE_t456FLMudE8YFPmPMt)\] MinGW readline Alt / Meta keys
-- \[Bug [#13569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13569&sa=D&source=editors&ust=1686087156510610&usg=AOvVaw0k9asRw25p5AF9hEsm4hch)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+- \[Bug [#13549](https://bugs.ruby-lang.org/issues/13549)\] MinGW / Windows encoding - Two issues
+- \[Bug [#13556](https://bugs.ruby-lang.org/issues/13556)\] MinGW readline Alt / Meta keys
+- \[Bug [#13569](https://bugs.ruby-lang.org/issues/13569)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
 
-- \[Bug [#13564](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13564&sa=D&source=editors&ust=1686087156510952&usg=AOvVaw29Jj333vNISP3NG4k2gSah)\] Exception message management
+- \[Bug [#13564](https://bugs.ruby-lang.org/issues/13564)\] Exception message management
 
-- \[Feature [#13383](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13383&sa=D&source=editors&ust=1686087156511287&usg=AOvVaw2vKkWlR9_NLrplwUbUQEaD)\] \[PATCH\] Module#source\_location (shyouhei)
-- \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087156511619&usg=AOvVaw1wObOeC1lGVpJH6j-zTvN_)\] better method definition in C API (shyouhei)
-- \[Feature [#13512](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13512&sa=D&source=editors&ust=1686087156511968&usg=AOvVaw2vgfqObmc2IFbSO_PbirvZ)\] System Threads (shyouhei)
-- \[Feature [#13518](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13518&sa=D&source=editors&ust=1686087156512303&usg=AOvVaw2e65VBJ0pKjyUbjrcTzIeu)\] Indented multiline comments (shyouhei)
-- \[Feature [#13516](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13516&sa=D&source=editors&ust=1686087156512643&usg=AOvVaw1CID3YzNqvKyfIoDR7yGjA)\] Improve the text of the circular require warning (shyouhei)
-- \[Feature [#13532](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13532&sa=D&source=editors&ust=1686087156513009&usg=AOvVaw3S9F32ECstLUxDT0J9dY9Y)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
+- \[Feature [#13383](https://bugs.ruby-lang.org/issues/13383)\] \[PATCH\] Module#source\_location (shyouhei)
+- \[Feature [#13434](https://bugs.ruby-lang.org/issues/13434)\] better method definition in C API (shyouhei)
+- \[Feature [#13512](https://bugs.ruby-lang.org/issues/13512)\] System Threads (shyouhei)
+- \[Feature [#13518](https://bugs.ruby-lang.org/issues/13518)\] Indented multiline comments (shyouhei)
+- \[Feature [#13516](https://bugs.ruby-lang.org/issues/13516)\] Improve the text of the circular require warning (shyouhei)
+- \[Feature [#13532](https://bugs.ruby-lang.org/issues/13532)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
 
 - shyouhei: is this by design or…?
 - akr: it’s ok to add.  Patch please.
 
-- \[Bug [#13535](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13535&sa=D&source=editors&ust=1686087156513552&usg=AOvVaw1VAoFAD1tXqwi_Z3bpSKIp)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
-- \[Feature [#13552](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13552&sa=D&source=editors&ust=1686087156513886&usg=AOvVaw2iR4NUqMaTR-QgzffLxrZT)\] \[PATCH 0/2\] reimplement ConditionVariable, Queue, SizedQueue using ccan/list (shyouhei)
-- \[Feature [#13568](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13568&sa=D&source=editors&ust=1686087156514270&usg=AOvVaw0bYuJ5ofufaGP_pwZLixGu)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
+- \[Bug [#13535](https://bugs.ruby-lang.org/issues/13535)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
+- \[Feature [#13552](https://bugs.ruby-lang.org/issues/13552)\] \[PATCH 0/2\] reimplement ConditionVariable, Queue, SizedQueue using ccan/list (shyouhei)
+- \[Feature [#13568](https://bugs.ruby-lang.org/issues/13568)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
 
 - sorah: It makes no sense for O\_TMPFILE to have a path
 - nobu: but should it be nil?  There will be no way to obtain underlying filesystem then.
@@ -364,10 +364,10 @@ log: TBD
 - akr: File#path is used as inspectation on logs. therefore it should return informational string
 - naruse: \`ls -al ll /proc/25378/fd/9\` returns “lrwx------ 1 naruse 64 May 19 17:13 9 -> /tmp/#14379824 (deleted)”
 
-- \[Feature [#13563](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13563&sa=D&source=editors&ust=1686087156515276&usg=AOvVaw1a-rMwtAA5NF6tofVqz2J7)\] Implement Hash#choice method. (shyouhei)
-- \[Feature [#13562](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13562&sa=D&source=editors&ust=1686087156515676&usg=AOvVaw2ORAGE_cmGHx9LZmECGkMZ)\] Use a sized enumerator with #yield\_self (shyouhei) needs?
+- \[Feature [#13563](https://bugs.ruby-lang.org/issues/13563)\] Implement Hash#choice method. (shyouhei)
+- \[Feature [#13562](https://bugs.ruby-lang.org/issues/13562)\] Use a sized enumerator with #yield\_self (shyouhei) needs?
 
-- \[Feature [#13056](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13056&sa=D&source=editors&ust=1686087156516020&usg=AOvVaw0m4XDCXguOzsod5ughtFeQ)\] base option to Dir.glob (nobu)
+- \[Feature [#13056](https://bugs.ruby-lang.org/issues/13056)\] base option to Dir.glob (nobu)
 
 - akr: how about it?
 - matz: OK.
@@ -378,7 +378,7 @@ log: TBD
 
 Write your name and your interest (what do you want to ask and to whom?) please.
 
-- \[Feature [#8661](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8661&sa=D&source=editors&ust=1686087156517195&usg=AOvVaw1BMLB5RCDdwsmcYCWe3In1)\] Backstrace in reverse order. The OP asked for an option but this is currently always the case for the toplevel exception handler. Is this OK for compatibility? It is surprising for the least (See comment 6). Can we have matz's opinion? (eregon)
+- \[Feature [#8661](https://bugs.ruby-lang.org/issues/8661)\] Backstrace in reverse order. The OP asked for an option but this is currently always the case for the toplevel exception handler. Is this OK for compatibility? It is surprising for the least (See comment 6). Can we have matz's opinion? (eregon)
 
 - shyouhei: test-unit scrumbles backtrace.
 - hsbt: I want to hear other application developer’s voice

--- a/2017/DevMeeting-2017-06-16.md
+++ b/2017/DevMeeting-2017-06-16.md
@@ -103,8 +103,8 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 # Date: 2017/06/16 (Fri)
 Time: 14:00- 18:00 (JST)
 Place: Money Forward inc. Headquarter
-Sign-up: [https://ruby.connpass.com/event/57968/](https://www.google.com/url?q=https://ruby.connpass.com/event/57968/&sa=D&source=editors&ust=1686087184887067&usg=AOvVaw2OZBMdpPJxVI_yu1jp1ICr)
-log edit: [https://docs.google.com/document/d/1z19pKt8jlpiEUR3RnWWBCfs3OR\_hbiAZMwpQ6ZTllP0/edit#](https://www.google.com/url?q=https://docs.google.com/document/d/1z19pKt8jlpiEUR3RnWWBCfs3OR_hbiAZMwpQ6ZTllP0/edit%23&sa=D&source=editors&ust=1686087184887495&usg=AOvVaw3VWTshutgCtNIdMFjYy2g1)
+Sign-up: [https://ruby.connpass.com/event/57968/](https://ruby.connpass.com/event/57968/)
+log edit: [https://docs.google.com/document/d/1z19pKt8jlpiEUR3RnWWBCfs3OR\_hbiAZMwpQ6ZTllP0/edit#](https://docs.google.com/document/d/1z19pKt8jlpiEUR3RnWWBCfs3OR_hbiAZMwpQ6ZTllP0/edit#)
 Attendees: duerst (Martin Dürst)
 Language: mostly Japanese (sorry for non native Japanese speakers)
 
@@ -122,12 +122,12 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 # About 2.5 timeframe
 
-# [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087184888539&usg=AOvVaw043T4verO1u-pRUKG6Mc_E)
+# [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25)
 
 
 ## Carry-over from previous meeting(s)
 
-## \[Feature [#12733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12733&sa=D&source=editors&ust=1686087184889024&usg=AOvVaw0gHwd6vDBbqp7qSRzuJBV-)\] Bundle bundler to ruby core (shyouhei) updates?
+## \[Feature [#12733](https://bugs.ruby-lang.org/issues/12733)\] Bundle bundler to ruby core (shyouhei) updates?
 
 
 - hsbt: rubygems/rubygems 2.7 requires bundler.  After it is released, when ruby-core merges that version, we have to take care.
@@ -138,23 +138,23 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: is there any blocker?
 - hsbt: rspec.
 
-## \[Feature [#13332](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13332&sa=D&source=editors&ust=1686087184889733&usg=AOvVaw1CcdqiB6YdbxIhbWJbFX_1)\] Forwardable#def\_instance\_delegator nil (shyouhei)
+## \[Feature [#13332](https://bugs.ruby-lang.org/issues/13332)\] Forwardable#def\_instance\_delegator nil (shyouhei)
 
 
 - assign nobu
 
-## \[Feature [#13333](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13333&sa=D&source=editors&ust=1686087184890295&usg=AOvVaw0GqC30q3mUgemm9FBfOuIb)\] block to yield (shyouhei)
+## \[Feature [#13333](https://bugs.ruby-lang.org/issues/13333)\] block to yield (shyouhei)
 
 
 - ko1: we need more use cases.
 - martin: nobu: add them to the ticket.
 
-## \[Feature [#13378](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13378&sa=D&source=editors&ust=1686087184890861&usg=AOvVaw01R3vn2nSGuEbMj6mswm8d)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+## \[Feature [#13378](https://bugs.ruby-lang.org/issues/13378)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
 
 
 - nobu: I don’t want to handle fds this way because we can’t close properly on exceptions. I think we should wrap them using IOs.
 
-## \[Feature [#13381](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13381&sa=D&source=editors&ust=1686087184891306&usg=AOvVaw2zjJLQ9Mw0cLcrODpULDzV)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## \[Feature [#13381](https://bugs.ruby-lang.org/issues/13381)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
 
 
 - ko1: how about it? I don’t like “f”string naming.
@@ -162,139 +162,139 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: true but we already have rb\_intern().
 - ko1: nobody has idea. so that nobu and ko1 will decide it. nobody against exposing this functionality.
 
-## \[Feature [#13385](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13385&sa=D&source=editors&ust=1686087184891916&usg=AOvVaw2RVOIyAr1VhU4Gt8NHdOS7)\] \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
+## \[Feature [#13385](https://bugs.ruby-lang.org/issues/13385)\] \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
 
 
 - akr: I can’t say if this is valid until I fully understand the RFC.
 - akira: what about using domain\_name gem?
 - assign akr.
 
-## \[Feature [#13383](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13383&sa=D&source=editors&ust=1686087184892450&usg=AOvVaw1EEHWUhq4dhMc6OymCu0aP)\] \[PATCH\] Module#source\_location (shyouhei)
+## \[Feature [#13383](https://bugs.ruby-lang.org/issues/13383)\] \[PATCH\] Module#source\_location (shyouhei)
 
 
 - akira: needs?
 - shyouhei: I think source\_locations makes more sense than source\_location.
 - akira: I started to confuse.  Is it useful?  We can already get Method#source\_location.
 
-## \[Feature [#12063](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12063&sa=D&source=editors&ust=1686087184893030&usg=AOvVaw2Fo_FzZrLeD7RWEGzoofyN)\] KeyError#receiver and KeyError#name (shyouhei) status?
+## \[Feature [#12063](https://bugs.ruby-lang.org/issues/12063)\] KeyError#receiver and KeyError#name (shyouhei) status?
 
 
 - matz: I take KeyError#key.
 
-## \[Bug [#13397](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13397&sa=D&source=editors&ust=1686087184893580&usg=AOvVaw3zo4Xb1qFIH5rUZyPSr234)\] #object\_id should not be signed (shyouhei)
+## \[Bug [#13397](https://bugs.ruby-lang.org/issues/13397)\] #object\_id should not be signed (shyouhei)
 
 
 - akr: isn’t it possible to somehow calculate so that we can avoid negative object\_id?  Because pointers are 8 byte aligned, while positive fixnums are of 262 space.
 - nobu: it’s true we can avoid negative numbers on some environment, but not always.
 - reject this specific issue and request for new issue that address the inspect helper.
 
-## \[Feature [#13396](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13396&sa=D&source=editors&ust=1686087184894240&usg=AOvVaw1vefgo5p62kDz6Zt2V-Onx)\] Net::HTTP has no write timeout (shyouhei)
+## \[Feature [#13396](https://bugs.ruby-lang.org/issues/13396)\] Net::HTTP has no write timeout (shyouhei)
 
-## \[Bug [#13407](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13407&sa=D&source=editors&ust=1686087184894587&usg=AOvVaw010kIpPf30MdMEq_ZGIxol)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+## \[Bug [#13407](https://bugs.ruby-lang.org/issues/13407)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
 
-## \[Feature [#13395](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13395&sa=D&source=editors&ust=1686087184894947&usg=AOvVaw1dSl1pcnJg6bUAWWDKWZME)\] Add a method to check for not nil (shyouhei)
+## \[Feature [#13395](https://bugs.ruby-lang.org/issues/13395)\] Add a method to check for not nil (shyouhei)
 
-## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087184895275&usg=AOvVaw12wiXOGVB4bD4Dgc6Zvrrn)\] better method definition in C API (shyouhei)
+## \[Feature [#13434](https://bugs.ruby-lang.org/issues/13434)\] better method definition in C API (shyouhei)
 
 
 - nobu: I think parsing string is not a good idea.
 
-## \[Feature [#13512](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13512&sa=D&source=editors&ust=1686087184895695&usg=AOvVaw1ZVaRuFFe3tgN5RfwBkN5a)\] System Threads (shyouhei)
+## \[Feature [#13512](https://bugs.ruby-lang.org/issues/13512)\] System Threads (shyouhei)
 
-## \[Feature [#13518](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13518&sa=D&source=editors&ust=1686087184896015&usg=AOvVaw1sXeOWCScQIvhZiiCrMi8k)\] Indented multiline comments (shyouhei)
+## \[Feature [#13518](https://bugs.ruby-lang.org/issues/13518)\] Indented multiline comments (shyouhei)
 
-## \[Feature [#13516](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13516&sa=D&source=editors&ust=1686087184896391&usg=AOvVaw0F00iM2ALPgPaq05Ic1Mys)\] Improve the text of the circular require warning (shyouhei)
+## \[Feature [#13516](https://bugs.ruby-lang.org/issues/13516)\] Improve the text of the circular require warning (shyouhei)
 
-## \[Feature [#13532](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13532&sa=D&source=editors&ust=1686087184896734&usg=AOvVaw0kcDakKJAaX2XxL-cWPSb-)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
+## \[Feature [#13532](https://bugs.ruby-lang.org/issues/13532)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
 
-## \[Bug [#13535](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13535&sa=D&source=editors&ust=1686087184897069&usg=AOvVaw2uatNbvc6g9yzT1sHwl1Vx)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
+## \[Bug [#13535](https://bugs.ruby-lang.org/issues/13535)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
 
-## \[Feature [#13568](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13568&sa=D&source=editors&ust=1686087184897401&usg=AOvVaw0lOVxztWlY59eqrQVGmHHz)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
+## \[Feature [#13568](https://bugs.ruby-lang.org/issues/13568)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
 
-## \[Feature [#13563](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13563&sa=D&source=editors&ust=1686087184897740&usg=AOvVaw1J_tfM5W2xRrzg0lc3Uxoa)\] Implement Hash#choice method. (shyouhei)
+## \[Feature [#13563](https://bugs.ruby-lang.org/issues/13563)\] Implement Hash#choice method. (shyouhei)
 
 - Previous bugs that were not assigned (shyouhei)
 
 
-## \[Bug [#13196](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13196&sa=D&source=editors&ust=1686087184898244&usg=AOvVaw2s9kAK_W1dClDf6-K_fI5S)\] Improve keyword argument errors when non-keyword arguments given
+## \[Bug [#13196](https://bugs.ruby-lang.org/issues/13196)\] Improve keyword argument errors when non-keyword arguments given
 
-## \[Bug [#13320](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13320&sa=D&source=editors&ust=1686087184898590&usg=AOvVaw0aF6yt42Xx2uNx1-w2qjwI)\] rescue blocks get an entry in backtrace locations
+## \[Bug [#13320](https://bugs.ruby-lang.org/issues/13320)\] rescue blocks get an entry in backtrace locations
 
-## \[Bug [#13336](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13336&sa=D&source=editors&ust=1686087184898914&usg=AOvVaw2xD22Y6Etgd6P1c6GQNaR3)\] Default Parameters don't work
+## \[Bug [#13336](https://bugs.ruby-lang.org/issues/13336)\] Default Parameters don't work
 
-## \[Bug [#13337](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13337&sa=D&source=editors&ust=1686087184899255&usg=AOvVaw2ujMtb45viBHo_OAOKh5pU)\] Eval and Later Defined Local Variables
+## \[Bug [#13337](https://bugs.ruby-lang.org/issues/13337)\] Eval and Later Defined Local Variables
 
-## \[Bug [#13350](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13350&sa=D&source=editors&ust=1686087184899627&usg=AOvVaw0Y37tTZsLOSHz6PvnlXlYT)\] File.read :newline option not respected on Linux
+## \[Bug [#13350](https://bugs.ruby-lang.org/issues/13350)\] File.read :newline option not respected on Linux
 
-## \[Bug [#13373](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13373&sa=D&source=editors&ust=1686087184899976&usg=AOvVaw0iPn3ks7iHAVt-YCOzHRr5)\] FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
+## \[Bug [#13373](https://bugs.ruby-lang.org/issues/13373)\] FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
 
-## \[Bug [#13101](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13101&sa=D&source=editors&ust=1686087184900315&usg=AOvVaw0kLgayEfaLiOOFxoiHOKLQ)\] Date#rfc2822 and Time#rfc2822 don't return the same format
+## \[Bug [#13101](https://bugs.ruby-lang.org/issues/13101)\] Date#rfc2822 and Time#rfc2822 don't return the same format
 
-## \[Bug [#12684](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12684&sa=D&source=editors&ust=1686087184900653&usg=AOvVaw2qHpzrmz4YU_aecfWQDLKQ)\] Delegator#eql? missing
+## \[Bug [#12684](https://bugs.ruby-lang.org/issues/12684)\] Delegator#eql? missing
 
-## \[Feature [#13389](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13389&sa=D&source=editors&ust=1686087184900993&usg=AOvVaw0dSpBqNXGYJqsQaEz9JdUx)\] \[PATCH\] POP3 support timeout for TLS handshake
+## \[Feature [#13389](https://bugs.ruby-lang.org/issues/13389)\] \[PATCH\] POP3 support timeout for TLS handshake
 
-## \[Bug [#13404](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13404&sa=D&source=editors&ust=1686087184901373&usg=AOvVaw1jNhbQ54aLoDrwfGpR0nMU)\] Hash#any? yields arguments to lambdas with proc semantics
+## \[Bug [#13404](https://bugs.ruby-lang.org/issues/13404)\] Hash#any? yields arguments to lambdas with proc semantics
 
-## \[Bug [#13413](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13413&sa=D&source=editors&ust=1686087184901778&usg=AOvVaw0MUJmkOc2xjZzFAarrHnzv)\] --with-static-linked-ext doesn't install extension files on make install
+## \[Bug [#13413](https://bugs.ruby-lang.org/issues/13413)\] --with-static-linked-ext doesn't install extension files on make install
 
-## \[Bug [#13429](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13429&sa=D&source=editors&ust=1686087184902166&usg=AOvVaw2vUhYc__TmQwFvAFvik40b)\] Net::SMTP has no read timeout when connexion over TLS
+## \[Bug [#13429](https://bugs.ruby-lang.org/issues/13429)\] Net::SMTP has no read timeout when connexion over TLS
 
-## \[Bug [#13432](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13432&sa=D&source=editors&ust=1686087184902515&usg=AOvVaw0VhpLLckIFymF7S_SOKHGa)\] set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
+## \[Bug [#13432](https://bugs.ruby-lang.org/issues/13432)\] set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
 
-## \[Bug [#13446](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13446&sa=D&source=editors&ust=1686087184902866&usg=AOvVaw2dccQS0f2yC7sz0PBrfNuW)\] refinements with prepend for module has strange behavior
+## \[Bug [#13446](https://bugs.ruby-lang.org/issues/13446)\] refinements with prepend for module has strange behavior
 
-## \[Bug [#13498](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13498&sa=D&source=editors&ust=1686087184903292&usg=AOvVaw1ofZUaZcw3yXfctIvzI_f5)\] Weakref, Weakmap and define\_finalizer don't work on frozen objects
+## \[Bug [#13498](https://bugs.ruby-lang.org/issues/13498)\] Weakref, Weakmap and define\_finalizer don't work on frozen objects
 
-## \[Bug [#13513](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13513&sa=D&source=editors&ust=1686087184903638&usg=AOvVaw3AnkJPxJEaO4T3Fhaey05W)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
+## \[Bug [#13513](https://bugs.ruby-lang.org/issues/13513)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
 
-## \[Bug [#13501](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13501&sa=D&source=editors&ust=1686087184903981&usg=AOvVaw0dGD3hZmpaJAHSLzIgyqOq)\] Process.kill behaviour for negative pid is not documented and may be wrong
+## \[Bug [#13501](https://bugs.ruby-lang.org/issues/13501)\] Process.kill behaviour for negative pid is not documented and may be wrong
 
-## \[Bug [#13515](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13515&sa=D&source=editors&ust=1686087184904325&usg=AOvVaw0639yqnZnSpsBlbTs0kC-X)\] Pathname#join doesn't add separator on UNC paths
+## \[Bug [#13515](https://bugs.ruby-lang.org/issues/13515)\] Pathname#join doesn't add separator on UNC paths
 
-## \[Bug [#13521](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13521&sa=D&source=editors&ust=1686087184904666&usg=AOvVaw2DI9jgBeqgpGn2F2Iz9ZnX)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
+## \[Bug [#13521](https://bugs.ruby-lang.org/issues/13521)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
 
-## \[Bug [#13537](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13537&sa=D&source=editors&ust=1686087184904990&usg=AOvVaw216houodGjR-03fVO552gj)\] ruby crash in rb\_gc\_mark
+## \[Bug [#13537](https://bugs.ruby-lang.org/issues/13537)\] ruby crash in rb\_gc\_mark
 
-## \[Bug [#13548](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13548&sa=D&source=editors&ust=1686087184905334&usg=AOvVaw2e7oo7kRI3i4HURpxAlppb)\] miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
+## \[Bug [#13548](https://bugs.ruby-lang.org/issues/13548)\] miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
 
-## \[Bug [#13555](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13555&sa=D&source=editors&ust=1686087184905672&usg=AOvVaw3os2StQA6bZbMG9f_yTbwM)\] Disable TestTrace#test\_trace\_stackoverflow
+## \[Bug [#13555](https://bugs.ruby-lang.org/issues/13555)\] Disable TestTrace#test\_trace\_stackoverflow
 
-## \[Bug [#13557](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13557&sa=D&source=editors&ust=1686087184906024&usg=AOvVaw07BpTjse2I4tatsCgyXDOT)\] there's no way to pass backtrace locations as a massaged backtrace
+## \[Bug [#13557](https://bugs.ruby-lang.org/issues/13557)\] there's no way to pass backtrace locations as a massaged backtrace
 
-## \[Bug [#10290](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10290&sa=D&source=editors&ust=1686087184906356&usg=AOvVaw2wp1u4a8-HWNT9tZKdtpIJ)\] segfault when calling a lambda recursively after rescuing SystemStackError
+## \[Bug [#10290](https://bugs.ruby-lang.org/issues/10290)\] segfault when calling a lambda recursively after rescuing SystemStackError
 
 
 - Fix confirmed?
 
 - nobu: the variant of setjmp seems to be the root cause.  The proposed workaround works, but may impact performance.  We have to measure before changing the default.
 
-## \[Feature [#10674](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10674&sa=D&source=editors&ust=1686087184906916&usg=AOvVaw3SUSEjy1EaXpxSgy3xSxyo)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
+## \[Feature [#10674](https://bugs.ruby-lang.org/issues/10674)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
 
-## \[Bug [#13542](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13542&sa=D&source=editors&ust=1686087184907304&usg=AOvVaw2XWXtg-WuS09dTI9it5xU1)\] MinGW trunk Builds - Summary of Issues
-
-
-## \[Bug [#13549](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13549&sa=D&source=editors&ust=1686087184907658&usg=AOvVaw3kIWSVox5-bKH-9eTSWyGr)\] MinGW / Windows encoding - Two issues
-
-## \[Bug [#13556](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13556&sa=D&source=editors&ust=1686087184907991&usg=AOvVaw1g8diUekmroHrffreje6hN)\] MinGW readline Alt / Meta keys
-
-## \[Bug [#13569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13569&sa=D&source=editors&ust=1686087184908312&usg=AOvVaw276LVEhPv68k00UZ8QN46G)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+## \[Bug [#13542](https://bugs.ruby-lang.org/issues/13542)\] MinGW trunk Builds - Summary of Issues
 
 
-## \[Bug [#13564](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13564&sa=D&source=editors&ust=1686087184908648&usg=AOvVaw0k8Swo5B7C6Dl_IFoZ-QRJ)\] Exception message management
+## \[Bug [#13549](https://bugs.ruby-lang.org/issues/13549)\] MinGW / Windows encoding - Two issues
+
+## \[Bug [#13556](https://bugs.ruby-lang.org/issues/13556)\] MinGW readline Alt / Meta keys
+
+## \[Bug [#13569](https://bugs.ruby-lang.org/issues/13569)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+
+
+## \[Bug [#13564](https://bugs.ruby-lang.org/issues/13564)\] Exception message management
 
 
 ## From attendees
 
-## \[Bug [#12159](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12159&sa=D&source=editors&ust=1686087184909106&usg=AOvVaw14r73bZdmJllJm8eG3zqKP)\] Thread::Backtrace::Location#path returns absolute path for files loaded by require\_relative (ko1)
+## \[Bug [#12159](https://bugs.ruby-lang.org/issues/12159)\] Thread::Backtrace::Location#path returns absolute path for files loaded by require\_relative (ko1)
 
 
 - ko1: I want to add Thread::Backtrace::Location#realpath to deprecate #absplute\_path instead.
 - matz: no objection.
 
-## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087184909602&usg=AOvVaw3rADmKR6FcB1SuxI2rcT-5)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
+## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
 
-- \[Bug [#13576](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13576&sa=D&source=editors&ust=1686087184909934&usg=AOvVaw1b5uOl23_juIpxUJaHDZpt)\] File#to\_path shall be deleted (shyouhei)
+- \[Bug [#13576](https://bugs.ruby-lang.org/issues/13576)\] File#to\_path shall be deleted (shyouhei)
 
 - akr: did you try deleting this method?
 - shyouhei: no, but I should.
@@ -304,7 +304,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Write your name and your interest (what do you want to ask and to whom?) please.
 
-## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087184910659&usg=AOvVaw1G8dM5_WXvz1jRn3bJCqOH)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (normalperson)
+## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (normalperson)
 
 
 - ko1: programmers transfer execution of fibers by hand.  Eric proposes to introduce “auto”-Fiber which are OK to transfer each other on blocking situations. His implementation is great. rb\_wait\_for\_single\_fd is the ponit of switching. matz wanted this feature, too.
@@ -321,7 +321,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: is it OK for you to accept Eric’s proposal as-is?
 - matz: I’m positive, but I know your concern so I won’t accept right now.
 
-## \[Feature [#12694](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12694&sa=D&source=editors&ust=1686087184912007&usg=AOvVaw0_w94BMBmN-E2kPUSFzcnD)\] Want a String method to remove heading substr.
+## \[Feature [#12694](https://bugs.ruby-lang.org/issues/12694)\] Want a String method to remove heading substr.
 
 
 - (sonots) I implemented with a name String#remove\_prefix. If the name is ok, I want to merge it. Matz, could you decide? There were other candidates such as lchomp, trim\_prefix. I dropped trim\_prefix because trim is used to remove a list of characters rather than a substring in some languages, so I felt trim\_prefix would raise confusion. I dropped lchomp because I just had never heard.

--- a/2017/DevMeeting-2017-07-14.md
+++ b/2017/DevMeeting-2017-07-14.md
@@ -141,7 +141,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 # Date: 2017/07/14 (Fri)
 Time: 14:00- 18:00 (JST)
 Place: Cookpad, Inc. Headquarter
-Sign-up: [https://ruby.connpass.com/event/60055/](https://www.google.com/url?q=https://ruby.connpass.com/event/60055/&sa=D&source=editors&ust=1686087205330655&usg=AOvVaw2GuqpQAOLTu7TpnTrk0Twr)
+Sign-up: [https://ruby.connpass.com/event/60055/](https://ruby.connpass.com/event/60055/)
 log edit:
 Attendees: duerst (Martin Dürst)
 Language: mostly Japanese (sorry for non native Japanese speakers)
@@ -160,7 +160,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 # About 2.5 timeframe
 
-# [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087205332186&usg=AOvVaw2hCtA_7P-leo4qLTdg0RKR)
+# [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25)
 
 
 - naruse: I’ll release PR1 at the end of this month
@@ -171,7 +171,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-## \[Feature [#13512](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13512&sa=D&source=editors&ust=1686087205333390&usg=AOvVaw1oRkAAHGIMfzkaxBA5tF1P)\] System Threads (shyouhei)
+## \[Feature [#13512](https://bugs.ruby-lang.org/issues/13512)\] System Threads (shyouhei)
 
 
 - ko1: I don’t like this idea.  I don’t want more states over a Thread.
@@ -180,7 +180,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - Previous bugs that were not assigned (shyouhei)
 
 
-## \[Bug [#13350](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13350&sa=D&source=editors&ust=1686087205334279&usg=AOvVaw3juizL8nSXxN-kJSJsagco)\] File.read :newline option not respected on Linux
+## \[Bug [#13350](https://bugs.ruby-lang.org/issues/13350)\] File.read :newline option not respected on Linux
 
 
 - nobu: on Linux we have to explicitly set text mode.
@@ -188,65 +188,65 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - nobu: then we should automatically assume text mode when newline: is specified.
 - matz: make it so,
 
-## \[Feature [#13389](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13389&sa=D&source=editors&ust=1686087205335100&usg=AOvVaw3v0mN0f6Lf6PFN4W2sxvTb)\] \[PATCH\] POP3 support timeout for TLS handshake
+## \[Feature [#13389](https://bugs.ruby-lang.org/issues/13389)\] \[PATCH\] POP3 support timeout for TLS handshake
 
 
 - hsbt: pop3 has no maintainer.
 - naruse: maybe shugo can review the patch?
 
-## \[Bug [#13404](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13404&sa=D&source=editors&ust=1686087205335718&usg=AOvVaw1nkGRmSqoGbvH7O52oIy-K)\] Hash#any? yields arguments to lambdas with proc semantics
+## \[Bug [#13404](https://bugs.ruby-lang.org/issues/13404)\] Hash#any? yields arguments to lambdas with proc semantics
 
 
 - assign ko1
 - cf: #13391
 
-## \[Bug [#13429](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13429&sa=D&source=editors&ust=1686087205336384&usg=AOvVaw1I2954ufU_K5cWL38BAryE)\] Net::SMTP has no read timeout when connexion over TLS
+## \[Bug [#13429](https://bugs.ruby-lang.org/issues/13429)\] Net::SMTP has no read timeout when connexion over TLS
 
 
 - should be closed so that usa can be aware of it.
 
-## \[Bug [#13513](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13513&sa=D&source=editors&ust=1686087205336834&usg=AOvVaw1Cu-1QET4rWRRqFiQOrFm4)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
+## \[Bug [#13513](https://bugs.ruby-lang.org/issues/13513)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
 
 
 - assign akr
 
-## \[Bug [#13501](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13501&sa=D&source=editors&ust=1686087205337383&usg=AOvVaw0GuXcpAo0Ebz1EpK8XkqTU)\] Process.kill behaviour for negative pid is not documented and may be wrong
+## \[Bug [#13501](https://bugs.ruby-lang.org/issues/13501)\] Process.kill behaviour for negative pid is not documented and may be wrong
 
 
 - shyouhei: doc issue?
 - akr: we take negative signal or negative pids.  signal.c:rb\_f\_kill() has special codes for negative signals but not for negative pids.
 - akr: what happens both signal and pid are negative?
 
-## \[Bug [#13521](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13521&sa=D&source=editors&ust=1686087205338050&usg=AOvVaw1eQ0bi0LlDCSzROTH9isY6)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
+## \[Bug [#13521](https://bugs.ruby-lang.org/issues/13521)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
 
 
 - nobu: 3rd party issue?
 
-## \[Bug [#13557](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13557&sa=D&source=editors&ust=1686087205338680&usg=AOvVaw2FR90c_szr8-PzUmvukYec)\] there's no way to pass backtrace locations as a massaged backtrace
+## \[Bug [#13557](https://bugs.ruby-lang.org/issues/13557)\] there's no way to pass backtrace locations as a massaged backtrace
 
 
 - nobu: I have to discuss this with ko1.
 
-## \[Feature [#10674](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10674&sa=D&source=editors&ust=1686087205339166&usg=AOvVaw1_hrNOdQhCLc08nbykFIyk)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
+## \[Feature [#10674](https://bugs.ruby-lang.org/issues/10674)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
 
 
 - assign naruse
 
-## \[Bug [#13542](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13542&sa=D&source=editors&ust=1686087205339788&usg=AOvVaw3sL5x0vSW7sqIvyWzVSM5s)\] MinGW trunk Builds - Summary of Issues
+## \[Bug [#13542](https://bugs.ruby-lang.org/issues/13542)\] MinGW trunk Builds - Summary of Issues
 
 
-## \[Bug [#13549](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13549&sa=D&source=editors&ust=1686087205340197&usg=AOvVaw2hWJh5jaIsHVLvV-5rec34)\] MinGW / Windows encoding - Two issues
+## \[Bug [#13549](https://bugs.ruby-lang.org/issues/13549)\] MinGW / Windows encoding - Two issues
 
-## \[Bug [#13556](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13556&sa=D&source=editors&ust=1686087205340605&usg=AOvVaw1R3JyV1EhQRvB1mXD-9JkK)\] MinGW readline Alt / Meta keys
+## \[Bug [#13556](https://bugs.ruby-lang.org/issues/13556)\] MinGW readline Alt / Meta keys
 
-## \[Bug [#13569](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13569&sa=D&source=editors&ust=1686087205340978&usg=AOvVaw1ePy4_g8xpOQ77PtddT4ht)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+## \[Bug [#13569](https://bugs.ruby-lang.org/issues/13569)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
 
 ---
 - nobu: I cannot reproduce these problems.
 - shyouhei: It seems the reporter is not eligible to fix them.
 - hsbt: I made an environment so I’ll see if they reproduce.
 
-## \[Bug [#13564](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13564&sa=D&source=editors&ust=1686087205341613&usg=AOvVaw2iT4c51EJv_LfWMTxY7kjI)\] Exception message management
+## \[Bug [#13564](https://bugs.ruby-lang.org/issues/13564)\] Exception message management
 
 
 - matz I understand that it breaks encapsulation \_by theory\_, but in practice is it worth, for instance, duplicate every time?
@@ -259,17 +259,17 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - should what happen for tainted string?
 - ko1: it seems there is string.c:fstring\_cmp.  Can’t we change this function?
 
-## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087205342542&usg=AOvVaw1SJPEKUC1GyYKSwAaA7a7R)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
 
 
 - akr: Socket to DB would normally be pooled / shared among threads in normal web applications.  There shall be some locking mechanism to do so.
 
-## \[Feature [#13583](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13583&sa=D&source=editors&ust=1686087205343077&usg=AOvVaw0NERbGFoTuSDgQDiHLrX8c)\] Adding Hash#transform\_keys method (shyouhei)
+## \[Feature [#13583](https://bugs.ruby-lang.org/issues/13583)\] Adding Hash#transform\_keys method (shyouhei)
 
 
 - matz: seems OK.
 
-## \[Feature [#12589](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12589&sa=D&source=editors&ust=1686087205343574&usg=AOvVaw3OnEyP0awwJxgjvtxhL4BW)\] VM performance improvement proposal (shyouhei)
+## \[Feature [#12589](https://bugs.ruby-lang.org/issues/12589)\] VM performance improvement proposal (shyouhei)
 
 
 - akr: is it OK for people to have C compilers in their production environment?
@@ -277,7 +277,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: I think scheme compilers tends to transpile into C.
 - matz: I like this idea itself.
 
-## \[Feature [#13676](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13676&sa=D&source=editors&ust=1686087205344473&usg=AOvVaw12roiV9BIxWJ1mKmHfJbvv)\] to\_s method is not overriden for Set (shyouhei)
+## \[Feature [#13676](https://bugs.ruby-lang.org/issues/13676)\] to\_s method is not overriden for Set (shyouhei)
 
 
 - assign knu
@@ -286,12 +286,12 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - knu: is it OK to call inspect?
 - matz: OK.
 
-## \[Feature [#10771](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10771&sa=D&source=editors&ust=1686087205345230&usg=AOvVaw0t3sWBC1vtd8g_FyrBpF6i)\] An easy way to get the source location of a constant (shyouhei)
+## \[Feature [#10771](https://bugs.ruby-lang.org/issues/10771)\] An easy way to get the source location of a constant (shyouhei)
 
 
 - nobu: we already maintain constant source locations for redefinition warnings.
 
-## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087205345685&usg=AOvVaw1WkrfwQvIzMMj8OwICC6iY)\] better method definition in C API (shyouhei)
+## \[Feature [#13434](https://bugs.ruby-lang.org/issues/13434)\] better method definition in C API (shyouhei)
 
 
 - ko1: is it convenient for you to show backtrace of C methods?
@@ -301,60 +301,60 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - bugs that are not assigned (shyouhei)
 
 
-## \[Bug [#13586](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13586&sa=D&source=editors&ust=1686087205346586&usg=AOvVaw2aRUKF8aDoR3DdqbrkFyKM)\] Ruby hangs when accessing array which is modified in instance\_eval after Coverage.start
+## \[Bug [#13586](https://bugs.ruby-lang.org/issues/13586)\] Ruby hangs when accessing array which is modified in instance\_eval after Coverage.start
 
 
 - assign nobu
 - nobu: seems 2.5 is not affected.
 
-## \[Bug [#13574](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13574&sa=D&source=editors&ust=1686087205347076&usg=AOvVaw2KRQgpczmOqexg2QBovB80)\] Method redefinition warning
+## \[Bug [#13574](https://bugs.ruby-lang.org/issues/13574)\] Method redefinition warning
 
 
 - akira: is it OK that we say this is the right way to suppress warning?
 - matz: reject.
 
-## \[Bug [#13616](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13616&sa=D&source=editors&ust=1686087205347715&usg=AOvVaw3smcBPrJD3MRheCx9MdXmU)\] Zlib::GzipReader#pos underflows after calling #ungetbyte or #ungetc at start of file
+## \[Bug [#13616](https://bugs.ruby-lang.org/issues/13616)\] Zlib::GzipReader#pos underflows after calling #ungetbyte or #ungetc at start of file
 
 
 - naruse: I’ll merge this.
 
-## \[Bug [#13593](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13593&sa=D&source=editors&ust=1686087205348317&usg=AOvVaw0Pfq7mZWwZxH0Qc07XIvg1)\] Addrinfo#== behaves oddly
+## \[Bug [#13593](https://bugs.ruby-lang.org/issues/13593)\] Addrinfo#== behaves oddly
 
 
 - akr: it’s difficult by theory.
 
-## \[Bug [#13631](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13631&sa=D&source=editors&ust=1686087205348924&usg=AOvVaw0OoQkMmTTPx3dIMGgElO6q)\] Cannot disable site and vendor directories
+## \[Bug [#13631](https://bugs.ruby-lang.org/issues/13631)\] Cannot disable site and vendor directories
 
 
 - assign nobu
 
-## \[Bug [#13647](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13647&sa=D&source=editors&ust=1686087205349362&usg=AOvVaw2WJ_C4IabgIR8r-TtI50pd)\] Some weird behaviour with keyword arguments
+## \[Bug [#13647](https://bugs.ruby-lang.org/issues/13647)\] Some weird behaviour with keyword arguments
 
 
 - nobu: we can explain this behaviour.
 
-## \[Bug [#13649](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13649&sa=D&source=editors&ust=1686087205349808&usg=AOvVaw1WxeTUQkczA0AH-pxm48JZ)\] Net::IMAP doesn't support response from a Microsoft Exchange server (which is not compliant with RFC standards)
+## \[Bug [#13649](https://bugs.ruby-lang.org/issues/13649)\] Net::IMAP doesn't support response from a Microsoft Exchange server (which is not compliant with RFC standards)
 
 
 - assign shugo
 
-## \[Bug [#13654](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13654&sa=D&source=editors&ust=1686087205350187&usg=AOvVaw1AJZIFku61yPU6XwOG8f6z)\] irb save-history extension is not concurrency-safe
+## \[Bug [#13654](https://bugs.ruby-lang.org/issues/13654)\] irb save-history extension is not concurrency-safe
 
 
 - akr: it’s same as shells.
 - assign keiju
 
-## \[Bug [#13655](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13655&sa=D&source=editors&ust=1686087205350664&usg=AOvVaw3gQmnkqeMXEkrVw2J5g3xk)\] external encoding named "-" (doc issue or…?)
+## \[Bug [#13655](https://bugs.ruby-lang.org/issues/13655)\] external encoding named "-" (doc issue or…?)
 
 
 - naruse: doc issue.
 
-## \[Bug [#13660](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13660&sa=D&source=editors&ust=1686087205351069&usg=AOvVaw0hxXYQlLknRQ7P5abMgFfY)\] rb\_str\_hash\_m discards bits from the hash
+## \[Bug [#13660](https://bugs.ruby-lang.org/issues/13660)\] rb\_str\_hash\_m discards bits from the hash
 
 
 - akr: it’s intentional.
 
-## \[Bug [#13671](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13671&sa=D&source=editors&ust=1686087205351458&usg=AOvVaw3fPDCG-bxs-ltk9I2ZsIaM)\] Regexp with lookbehind and case-insensitivity raises RegexpError only on strings with certain characters
+## \[Bug [#13671](https://bugs.ruby-lang.org/issues/13671)\] Regexp with lookbehind and case-insensitivity raises RegexpError only on strings with certain characters
 
 
 - naruse: /(?<!ass)/iu is suffient to reproduce
@@ -366,7 +366,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - \=> nil
 - But I don't know the expected behavior.
 
-## \[Bug [#13735](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13735&sa=D&source=editors&ust=1686087205352246&usg=AOvVaw39fIfz4A5Jg6CiBMVLiO84)\] Initialization-error of sortedset
+## \[Bug [#13735](https://bugs.ruby-lang.org/issues/13735)\] Initialization-error of sortedset
 
 
 - assign knu
@@ -375,19 +375,19 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Write your name and your interest (what do you want to ask and to whom?) please.
 
-## \[Feature [#13666](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13666&sa=D&source=editors&ust=1686087205352871&usg=AOvVaw3Po-o362aVMKWIvFedFf0O)\] Allow to write specs instead of tests (nobody wants to write test code twice). (eregon)
+## \[Feature [#13666](https://bugs.ruby-lang.org/issues/13666)\] Allow to write specs instead of tests (nobody wants to write test code twice). (eregon)
 
 
 - Martin: Okay to me.
 - nobu: nobody disallows to write specs at the first place, do they?
 
-## \[Feature [#13665](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13665&sa=D&source=editors&ust=1686087205353342&usg=AOvVaw2wUqCkIJVzi2pQ2d0sIUHQ)\] Before I added String#delete\_prefix. For symmetry, is it okay to commit String#delete\_suffix? (sonots)
+## \[Feature [#13665](https://bugs.ruby-lang.org/issues/13665)\] Before I added String#delete\_prefix. For symmetry, is it okay to commit String#delete\_suffix? (sonots)
 
 
 - shyouhei: should we add it?
 - matz: no objection.
 
-## \[Feature [#13743](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13743&sa=D&source=editors&ust=1686087205353899&usg=AOvVaw2f33NXuymDNo2g9nlJCe7g)\] Support linking of files opened with O\_TMPFILE (mmasaki)
+## \[Feature [#13743](https://bugs.ruby-lang.org/issues/13743)\] Support linking of files opened with O\_TMPFILE (mmasaki)
 
 
 - nobu: File.link or File#link?

--- a/2017/DevMeeting-2017-08-31.md
+++ b/2017/DevMeeting-2017-08-31.md
@@ -161,7 +161,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 # Date: 2017/08/31 (Thu)
 Time: 14:00- 18:00 (JST)
 Place: Cookpad, Inc. Headquarter
-Sign-up: [https://ruby.connpass.com/event/60055/](https://www.google.com/url?q=https://ruby.connpass.com/event/60055/&sa=D&source=editors&ust=1686087248435633&usg=AOvVaw3JQJAmWFQIQ5iiGiAhflf_)
+Sign-up: [https://ruby.connpass.com/event/60055/](https://ruby.connpass.com/event/60055/)
 log edit:
 Attendees: matz (Yukihiro Matsumoto), nobu (Nobuyoshi Nakada), ko1 (Koichi Sasada, partially), naruse (Yui Naruse), akr (Akira Tanaka), hsbt (Hiroshi SHIBATA), matsuda (Akira Matsuda), shyouhei (Shyouhei Urabe), sorah (Sorah Fukumori), mrkn (Kenta Murata), mame (Yusuke Endo), kosaki (Motohiro KOSAKI), knu (Akinori MUSHA),  duerst (Martin Dürst)
 Language: mostly Japanese (sorry for non native Japanese speakers)
@@ -175,14 +175,14 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 # About 2.5 timeframe
 
-# [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087248437047&usg=AOvVaw1HOMVQwc0SAHj_rXp4stDU)
+# [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25)
 
 
 - naruse: I’ll release PR1 after stable releases are published
 
 ## Hackathon for Ruby 2.5
 
-- [https://chouseisan.com/s?h=cbab178ad925432ca81f9a64b2563b95](https://www.google.com/url?q=https://chouseisan.com/s?h%3Dcbab178ad925432ca81f9a64b2563b95&sa=D&source=editors&ust=1686087248438320&usg=AOvVaw0jiITyyng-2AyhqcQ84eEg)
+- [https://chouseisan.com/s?h=cbab178ad925432ca81f9a64b2563b95](https://chouseisan.com/s?h=cbab178ad925432ca81f9a64b2563b95)
 
 ## Invitation to "mini RubyKaigi" (a\_matsuda)
 
@@ -190,245 +190,245 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-## \[Feature [#13396](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13396&sa=D&source=editors&ust=1686087248439334&usg=AOvVaw3-fGaFhcM2KlhY_y_L2yuy)\] Net::HTTP has no write timeout (shyouhei)
+## \[Feature [#13396](https://bugs.ruby-lang.org/issues/13396)\] Net::HTTP has no write timeout (shyouhei)
 
-## \[Bug [#13407](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13407&sa=D&source=editors&ust=1686087248439873&usg=AOvVaw2YJTo3FZIqnKNjwQOuq03Q)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+## \[Bug [#13407](https://bugs.ruby-lang.org/issues/13407)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
 
-## \[Feature [#13395](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13395&sa=D&source=editors&ust=1686087248440342&usg=AOvVaw15bBEqC1LdFOmjjgeNdFCE)\] Add a method to check for not nil (shyouhei)
+## \[Feature [#13395](https://bugs.ruby-lang.org/issues/13395)\] Add a method to check for not nil (shyouhei)
 
-## \[Feature [#13516](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13516&sa=D&source=editors&ust=1686087248440777&usg=AOvVaw3KgdfA_xrkmWCH_Kl-cyf1)\] Improve the text of the circular require warning (shyouhei)
+## \[Feature [#13516](https://bugs.ruby-lang.org/issues/13516)\] Improve the text of the circular require warning (shyouhei)
 
-## \[Feature [#13532](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13532&sa=D&source=editors&ust=1686087248441257&usg=AOvVaw3IT9ett_AF2-6HhMt89leR)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
+## \[Feature [#13532](https://bugs.ruby-lang.org/issues/13532)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
 
-## \[Bug [#13535](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13535&sa=D&source=editors&ust=1686087248441745&usg=AOvVaw0vy26BeKZLtlUF8IIYh3vg)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
+## \[Bug [#13535](https://bugs.ruby-lang.org/issues/13535)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
 
-## \[Feature [#13568](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13568&sa=D&source=editors&ust=1686087248442162&usg=AOvVaw1VboLQX9rbkfJAGwfgVo2f)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
+## \[Feature [#13568](https://bugs.ruby-lang.org/issues/13568)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
 
 
 - raising exception
 
-## \[Feature [#13563](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13563&sa=D&source=editors&ust=1686087248442744&usg=AOvVaw3YrUc0niTfCDFtcDvRHz2F)\] Implement Hash#choice method. (shyouhei)
+## \[Feature [#13563](https://bugs.ruby-lang.org/issues/13563)\] Implement Hash#choice method. (shyouhei)
 
 
 - naming issue.
 
-## \[Feature [#13581](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13581&sa=D&source=editors&ust=1686087248443476&usg=AOvVaw3nIE35NNPirRuIshiXu_DL)\] Syntax sugar for method reference (shyouhei)
+## \[Feature [#13581](https://bugs.ruby-lang.org/issues/13581)\] Syntax sugar for method reference (shyouhei)
 
 
 - naming issue.
 
-## \[Bug [#13438](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13438&sa=D&source=editors&ust=1686087248444216&usg=AOvVaw1jHe1RISZwwWs-q6Xe-6Me)\] Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei)
+## \[Bug [#13438](https://bugs.ruby-lang.org/issues/13438)\] Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei)
 
-## \[Misc [#12529](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12529&sa=D&source=editors&ust=1686087248444865&usg=AOvVaw2nHZ2tKp-38XzFDO_a2Y5C)\] LEGAL file covering all the license information within Ruby (shyouhei)
+## \[Misc [#12529](https://bugs.ruby-lang.org/issues/12529)\] LEGAL file covering all the license information within Ruby (shyouhei)
 
-## \[Feature [#13600](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13600&sa=D&source=editors&ust=1686087248445352&usg=AOvVaw0A_SwByifBGUtYSrNOeMV8)\] yield\_self should be chainable/composable (shyouhei)
+## \[Feature [#13600](https://bugs.ruby-lang.org/issues/13600)\] yield\_self should be chainable/composable (shyouhei)
 
-## \[Misc [#13597](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13597&sa=D&source=editors&ust=1686087248445756&usg=AOvVaw2jMQLGDP5S0STVkMhmKUMf)\] Does read\_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
+## \[Misc [#13597](https://bugs.ruby-lang.org/issues/13597)\] Does read\_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
 
-## \[Feature [#13606](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13606&sa=D&source=editors&ust=1686087248446232&usg=AOvVaw2TRN4qpIthl4bX42-KtntP)\] Enumerator equality and comparison (shyouhei)
+## \[Feature [#13606](https://bugs.ruby-lang.org/issues/13606)\] Enumerator equality and comparison (shyouhei)
 
-## \[Feature [#13604](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13604&sa=D&source=editors&ust=1686087248446747&usg=AOvVaw0orG4YS8WpJkN7Q0SL2gXJ)\] Exposing alternative interface of readline (shyouhei)
+## \[Feature [#13604](https://bugs.ruby-lang.org/issues/13604)\] Exposing alternative interface of readline (shyouhei)
 
 ---
-## \[Feature [#13608](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13608&sa=D&source=editors&ust=1686087248447468&usg=AOvVaw2jNbM2WcIRAe9NpU71Fryy)\] Add TracePoint#thread (shyouhei)
+## \[Feature [#13608](https://bugs.ruby-lang.org/issues/13608)\] Add TracePoint#thread (shyouhei)
 
-## \[Feature [#13602](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13602&sa=D&source=editors&ust=1686087248448071&usg=AOvVaw1ZOTzKNoPx16A5oh3aefn-)\] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
+## \[Feature [#13602](https://bugs.ruby-lang.org/issues/13602)\] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
 
-## \[Feature [#13613](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13613&sa=D&source=editors&ust=1686087248448609&usg=AOvVaw3JBka6kTJEYPs0oZnsn6Pb)\] Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
+## \[Feature [#13613](https://bugs.ruby-lang.org/issues/13613)\] Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
 
-## \[Feature [#13620](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13620&sa=D&source=editors&ust=1686087248449144&usg=AOvVaw1fkEA2It7SAksl0tB_WzCy)\] Simplifying MRI's build system: always install (shyouhei)
+## \[Feature [#13620](https://bugs.ruby-lang.org/issues/13620)\] Simplifying MRI's build system: always install (shyouhei)
 
-## \[Feature [#13630](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13630&sa=D&source=editors&ust=1686087248449767&usg=AOvVaw0bNJAu9TH9TuPcI4Dn8Xfj)\] :\[\] method should accept block in nice syntax (shyouhei)
+## \[Feature [#13630](https://bugs.ruby-lang.org/issues/13630)\] :\[\] method should accept block in nice syntax (shyouhei)
 
-## \[Feature [#13639](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13639&sa=D&source=editors&ust=1686087248450388&usg=AOvVaw0tiWUZScGHyqj-9S5q7tjj)\] Add "RTMIN" and "RTMAX" to Signal.list (shyouhei)
+## \[Feature [#13639](https://bugs.ruby-lang.org/issues/13639)\] Add "RTMIN" and "RTMAX" to Signal.list (shyouhei)
 
-## \[Feature [#11484](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11484&sa=D&source=editors&ust=1686087248450964&usg=AOvVaw2zndrSGKl9iuSAbTzb0j8V)\] add output offset for readpartial/read\_nonblock/etc (shyouhei)
+## \[Feature [#11484](https://bugs.ruby-lang.org/issues/11484)\] add output offset for readpartial/read\_nonblock/etc (shyouhei)
 
-## \[Feature [#9001](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9001&sa=D&source=editors&ust=1686087248451532&usg=AOvVaw1ZzGRPzSEjpGRoZNKpWgIz)\] Please package better standard library (shyouhei)
+## \[Feature [#9001](https://bugs.ruby-lang.org/issues/9001)\] Please package better standard library (shyouhei)
 
-## \[Feature [#13563](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13563&sa=D&source=editors&ust=1686087248452162&usg=AOvVaw2_wyOEoPiEtjBVRs0-kuU2)\] Implement Hash#choice method. (shyouhei)
+## \[Feature [#13563](https://bugs.ruby-lang.org/issues/13563)\] Implement Hash#choice method. (shyouhei)
 
-## \[Feature [#12533](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12533&sa=D&source=editors&ust=1686087248452789&usg=AOvVaw23wc-w7X07v2deCmSCs-Re)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
+## \[Feature [#12533](https://bugs.ruby-lang.org/issues/12533)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
 
-## \[Feature [#13653](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13653&sa=D&source=editors&ust=1686087248453393&usg=AOvVaw3zsDISNcIvPs8gk-pd_916)\] Bundled zlib helper (shyouhei)
+## \[Feature [#13653](https://bugs.ruby-lang.org/issues/13653)\] Bundled zlib helper (shyouhei)
 
-## \[Feature [#13626](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13626&sa=D&source=editors&ust=1686087248454018&usg=AOvVaw3Ce8Gtwfhje739UgE44RN9)\] Add String#byteslice! (shyouhei)
+## \[Feature [#13626](https://bugs.ruby-lang.org/issues/13626)\] Add String#byteslice! (shyouhei)
 
-## \[Feature [#13551](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13551&sa=D&source=editors&ust=1686087248454548&usg=AOvVaw2fUsOzfvSiLoqDMbLQTfba)\] Add a method to alias class methods (shyouhei)
+## \[Feature [#13551](https://bugs.ruby-lang.org/issues/13551)\] Add a method to alias class methods (shyouhei)
 
-## \[Feature [#13332](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13332&sa=D&source=editors&ust=1686087248455086&usg=AOvVaw2_kF4dBUP-dkmC3huyOfBF)\] Forwardable#def\_instance\_delegator nil (shyouhei)
+## \[Feature [#13332](https://bugs.ruby-lang.org/issues/13332)\] Forwardable#def\_instance\_delegator nil (shyouhei)
 
-## \[Feature [#13378](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13378&sa=D&source=editors&ust=1686087248455762&usg=AOvVaw1P18CD0ALL6o4sYqXgpml_)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+## \[Feature [#13378](https://bugs.ruby-lang.org/issues/13378)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
 
-## \[Feature [#13381](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13381&sa=D&source=editors&ust=1686087248456346&usg=AOvVaw3meRHh_YiIEwgrIyfaIS_c)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## \[Feature [#13381](https://bugs.ruby-lang.org/issues/13381)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
 
-## \[Feature [#13677](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13677&sa=D&source=editors&ust=1686087248456833&usg=AOvVaw2a2pTFqaTvTrLzp-V1BLfy)\] Add more details to error "Name or service not known (SocketError)" (shyouhei)
+## \[Feature [#13677](https://bugs.ruby-lang.org/issues/13677)\] Add more details to error "Name or service not known (SocketError)" (shyouhei)
 
-## \[Feature [#9323](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9323&sa=D&source=editors&ust=1686087248457365&usg=AOvVaw3exATmD5NSic34DNxKCOCG)\] IO#writev (shyouhei)
+## \[Feature [#9323](https://bugs.ruby-lang.org/issues/9323)\] IO#writev (shyouhei)
 
-## \[Feature [#13686](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13686&sa=D&source=editors&ust=1686087248457844&usg=AOvVaw1eu5nSkp5qy9x06PS1rsEj)\] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (shyouhei)
+## \[Feature [#13686](https://bugs.ruby-lang.org/issues/13686)\] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (shyouhei)
 
-## \[Feature [#13693](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13693&sa=D&source=editors&ust=1686087248458271&usg=AOvVaw2YqvbaRFRk0ikfCkgwlilt)\] Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
+## \[Feature [#13693](https://bugs.ruby-lang.org/issues/13693)\] Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
 
-## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087248458776&usg=AOvVaw3QYdt7mUmFcB0IN6-vxr48)\] better method definition in C API (shyouhei)
+## \[Feature [#13434](https://bugs.ruby-lang.org/issues/13434)\] better method definition in C API (shyouhei)
 
-## \[Feature [#13696](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13696&sa=D&source=editors&ust=1686087248459367&usg=AOvVaw3um9tviugUPTjiNSm4IcuB)\] Add exchange and noreplace options to File.rename (shyouhei)
+## \[Feature [#13696](https://bugs.ruby-lang.org/issues/13696)\] Add exchange and noreplace options to File.rename (shyouhei)
 
-## \[Feature [#13683](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13683&sa=D&source=editors&ust=1686087248459901&usg=AOvVaw0T1_1NuFRGDMwKrUlh28Or)\] Add strict Enumerable#single (shyouhei)
+## \[Feature [#13683](https://bugs.ruby-lang.org/issues/13683)\] Add strict Enumerable#single (shyouhei)
 
-## \[Misc [#13704](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13704&sa=D&source=editors&ust=1686087248460392&usg=AOvVaw1_bw6VlP6eSwoiz6gRkMdK)\] Exclude Changelog files from documentation. (shyouhei)
+## \[Misc [#13704](https://bugs.ruby-lang.org/issues/13704)\] Exclude Changelog files from documentation. (shyouhei)
 
-## \[Feature [#13713](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13713&sa=D&source=editors&ust=1686087248460872&usg=AOvVaw1Bg8vHmN_Ps0m-YjQ2b87L)\] socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
+## \[Feature [#13713](https://bugs.ruby-lang.org/issues/13713)\] socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
 
-## \[Feature [#13715](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13715&sa=D&source=editors&ust=1686087248461383&usg=AOvVaw2zD9Hkk_ExwqZ39JkVdwh8)\] \[PATCH\] avoid garbage from Symbol#to\_s in interpolation (shyouhei)
+## \[Feature [#13715](https://bugs.ruby-lang.org/issues/13715)\] \[PATCH\] avoid garbage from Symbol#to\_s in interpolation (shyouhei)
 
-## \[Feature [#13719](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13719&sa=D&source=editors&ust=1686087248461977&usg=AOvVaw3T94NXC_LGbgSazYFYYe5q)\] \[PATCH\] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
+## \[Feature [#13719](https://bugs.ruby-lang.org/issues/13719)\] \[PATCH\] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
 
-## \[Feature [#13732](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13732&sa=D&source=editors&ust=1686087248462605&usg=AOvVaw19P4qJ37ksdyVBk2wc2uCL)\] Precise Time.now on Windows (shyouhei)
+## \[Feature [#13732](https://bugs.ruby-lang.org/issues/13732)\] Precise Time.now on Windows (shyouhei)
 
-## \[Feature [#13733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13733&sa=D&source=editors&ust=1686087248463256&usg=AOvVaw2I94z2H9iIK3UwbEFe4Ulg)\] Dump the delegator instead of the delegated object (shyouhei)
+## \[Feature [#13733](https://bugs.ruby-lang.org/issues/13733)\] Dump the delegator instead of the delegated object (shyouhei)
 
-## \[Feature [#13625](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13625&sa=D&source=editors&ust=1686087248463854&usg=AOvVaw01NpLQVd_SHjJdVQ8qIlI3)\] BigDecimal short form / shorthand (shyouhei)
+## \[Feature [#13625](https://bugs.ruby-lang.org/issues/13625)\] BigDecimal short form / shorthand (shyouhei)
 
-## \[Feature [#13712](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13712&sa=D&source=editors&ust=1686087248464453&usg=AOvVaw1X9g__KMZyyjC17wu-eRvC)\] String#start\_with? with regexp (shyouhei)
+## \[Feature [#13712](https://bugs.ruby-lang.org/issues/13712)\] String#start\_with? with regexp (shyouhei)
 
 - bugs that are not assigned (shyouhei)
 
 
-## \[Bug [#13674](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13674&sa=D&source=editors&ust=1686087248465292&usg=AOvVaw1e3UizuNMl9z-Ecsz4vepS)\] BigDecimal comparison with Float::INFINITY is erroneous in 2.2.x and 2.3.x
+## \[Bug [#13674](https://bugs.ruby-lang.org/issues/13674)\] BigDecimal comparison with Float::INFINITY is erroneous in 2.2.x and 2.3.x
 
-## \[Bug [#13675](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13675&sa=D&source=editors&ust=1686087248465905&usg=AOvVaw3l31bLW3V0d7DPrHsmq5Bu)\] Should Zlib::GzipReader#ungetc accept nil?
+## \[Bug [#13675](https://bugs.ruby-lang.org/issues/13675)\] Should Zlib::GzipReader#ungetc accept nil?
 
-## \[Bug [#13700](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13700&sa=D&source=editors&ust=1686087248466526&usg=AOvVaw0XJWj6L0k0SeC0ogHdB6CX)\] Enumerable#sum may not work for Ranges subclasses due to optimization (mrkn)
+## \[Bug [#13700](https://bugs.ruby-lang.org/issues/13700)\] Enumerable#sum may not work for Ranges subclasses due to optimization (mrkn)
 
-## \[Bug [#13705](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13705&sa=D&source=editors&ust=1686087248467126&usg=AOvVaw3qm_Qux1FBAzlnaUrlEYmB)\] \[PATCH\] \`cfp consistency error' occurs when raising exception in bmethod call event
+## \[Bug [#13705](https://bugs.ruby-lang.org/issues/13705)\] \[PATCH\] \`cfp consistency error' occurs when raising exception in bmethod call event
 
-## \[Bug [#13716](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13716&sa=D&source=editors&ust=1686087248467657&usg=AOvVaw31NFqFUW6liDUolVOdIe09)\] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+## \[Bug [#13716](https://bugs.ruby-lang.org/issues/13716)\] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
 
-## \[Bug [#13670](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13670&sa=D&source=editors&ust=1686087248468237&usg=AOvVaw0SNkXcwOTwt1x6TvmypAIf)\] \[BUG\] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
+## \[Bug [#13670](https://bugs.ruby-lang.org/issues/13670)\] \[BUG\] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
 
 
 ## From attendees
 
-## \[Feature [#13780](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13780&sa=D&source=editors&ust=1686087248468997&usg=AOvVaw2deS9Zb2oSnBS_xAz7Me0s)\] String#each\_grapheme (naruse)
+## \[Feature [#13780](https://bugs.ruby-lang.org/issues/13780)\] String#each\_grapheme (naruse)
 
 
 - matz: the unit is grapheme cluster. so the name should be each\_grapheme\_cluster.
 
 
-## \[Misc [#13704](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13704&sa=D&source=editors&ust=1686087248469840&usg=AOvVaw2GG95VopuQ9MYRGBvNeKzB)\] \[PATCH\] Exclude Changelog files from documentation. (hsbt)
+## \[Misc [#13704](https://bugs.ruby-lang.org/issues/13704)\] \[PATCH\] Exclude Changelog files from documentation. (hsbt)
 
-## \[Feature [#12733](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12733&sa=D&source=editors&ust=1686087248470451&usg=AOvVaw2rOgti2OpgNg5JU10MPHCx)\] Bundle bundler to ruby core (hsbt)
+## \[Feature [#12733](https://bugs.ruby-lang.org/issues/12733)\] Bundle bundler to ruby core (hsbt)
 
-## \[Feature [#13847](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13847&sa=D&source=editors&ust=1686087248470938&usg=AOvVaw0jwreXuPZnL_F4ZAU0a9_q)\] Gem activated problem for default gems (hsbt)
-
-
-## [https://gist.github.com/hsbt/968fcbb7acfa9405d82040a3c219f43a](https://www.google.com/url?q=https://gist.github.com/hsbt/968fcbb7acfa9405d82040a3c219f43a&sa=D&source=editors&ust=1686087248471518&usg=AOvVaw0pw8poXncxT_FiymVKbY8h) (ja)
-
-- Related with [https://bugs.ruby-lang.org/issues/10320](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10320&sa=D&source=editors&ust=1686087248472114&usg=AOvVaw0Gce_ebZC_JoNnL94M5z_4)
+## \[Feature [#13847](https://bugs.ruby-lang.org/issues/13847)\] Gem activated problem for default gems (hsbt)
 
 
-## \[Misc [#13747](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13747&sa=D&source=editors&ust=1686087248472663&usg=AOvVaw0Qq--l11He0lq5Z8e-A61S)\] MinGW trunk build available on Appveyor (shyouhei)
+## [https://gist.github.com/hsbt/968fcbb7acfa9405d82040a3c219f43a](https://gist.github.com/hsbt/968fcbb7acfa9405d82040a3c219f43a) (ja)
 
-## \[Feature [#13751](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13751&sa=D&source=editors&ust=1686087248473254&usg=AOvVaw1MGp-hjIkoMp-463ALS69o)\] Suppert SSHFP resource records in rubysl-resolv (shyouhei)
+- Related with [https://bugs.ruby-lang.org/issues/10320](https://bugs.ruby-lang.org/issues/10320)
 
-## \[Bug [#13752](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13752&sa=D&source=editors&ust=1686087248473899&usg=AOvVaw0lSZECyxz3PPPdDiimvA_1)\] Can't observe sibling refinements (shyouhei)
 
-## \[Feature [#13683](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13683&sa=D&source=editors&ust=1686087248474471&usg=AOvVaw2eaIn2rbL3FARturD5-FV4)\] Add strict Enumerable#single (shyouhei)
+## \[Misc [#13747](https://bugs.ruby-lang.org/issues/13747)\] MinGW trunk build available on Appveyor (shyouhei)
 
-## \[Feature [#13763](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13763&sa=D&source=editors&ust=1686087248475051&usg=AOvVaw0jyuMUQ08wNN9TVbkZ_E3H)\] Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
+## \[Feature [#13751](https://bugs.ruby-lang.org/issues/13751)\] Suppert SSHFP resource records in rubysl-resolv (shyouhei)
 
-## \[Feature [#13765](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13765&sa=D&source=editors&ust=1686087248475708&usg=AOvVaw1qaicvgPxCeP7NyVRGv-tU)\] Add Proc#bind (shyouhei)
+## \[Bug [#13752](https://bugs.ruby-lang.org/issues/13752)\] Can't observe sibling refinements (shyouhei)
 
-## \[Feature [#13767](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13767&sa=D&source=editors&ust=1686087248476306&usg=AOvVaw1d2Ytv2BczJOTf_9nhtO8a)\] add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
+## \[Feature [#13683](https://bugs.ruby-lang.org/issues/13683)\] Add strict Enumerable#single (shyouhei)
 
-## \[Feature [#13777](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13777&sa=D&source=editors&ust=1686087248476948&usg=AOvVaw2dMUpqlvCbuOo4rtiGumM5)\] Array#delete\_all (shyouhei)
+## \[Feature [#13763](https://bugs.ruby-lang.org/issues/13763)\] Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
 
-## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087248477644&usg=AOvVaw0nVQybSwJjE6TU0I696Uml)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## \[Feature [#13765](https://bugs.ruby-lang.org/issues/13765)\] Add Proc#bind (shyouhei)
 
-## \[Feature [#13784](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13784&sa=D&source=editors&ust=1686087248478317&usg=AOvVaw1qGIizSgeVwz5KzKN-5-gh)\] Add Enumerable#filter as an alias of Enumerable#select (shyouhei)
+## \[Feature [#13767](https://bugs.ruby-lang.org/issues/13767)\] add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
 
-## \[Misc [#13804](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13804&sa=D&source=editors&ust=1686087248478958&usg=AOvVaw3_MMeFelbCNGje1glRKPeH)\] Protected methods cannot be overridden (shyouhei)
+## \[Feature [#13777](https://bugs.ruby-lang.org/issues/13777)\] Array#delete\_all (shyouhei)
 
-## \[Feature [#13803](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13803&sa=D&source=editors&ust=1686087248479602&usg=AOvVaw0zWA_FGwHoQCoFZe3unsk4)\] Add Socket::Ifaddr.vhid on supported platforms (shyouhei)
+## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
 
-## \[Feature [#13807](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13807&sa=D&source=editors&ust=1686087248480274&usg=AOvVaw1-UIDFjcuO0EVFZKJr3F3N)\] A method to filter the receiver against some condition (shyouhei)
+## \[Feature [#13784](https://bugs.ruby-lang.org/issues/13784)\] Add Enumerable#filter as an alias of Enumerable#select (shyouhei)
 
-## \[Feature [#13805](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13805&sa=D&source=editors&ust=1686087248480892&usg=AOvVaw1lWumto5jqVgfYuQ7NwizI)\] Make refinement scoping to be like that of constants (shyouhei)
+## \[Misc [#13804](https://bugs.ruby-lang.org/issues/13804)\] Protected methods cannot be overridden (shyouhei)
 
-## \[Feature [#13789](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13789&sa=D&source=editors&ust=1686087248481463&usg=AOvVaw1wI8HXjLqFj8PYVxChA4hm)\] Dir - methods (shyouhei)
+## \[Feature [#13803](https://bugs.ruby-lang.org/issues/13803)\] Add Socket::Ifaddr.vhid on supported platforms (shyouhei)
 
-## \[Misc [#13810](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13810&sa=D&source=editors&ust=1686087248482017&usg=AOvVaw0rLW2CGEyeDp8c47C6JHWn)\] Inconsistency between Date and Time.strftime("%v") (shyouhei)
+## \[Feature [#13807](https://bugs.ruby-lang.org/issues/13807)\] A method to filter the receiver against some condition (shyouhei)
 
-## \[Feature [#12282](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12282&sa=D&source=editors&ust=1686087248482584&usg=AOvVaw0P_1qTyAboqZ1Jezu4ajrQ)\] Hash#dig! for repeated applications of Hash#fetch (shyouhei)
+## \[Feature [#13805](https://bugs.ruby-lang.org/issues/13805)\] Make refinement scoping to be like that of constants (shyouhei)
 
-## \[Feature [#13821](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13821&sa=D&source=editors&ust=1686087248483204&usg=AOvVaw2A4BS3bKp92Qb4g7tgeluR)\] Allow fibers to be resumed across threads (shyouhei)
+## \[Feature [#13789](https://bugs.ruby-lang.org/issues/13789)\] Dir - methods (shyouhei)
 
-## \[Feature [#9450](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9450&sa=D&source=editors&ust=1686087248483844&usg=AOvVaw3p4UknTP8HSVS9Pur4JGxE)\] Allow overriding SSLContext options in Net::HTTP (shyouhei)
+## \[Misc [#13810](https://bugs.ruby-lang.org/issues/13810)\] Inconsistency between Date and Time.strftime("%v") (shyouhei)
 
-## \[Feature [#13820](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13820&sa=D&source=editors&ust=1686087248484447&usg=AOvVaw2gQU0HypT_cYCn_jjd7Mqa)\] Add a nill coalescing operator (shyouhei)
+## \[Feature [#12282](https://bugs.ruby-lang.org/issues/12282)\] Hash#dig! for repeated applications of Hash#fetch (shyouhei)
 
-## \[Feature [#13770](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13770&sa=D&source=editors&ust=1686087248485050&usg=AOvVaw0HlZHJKJhk0mHt1wWGtAU-)\] Can't create valid Cyrillic-named class/module (shyouhei, duerst)
+## \[Feature [#13821](https://bugs.ruby-lang.org/issues/13821)\] Allow fibers to be resumed across threads (shyouhei)
 
-## \[Feature [#13839](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13839&sa=D&source=editors&ust=1686087248485702&usg=AOvVaw2ZZRaxGPuW1bXridk8duat)\] String Interpolation Statements (shyouhei)
+## \[Feature [#9450](https://bugs.ruby-lang.org/issues/9450)\] Allow overriding SSLContext options in Net::HTTP (shyouhei)
 
-## \[Misc [#13840](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13840&sa=D&source=editors&ust=1686087248486253&usg=AOvVaw2F4vjCppZO6_6qo6CflSsQ)\] Collection methods - stability (shyouhei, duerst (propose to reject))
+## \[Feature [#13820](https://bugs.ruby-lang.org/issues/13820)\] Add a nill coalescing operator (shyouhei)
 
-- \[Feature [#13801](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13801&sa=D&source=editors&ust=1686087248486834&usg=AOvVaw0Xe_uLGLwT5JJPRduy2Do_)\] Implement case equality test for Set#=== (duerst)
+## \[Feature [#13770](https://bugs.ruby-lang.org/issues/13770)\] Can't create valid Cyrillic-named class/module (shyouhei, duerst)
+
+## \[Feature [#13839](https://bugs.ruby-lang.org/issues/13839)\] String Interpolation Statements (shyouhei)
+
+## \[Misc [#13840](https://bugs.ruby-lang.org/issues/13840)\] Collection methods - stability (shyouhei, duerst (propose to reject))
+
+- \[Feature [#13801](https://bugs.ruby-lang.org/issues/13801)\] Implement case equality test for Set#=== (duerst)
 - bugs that are not assigned (shyouhei)
 
 
-## \[Bug [#13549](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13549&sa=D&source=editors&ust=1686087248487663&usg=AOvVaw2xAe1ZAbjxcwZ8ZJFwQVTV)\] MinGW / Windows encoding - Two issues
+## \[Bug [#13549](https://bugs.ruby-lang.org/issues/13549)\] MinGW / Windows encoding - Two issues
 
-## \[Bug [#13754](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13754&sa=D&source=editors&ust=1686087248488261&usg=AOvVaw05cVy5vMt5QJT27I3sSvJi)\] bigdecimal with lower precision that Float
+## \[Bug [#13754](https://bugs.ruby-lang.org/issues/13754)\] bigdecimal with lower precision that Float
 
-## \[Bug [#13746](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13746&sa=D&source=editors&ust=1686087248488851&usg=AOvVaw2nGMCubqOowsFgpS0fFark)\] windows-pr gemのRuby 2.4 32bit版でのSEGV
+## \[Bug [#13746](https://bugs.ruby-lang.org/issues/13746)\] windows-pr gemのRuby 2.4 32bit版でのSEGV
 
-## \[Bug [#13758](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13758&sa=D&source=editors&ust=1686087248489320&usg=AOvVaw1mbLq6mOojMydjKuuhvr7y)\] TestRubyOptions#test\_segv\_setproctitle segfaults on AARCH64
+## \[Bug [#13758](https://bugs.ruby-lang.org/issues/13758)\] TestRubyOptions#test\_segv\_setproctitle segfaults on AARCH64
 
-## \[Bug [#13716](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13716&sa=D&source=editors&ust=1686087248489747&usg=AOvVaw0CODpdXTSimLfM4I0Qam_b)\] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+## \[Bug [#13716](https://bugs.ruby-lang.org/issues/13716)\] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
 
-## \[Bug [#13691](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13691&sa=D&source=editors&ust=1686087248490254&usg=AOvVaw1lzFaHXSU2e2fO-vx31LWH)\] Word- and symbol array literals not valid where regular array is
+## \[Bug [#13691](https://bugs.ruby-lang.org/issues/13691)\] Word- and symbol array literals not valid where regular array is
 
-## \[Bug [#13769](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13769&sa=D&source=editors&ust=1686087248490720&usg=AOvVaw1H8XlbE-FKW965siy4GSeF)\] IPAddr#ipv4\_compat incorrect behavior
+## \[Bug [#13769](https://bugs.ruby-lang.org/issues/13769)\] IPAddr#ipv4\_compat incorrect behavior
 
-## \[Bug [#13768](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13768&sa=D&source=editors&ust=1686087248491171&usg=AOvVaw1whAN143uBgX2l5fKgGH5F)\] SIGCHLD and Thread dead-lock problem
+## \[Bug [#13768](https://bugs.ruby-lang.org/issues/13768)\] SIGCHLD and Thread dead-lock problem
 
-## \[Bug [#13773](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13773&sa=D&source=editors&ust=1686087248491766&usg=AOvVaw0N9LDgsEEbM_DdAgKDUn1i)\] Improve String#prepend performance if only one argument is given
+## \[Bug [#13773](https://bugs.ruby-lang.org/issues/13773)\] Improve String#prepend performance if only one argument is given
 
-## \[Bug [#13774](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13774&sa=D&source=editors&ust=1686087248492348&usg=AOvVaw2v1WqoBrGzj56HIBx8ryby)\] for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
+## \[Bug [#13774](https://bugs.ruby-lang.org/issues/13774)\] for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
 
-## \[Bug [#13748](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13748&sa=D&source=editors&ust=1686087248492943&usg=AOvVaw1m_EqVkrVESIxNBWLg9rM7)\] \[PATCH\] Fix mul overflow detection for LLP64 arch.
+## \[Bug [#13748](https://bugs.ruby-lang.org/issues/13748)\] \[PATCH\] Fix mul overflow detection for LLP64 arch.
 
-## \[Bug [#13781](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13781&sa=D&source=editors&ust=1686087248493514&usg=AOvVaw0rN3pwh4XrH_yPsQK6vLSb)\] Should the safe navigation operator invoke nil?
+## \[Bug [#13781](https://bugs.ruby-lang.org/issues/13781)\] Should the safe navigation operator invoke nil?
 
-## \[Bug [#13795](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13795&sa=D&source=editors&ust=1686087248494150&usg=AOvVaw1WRiCLjKKmTS1XkvXAaUoP)\] Hash#select return type does not match Hash#find\_all
+## \[Bug [#13795](https://bugs.ruby-lang.org/issues/13795)\] Hash#select return type does not match Hash#find\_all
 
-## \[Bug [#13811](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13811&sa=D&source=editors&ust=1686087248494717&usg=AOvVaw1vX83eOfh89adYUhVBV12F)\] Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
+## \[Bug [#13811](https://bugs.ruby-lang.org/issues/13811)\] Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
 
 
 We couldn’t investigate it because there is not enough reproduction instruction..
 
-## \[Bug [#13818](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13818&sa=D&source=editors&ust=1686087248495448&usg=AOvVaw3NtVG1B_sh4z7Qf4Mm13tv)\] Licence issue with use of Onigmo rather than Oniguruma library files
+## \[Bug [#13818](https://bugs.ruby-lang.org/issues/13818)\] Licence issue with use of Onigmo rather than Oniguruma library files
 
-## \[Bug [#13827](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13827&sa=D&source=editors&ust=1686087248496109&usg=AOvVaw2lI4oij8nHP6enF5y9YrMT)\] Improve performance of Base64.urlsafe\_encode64
+## \[Bug [#13827](https://bugs.ruby-lang.org/issues/13827)\] Improve performance of Base64.urlsafe\_encode64
 
-## \[Bug [#13829](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13829&sa=D&source=editors&ust=1686087248496810&usg=AOvVaw1ivZ0aG5GPe53RBUXP20BA)\] NUL char in $0
+## \[Bug [#13829](https://bugs.ruby-lang.org/issues/13829)\] NUL char in $0
 
-## \[Bug [#13833](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13833&sa=D&source=editors&ust=1686087248497418&usg=AOvVaw1sD9eIzOvqS6taMRcUKEQF)\] String#scanf("%a") incorrectly requires a sign on the (binary) exponent
+## \[Bug [#13833](https://bugs.ruby-lang.org/issues/13833)\] String#scanf("%a") incorrectly requires a sign on the (binary) exponent
 
-## \[Bug [#13835](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13835&sa=D&source=editors&ust=1686087248498063&usg=AOvVaw1ZTqzvYF2ymsNiMLiG8JFL)\] Using 'open-uri' with 'tempfile' causes an exception
+## \[Bug [#13835](https://bugs.ruby-lang.org/issues/13835)\] Using 'open-uri' with 'tempfile' causes an exception
 
-## \[Bug [#13757](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13757&sa=D&source=editors&ust=1686087248498655&usg=AOvVaw2ubAeH0s-MyTCSDqCZYRlS)\] TestBacktrace#test\_caller\_lev segaults on PPC
+## \[Bug [#13757](https://bugs.ruby-lang.org/issues/13757)\] TestBacktrace#test\_caller\_lev segaults on PPC
 
-## \[Bug [#13167](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13167&sa=D&source=editors&ust=1686087248499272&usg=AOvVaw09EjI9NbJ2DtSjdg0jQBRU)\] Dir.glob is 25x slower since Ruby 2.2
+## \[Bug [#13167](https://bugs.ruby-lang.org/issues/13167)\] Dir.glob is 25x slower since Ruby 2.2
 
-## \[Bug [#13844](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13844&sa=D&source=editors&ust=1686087248499866&usg=AOvVaw3lKIDh9x6Rtb8PvidTGtEL)\] Toplevel returns should fire ensures
+## \[Bug [#13844](https://bugs.ruby-lang.org/issues/13844)\] Toplevel returns should fire ensures
 
 
 ## From non-attendees
 
-## \[Feature [#13686](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13686&sa=D&source=editors&ust=1686087248500655&usg=AOvVaw0y0uxR7qjEbjWE4viyrmKt)\] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (aycabta)
+## \[Feature [#13686](https://bugs.ruby-lang.org/issues/13686)\] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (aycabta)
 
 
 ## Write your name and your interest (what do you want to ask and to whom?) please.

--- a/2017/DevMeeting-2017-09-25.md
+++ b/2017/DevMeeting-2017-09-25.md
@@ -161,9 +161,9 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 Date: 2017/09/25 (Mon)
 Time: 14:00- 18:00 (JST)
 Place: Speee, Inc.
-Sign-up: [https://ruby.connpass.com/event/67822/](https://www.google.com/url?q=https://ruby.connpass.com/event/67822/&sa=D&source=editors&ust=1686087280530638&usg=AOvVaw1DMfPeF2_EJLjtzpVz8oD7)
-log edit: [https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9\_TkMayQ6\_s/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9_TkMayQ6_s/edit&sa=D&source=editors&ust=1686087280531084&usg=AOvVaw18a1fjbxrWdfNTo3R_qKxK)
-log: [https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9\_TkMayQ6\_s/pub](https://www.google.com/url?q=https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9_TkMayQ6_s/pub&sa=D&source=editors&ust=1686087280531380&usg=AOvVaw3-MBfXmn2DtjonTgnvD2UM)
+Sign-up: [https://ruby.connpass.com/event/67822/](https://ruby.connpass.com/event/67822/)
+log edit: [https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9\_TkMayQ6\_s/edit](https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9_TkMayQ6_s/edit)
+log: [https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9\_TkMayQ6\_s/pub](https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9_TkMayQ6_s/pub)
 Attendees: matz (Yukihiro Matsumoto), nobu (Nobuyoshi Nakada), ko1 (Koichi Sasada, partially), naruse (Yui Naruse), akr (Akira Tanaka), shyouhei (Shyouhei Urabe), mrkn (Kenta Murata), mame (Yusuke Endoh), knu (Akinori MUSHA), duerst (Martin Dürst), yuki (Yuki Nishijima) (add your name here if you would like to appear)
 Language: mostly Japanese (sorry for non native Japanese speakers)
 
@@ -183,7 +183,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## About 2.5 timeframe
 
-## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25&sa=D&source=editors&ust=1686087280533030&usg=AOvVaw0W4B5MfU7_hqlhOkj85JrJ)
+## [https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/ReleaseEngineering25)
 
 
 - shyouhei: no blocker now.
@@ -191,12 +191,12 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-## \[Feature [#13396](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13396&sa=D&source=editors&ust=1686087280534228&usg=AOvVaw33J_B18QtOe6KykD_Nxxxe)\] Net::HTTP has no write timeout (shyouhei) Sorry, what was the conclusion of it?
+## \[Feature [#13396](https://bugs.ruby-lang.org/issues/13396)\] Net::HTTP has no write timeout (shyouhei) Sorry, what was the conclusion of it?
 
 
 - naruse: I’ll implement this.
 
-## \[Bug [#13438](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13438&sa=D&source=editors&ust=1686087280534889&usg=AOvVaw0maGzvrSQUnoz3SFc1Bpyl)\] Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei) Sorry, what was the conclusion of it?
+## \[Bug [#13438](https://bugs.ruby-lang.org/issues/13438)\] Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei) Sorry, what was the conclusion of it?
 
 
 - mrkn: I remember we should not support old OpenBSD.
@@ -204,39 +204,39 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - shyouhei: then should we accept this?
 - nobu: yes.
 
-## \[Feature [#13608](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13608&sa=D&source=editors&ust=1686087280535880&usg=AOvVaw3u8j7ONvSZr2h8phJdb5N5)\] Add TracePoint#thread (shyouhei)
+## \[Feature [#13608](https://bugs.ruby-lang.org/issues/13608)\] Add TracePoint#thread (shyouhei)
 
 
 - ko1: I think we don’t need this.
 - naruse: I wanted this when I created a tracer.
 - ko1: the tracer shall run on the thread. Thread.current should suffice
 
-## \[Feature [#13602](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13602&sa=D&source=editors&ust=1686087280536664&usg=AOvVaw088YT2SCkTD5DOb2ANzSfv)\] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
+## \[Feature [#13602](https://bugs.ruby-lang.org/issues/13602)\] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
 
 
 - ko1: is it worth for a 5-6% speedup?
 - mame: this should affect optcarrot...
 
-## \[Feature [#13613](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13613&sa=D&source=editors&ust=1686087280537347&usg=AOvVaw1qm5R91gtCQizT0WWLP-nQ)\] Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
+## \[Feature [#13613](https://bugs.ruby-lang.org/issues/13613)\] Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
 
 
 - akr: we should define errors that are “fatal” and those aren’t.  For instance, ENOENT is not fatal but EPERM is.
 - shyouhei: it sounds reasonable for someone want to know when there \_are\_ some nasty files.
 - mame: should we raise exceptions for errors other than ENOENT? or to warn only?
 
-## \[Feature [#13620](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13620&sa=D&source=editors&ust=1686087280538106&usg=AOvVaw1fPJWxGVwZnEg4YOfWA8Qe)\] Simplifying MRI's build system: always install (shyouhei)
+## \[Feature [#13620](https://bugs.ruby-lang.org/issues/13620)\] Simplifying MRI's build system: always install (shyouhei)
 
 
 - the thread is going on.
 
-## \[Feature [#13630](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13630&sa=D&source=editors&ust=1686087280538651&usg=AOvVaw0rb-Vtx5f6Q53bJzq1cqdD)\] :\[\] method should accept block in nice syntax (shyouhei) OK to close?
+## \[Feature [#13630](https://bugs.ruby-lang.org/issues/13630)\] :\[\] method should accept block in nice syntax (shyouhei) OK to close?
 
 
 - matz: I think it should be accepted.
 - nobu: mruby doesn’t work this way, BTW.
 - shyouhei: OK, lets close.
 
-- \[Feature [#11484](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11484&sa=D&source=editors&ust=1686087280539496&usg=AOvVaw3hgQrpKthUFI0DWT_H639w)\] add output offset for readpartial/read\_nonblock/etc (shyouhei)
+- \[Feature [#11484](https://bugs.ruby-lang.org/issues/11484)\] add output offset for readpartial/read\_nonblock/etc (shyouhei)
 
 - akr: sounds OK to me.
 - shyouhei: seems nobody is against the feature itself but the API?
@@ -245,14 +245,14 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - nobu: what about buffer\_offset?
 - knu: seems IO.write has optional 3rd argument, offset, which is used to seek the file.
 
-## \[Feature [#9001](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9001&sa=D&source=editors&ust=1686087280540497&usg=AOvVaw0Xhok2krZGSbbQc7ZEcwnk)\] Please package better standard library (shyouhe)
+## \[Feature [#9001](https://bugs.ruby-lang.org/issues/9001)\] Please package better standard library (shyouhe)
 
 
 - duerst: This particular ticket seems no feature but for long term, what should we do for standard libraries?
 - mrkn: I think current goal is to bundle things that are only needed for installing rubygems
 - akira: close this and let people individually name replacemets.
 
-## \[Feature [#12533](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12533&sa=D&source=editors&ust=1686087280541062&usg=AOvVaw2kutIF7DGy929CUeVyTQKP)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
+## \[Feature [#12533](https://bugs.ruby-lang.org/issues/12533)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
 
 
 - matz: this sounds like a bug instead of local rebinding?
@@ -289,24 +289,24 @@ end
 
 puts "tomatoe".vegetables
 
-## \[Feature [#13653](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13653&sa=D&source=editors&ust=1686087280543152&usg=AOvVaw3kNrSzYZt1wWiYNEKEl416)\] Bundled zlib helper (shyouhei)
+## \[Feature [#13653](https://bugs.ruby-lang.org/issues/13653)\] Bundled zlib helper (shyouhei)
 
 
 - shyouhei: postpone because hsbt is absent.
 
-## \[Feature [#13626](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13626&sa=D&source=editors&ust=1686087280543840&usg=AOvVaw0znFKkf_dH25kJXzODgTpK)\] Add String#byteslice! (shyouhei)
+## \[Feature [#13626](https://bugs.ruby-lang.org/issues/13626)\] Add String#byteslice! (shyouhei)
 
 
 - mame: sounds reasonable because we have both slice and slice!
 - matz: agreed.
 
-## \[Feature [#13551](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13551&sa=D&source=editors&ust=1686087280544575&usg=AOvVaw3aoPOj81lUi1OkxopfJ7cp)\] Add a method to alias class methods (shyouhei)
+## \[Feature [#13551](https://bugs.ruby-lang.org/issues/13551)\] Add a method to alias class methods (shyouhei)
 
 
 - shyouhei: ah, I want this feature.
 - matz: I prefer opening singleton class.
 
-## \[Feature [#13332](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13332&sa=D&source=editors&ust=1686087280545273&usg=AOvVaw1kw4565_1X6rjaYAUQdJqV)\] Forwardable#def\_instance\_delegator nil (shyouhei)
+## \[Feature [#13332](https://bugs.ruby-lang.org/issues/13332)\] Forwardable#def\_instance\_delegator nil (shyouhei)
 
 
 - nobu: I don’t think this is much meaningful.
@@ -314,30 +314,30 @@ puts "tomatoe".vegetables
 - knu: ActiveSupport::Delegate also doesn’t support this comples feature (but only allow\_nil)
 - matz: I’d like to hear use cases.
 
-## \[Feature [#13378](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13378&sa=D&source=editors&ust=1686087280545959&usg=AOvVaw2kfMzLXObkr-9QSuXzvSS0)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+## \[Feature [#13378](https://bugs.ruby-lang.org/issues/13378)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
 
 
 - nobu: I’m handlig this. WIP.
 
-## \[Feature [#13381](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13381&sa=D&source=editors&ust=1686087280546453&usg=AOvVaw0JRLdy99IkuWXDSgRGFWlf)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## \[Feature [#13381](https://bugs.ruby-lang.org/issues/13381)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
 
 
 - matz: postpone because ko1 is absent.
 
-## \[Feature [#13677](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13677&sa=D&source=editors&ust=1686087280547021&usg=AOvVaw3q2B0XFOQ0KK0gIlS8RPTK)\] Add more details to error "Name or service not known (SocketError)" (shyouhei)
+## \[Feature [#13677](https://bugs.ruby-lang.org/issues/13677)\] Add more details to error "Name or service not known (SocketError)" (shyouhei)
 
 
 - akr: we currenly only show the return value of gai\_strerror(). Seems OK to extend though.
 - akr: patch is welcomed.
 
-## \[Feature [#9323](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9323&sa=D&source=editors&ust=1686087280547573&usg=AOvVaw0_AsdqTk98KVnKB529OBSI)\] IO#writev (shyouhei)
+## \[Feature [#9323](https://bugs.ruby-lang.org/issues/9323)\] IO#writev (shyouhei)
 
 
 - akr: do we call syscalls many times, or should we buffer?
 - mame: I want to know how this speeds things up.
 - knu: maybe atomic write is the point.
 
-## \[Feature [#13693](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13693&sa=D&source=editors&ust=1686087280548098&usg=AOvVaw3anf_hNNXQu48ruBqi8w-M)\] Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
+## \[Feature [#13693](https://bugs.ruby-lang.org/issues/13693)\] Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
 
 
 - mame: haha
@@ -349,18 +349,18 @@ puts "tomatoe".vegetables
 - mrkn: yes.
 - mrkn: it seems the behaviour of #to\_i comes with atoi().
 
-## \[Feature [#13434](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13434&sa=D&source=editors&ust=1686087280549113&usg=AOvVaw2cxOT0ni4UA8D1u1wU6xjw)\] better method definition in C API (shyouhei)
+## \[Feature [#13434](https://bugs.ruby-lang.org/issues/13434)\] better method definition in C API (shyouhei)
 
 
 - shyouhei: postpone because ko1 is absent now.
 
-## \[Feature [#13696](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13696&sa=D&source=editors&ust=1686087280549582&usg=AOvVaw0u2vgwWSMqrRZWPRziV6KE)\] Add exchange and noreplace options to File.rename (shyouhei)
+## \[Feature [#13696](https://bugs.ruby-lang.org/issues/13696)\] Add exchange and noreplace options to File.rename (shyouhei)
 
 
 - akr: This should definitely not be an extension to #rename.
 - nobu: It’s hard to introduce in-core.
 
-## \[Feature [#13683](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13683&sa=D&source=editors&ust=1686087280550109&usg=AOvVaw2ScW1cnL3mfvvflZxyz0LT)\] Add strict Enumerable#single (shyouhei)
+## \[Feature [#13683](https://bugs.ruby-lang.org/issues/13683)\] Add strict Enumerable#single (shyouhei)
 
 
 - shyouhei: わかる
@@ -371,7 +371,7 @@ puts "tomatoe".vegetables
 - mame: what about the feature itself?
 - matz: think we need more use case.
 
-## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686087280551188&usg=AOvVaw05fsyaWbHAKnxDoHuiw7vw)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
 
 
 - matz: async { File.read }
@@ -380,12 +380,12 @@ puts "tomatoe".vegetables
 - ko1: what if a library author did this, its user can never be aware of this async call.
 - ko1: If a Fiber body is small, it may have no problem.  However when someone write a framework that wraps existing external library, that should result in a problematic situation.
 
-## \[Feature [#13821](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13821&sa=D&source=editors&ust=1686087280552245&usg=AOvVaw08bg-bz9yjadzgB6bUwVjW)\] Allow fibers to be resumed across threads (shyouhei)
+## \[Feature [#13821](https://bugs.ruby-lang.org/issues/13821)\] Allow fibers to be resumed across threads (shyouhei)
 
 
 - ko1: it’s technically impossible.
 
-## \[Bug [#13931](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13931&sa=D&source=editors&ust=1686087280552799&usg=AOvVaw2OF0PRpGjlLUOZTb7qZtnb)\] correct install\_name of libruby on macOS (libruby.2.5.0.dylib -> libruby.2.5.dylib) (naruse)
+## \[Bug [#13931](https://bugs.ruby-lang.org/issues/13931)\] correct install\_name of libruby on macOS (libruby.2.5.0.dylib -> libruby.2.5.dylib) (naruse)
 
 
 - nobu: compatibility version shall be, and is, “2.4.0” ATM.  But we had bugs before.  I don’t want to change the AS-IS behaviour.
@@ -393,24 +393,24 @@ puts "tomatoe".vegetables
 - naruse: compatibility version shall be “2.4.0” or “2.4”, and linked libray should be libruby.2.4.dylib
 
 
-- \[Bug [#13917](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13917&sa=D&source=editors&ust=1686087280553388&usg=AOvVaw3xTSpLxfdUUE4F31z_AeWj)\] Comparable#clamp is slower than using Array#min,max. (naruse)
+- \[Bug [#13917](https://bugs.ruby-lang.org/issues/13917)\] Comparable#clamp is slower than using Array#min,max. (naruse)
 
 - nobu: the prposed patch seems roughly okay
 - mame: we don’t optimize Comparable#clamp for literals, because no practical usage can be thought for such thing. NEWS shall be consulted.
 - naruse: I’ll respond as such. nobu will merge the pull request.
 
-## \[Feature [#13893](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13893&sa=D&source=editors&ust=1686087280554009&usg=AOvVaw1th4kPmvwr7OzkfjoXqk5Y)\] Add Fiber#\[\] and Fiber#\[\]= and restore Thread#\[\] and Thread#\[\]= to their original behavior (shyouhei)
+## \[Feature [#13893](https://bugs.ruby-lang.org/issues/13893)\] Add Fiber#\[\] and Fiber#\[\]= and restore Thread#\[\] and Thread#\[\]= to their original behavior (shyouhei)
 
 
 - akr: This is clear, but too late.
 
-## \[Feature [#10344](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10344&sa=D&source=editors&ust=1686087280554554&usg=AOvVaw33DADjQ83tpRt-HH9nB32p)\] \[PATCH\] Implement Fiber#raise (shyouhei)
+## \[Feature [#10344](https://bugs.ruby-lang.org/issues/10344)\] \[PATCH\] Implement Fiber#raise (shyouhei)
 
 
 - ko1: if we allow Fiber#raise, auto fiber shall introduce weired behaviour.
 - akr: I don’t think auto fiber should transfar exceptions.
 
-## \[Feature [#13923](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13923&sa=D&source=editors&ust=1686087280555160&usg=AOvVaw2aoTYfXoD7tVDS_mkTGqiH)\] Idiom to release resources safely, with less indentations (shyouhei)
+## \[Feature [#13923](https://bugs.ruby-lang.org/issues/13923)\] Idiom to release resources safely, with less indentations (shyouhei)
 
 
 - shyouhei: This is what C++ resolves using RAII
@@ -441,7 +441,7 @@ puts "tomatoe".vegetables
 - matz: returning to the issue, let’s hear what the OP thinks about the nobu’s library.
 
 
-## \[Feature [#13919](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13919&sa=D&source=editors&ust=1686087280557224&usg=AOvVaw2sXUu_YLSxvW4f2OUGS7fw)\] Add a new method to create Time instances from unix time and nsec (shyouhei)
+## \[Feature [#13919](https://bugs.ruby-lang.org/issues/13919)\] Add a new method to create Time instances from unix time and nsec (shyouhei)
 
 
 - naruse: I want it.
@@ -459,7 +459,7 @@ puts "tomatoe".vegetables
 - naruse: I think no practical usage are there for specifying both msec and nsec.
 - matz: OK, accepted.  But specifying nil shall raise exceptions.
 
-## \[Bug [#13887](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13887&sa=D&source=editors&ust=1686087280559317&usg=AOvVaw1Y6JrF6D3Ltd1KjmqbC9Il)\] test/ruby/test\_io.rb may get stuck with FIBER\_USE\_NATIVE=0 on Linux
+## \[Bug [#13887](https://bugs.ruby-lang.org/issues/13887)\] test/ruby/test\_io.rb may get stuck with FIBER\_USE\_NATIVE=0 on Linux
 
 
 - ko1: this is a bug that should be fixed. I’ll do.

--- a/2018/DevMeeting-2018-01-24.md
+++ b/2018/DevMeeting-2018-01-24.md
@@ -125,9 +125,9 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 
 ## Place: Speee Inc.
 
-## Sign-up: [https://ruby.connpass.com/event/73509/](https://www.google.com/url?q=https://ruby.connpass.com/event/73509/&sa=D&source=editors&ust=1686087512359141&usg=AOvVaw1XFgDP9uD_HSpBxDUm2Es_)
+## Sign-up: [https://ruby.connpass.com/event/73509/](https://ruby.connpass.com/event/73509/)
 
-## log edit: [https://docs.google.com/document/d/1XbUbch8\_eTqh21FOwj9a\_X-ZyJyCBjxkq8rWwfpf5BM/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1XbUbch8_eTqh21FOwj9a_X-ZyJyCBjxkq8rWwfpf5BM/edit&sa=D&source=editors&ust=1686087512359522&usg=AOvVaw2oNKMsU2OdAKI5aMhLpGWY)
+## log edit: [https://docs.google.com/document/d/1XbUbch8\_eTqh21FOwj9a\_X-ZyJyCBjxkq8rWwfpf5BM/edit](https://docs.google.com/document/d/1XbUbch8_eTqh21FOwj9a_X-ZyJyCBjxkq8rWwfpf5BM/edit)
 
 ## log: TBD
 
@@ -148,7 +148,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 
 ## toolchain versioning
 
-## Revisions r61785, r61786, r61787 were introduced by the request from @naruse. However [shyouhei](https://www.google.com/url?q=https://bugs.ruby-lang.org/users/10&sa=D&source=editors&ust=1686087512360881&usg=AOvVaw0ePcJzCf5XdJSgCLsuD24q) thinks the request was somewhat vague.
+## Revisions r61785, r61786, r61787 were introduced by the request from @naruse. However [shyouhei](https://bugs.ruby-lang.org/users/10) thinks the request was somewhat vague.
 
 - Do we have to support such old toolchains? (shyouhei)
 
@@ -162,12 +162,12 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 
 ## From attendees
 
-## \[Feature [#14223](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14223&sa=D&source=editors&ust=1686087512361697&usg=AOvVaw2qoIVwRQ21jZGfCNmt4Avp)\] Enable #to\_proc by Refinements at &hoge (nobu)
+## \[Feature [#14223](https://bugs.ruby-lang.org/issues/14223)\] Enable #to\_proc by Refinements at &hoge (nobu)
 
 
 - Matz: LGTM.
 
-## \[Feature [#14371](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14371&sa=D&source=editors&ust=1686087512362186&usg=AOvVaw3C2jlghrPiW2dGUkolCj4y)\] New option "recursive: true" for Hash#transform\_keys! (nobu)
+## \[Feature [#14371](https://bugs.ruby-lang.org/issues/14371)\] New option "recursive: true" for Hash#transform\_keys! (nobu)
 
 
 - Mrkn: This is deep\_stringify\_keys!
@@ -184,14 +184,14 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Mrkn: we can fix it by preserving entries that conflict.
 - Matz: I have strong opinion on this.  Isn’t the current behaviour acceptable in sake of space efficiency?
 
-## \[Bug [#14374](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14374&sa=D&source=editors&ust=1686087512363214&usg=AOvVaw2B1puv_rNMyUOXl6K4ljSU)\] for does not splat elements (nobu)
+## \[Bug [#14374](https://bugs.ruby-lang.org/issues/14374)\] for does not splat elements (nobu)
 
 
 - Ko1: is it me?
 - Nobu: because it’s since 1.9
 - Matz: please fix.
 
-## \[Feature [#14313](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14313&sa=D&source=editors&ust=1686087512363750&usg=AOvVaw2KpS-czrNodNpwLcBg2XDl)\] Support creating KeyError with receiver and key from Ruby (mrkn/kou)
+## \[Feature [#14313](https://bugs.ruby-lang.org/issues/14313)\] Support creating KeyError with receiver and key from Ruby (mrkn/kou)
 
 
 - Mrkn: I was asked to bring this.
@@ -205,15 +205,15 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Mrkn: But he doesn’t have the repo access bit, nor gem release right.
 - Mame: He’s active on twitter etc.  You should ask his current status.
 
-## \[Feature [#4831](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4831&sa=D&source=editors&ust=1686087512364553&usg=AOvVaw2NGtLMxfwqnTu1GnsVIkwn)\] Integer#prime\_factors (mrkn)
+## \[Feature [#4831](https://bugs.ruby-lang.org/issues/4831)\] Integer#prime\_factors (mrkn)
 
 
 - Mrkn: name?
 - Shyouhei: yugui is on the ticket.
 
-## \[Feature [#14235](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14235&sa=D&source=editors&ust=1686087512365105&usg=AOvVaw3eDxHEK0-D0acn16JHMRMx)\] Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
+## \[Feature [#14235](https://bugs.ruby-lang.org/issues/14235)\] Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
 
-## \[Feature [#14386](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14386&sa=D&source=editors&ust=1686087512365387&usg=AOvVaw2AN5f2c2f_uvaRIS83hIRi)\] Add option to let Kernel.#system raise error instead of returning false (k0kubun)
+## \[Feature [#14386](https://bugs.ruby-lang.org/issues/14386)\] Add option to let Kernel.#system raise error instead of returning false (k0kubun)
 
 
 - Nobu: is this request to raise error when spawn fails, or when the spawned process fails?
@@ -222,7 +222,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Mrkn: I see similarity for discussion on Integer(). \[ruby-core:77171\] \[Feature#12732\]
 - Akr: There are \`exception: true\`
 
-## \[Bug [#14353](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14353&sa=D&source=editors&ust=1686087512365973&usg=AOvVaw1oixIdf58UwAT9WWQAxiYg)\] $SAFE should stay at least thread-local for compatibility (ko1)
+## \[Bug [#14353](https://bugs.ruby-lang.org/issues/14353)\] $SAFE should stay at least thread-local for compatibility (ko1)
 
 
 - Matz: This feature is something to extinct in future.
@@ -248,7 +248,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 
 ## From non-attendees
 
-## \[Feature [#14382](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14382&sa=D&source=editors&ust=1686087512367039&usg=AOvVaw3gFB_Lay0sGojfbewW7Sa7)\] Make public access of a private constant call const\_missing (jeremyevans0)
+## \[Feature [#14382](https://bugs.ruby-lang.org/issues/14382)\] Make public access of a private constant call const\_missing (jeremyevans0)
 
 
 - Nobu: sounds like a bug to me
@@ -256,7 +256,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Matz: Let’s try.
 - Nobu: I’d like to review the patch.
 
-## \[Feature [#14385](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14385&sa=D&source=editors&ust=1686087512367688&usg=AOvVaw0eQ3yNpD38-9kMww4Bo970)\] Deprecate back-tick for Ruby 3 (hsbt)
+## \[Feature [#14385](https://bugs.ruby-lang.org/issues/14385)\] Deprecate back-tick for Ruby 3 (hsbt)
 
 
 - Matz: I see several objections are there.
@@ -268,7 +268,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Mame: should we also deprecate def \`; end; self.\` ? If so, warning on parsing is dangerous.
 - Matz: I think we don’t necessarily warn this as soon as 2.6.
 
-## \[Feature [#13969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13969&sa=D&source=editors&ust=1686087512368511&usg=AOvVaw3WyXrLdBrk8ACvBw3WmPmA)\] Dir#each\_child (znz)
+## \[Feature [#13969](https://bugs.ruby-lang.org/issues/13969)\] Dir#each\_child (znz)
 
 
 - Matz: OK.

--- a/2018/DevMeeting-2018-02-20.md
+++ b/2018/DevMeeting-2018-02-20.md
@@ -122,9 +122,9 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 ## Place: MoneyForward Inc.
 
-## Sign-up: [https://ruby.connpass.com/event/73509/](https://www.google.com/url?q=https://ruby.connpass.com/event/73509/&sa=D&source=editors&ust=1686087534727438&usg=AOvVaw1jDaOHj58-KAWvuj258UUc)
+## Sign-up: [https://ruby.connpass.com/event/73509/](https://ruby.connpass.com/event/73509/)
 
-## log edit: [https://docs.google.com/document/d/1XbUbch8\_eTqh21FOwj9a\_X-ZyJyCBjxkq8rWwfpf5BM/edit](https://www.google.com/url?q=https://docs.google.com/document/d/1XbUbch8_eTqh21FOwj9a_X-ZyJyCBjxkq8rWwfpf5BM/edit&sa=D&source=editors&ust=1686087534728028&usg=AOvVaw0OtexNETjIckmV8KeegrgY)
+## log edit: [https://docs.google.com/document/d/1XbUbch8\_eTqh21FOwj9a\_X-ZyJyCBjxkq8rWwfpf5BM/edit](https://docs.google.com/document/d/1XbUbch8_eTqh21FOwj9a_X-ZyJyCBjxkq8rWwfpf5BM/edit)
 
 ## log: TBD
 
@@ -149,7 +149,7 @@ Next Developper Meetings
 
 ## toolchain versioning
 
-## Revisions r61785, r61786, r61787 were introduced by the request from @naruse. However [shyouhei](https://www.google.com/url?q=https://bugs.ruby-lang.org/users/10&sa=D&source=editors&ust=1686087534729949&usg=AOvVaw0zCOxnLHfD-SAJpu3U4FWv) thinks the request was somewhat vague.
+## Revisions r61785, r61786, r61787 were introduced by the request from @naruse. However [shyouhei](https://bugs.ruby-lang.org/users/10) thinks the request was somewhat vague.
 
 - Do we have to support such old toolchains? (shyouhei)
 
@@ -163,12 +163,12 @@ Next Developper Meetings
 
 ## From attendees
 
-## \[Feature [#14223](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14223&sa=D&source=editors&ust=1686087534730902&usg=AOvVaw0hKDkPhy2smcNbHV7h3t95)\] Enable #to\_proc by Refinements at &hoge (nobu)
+## \[Feature [#14223](https://bugs.ruby-lang.org/issues/14223)\] Enable #to\_proc by Refinements at &hoge (nobu)
 
 
 - Matz: LGTM.
 
-## \[Feature [#14371](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14371&sa=D&source=editors&ust=1686087534731456&usg=AOvVaw0138Z7WbBbP8sVNjKJtboU)\] New option "recursive: true" for Hash#transform\_keys! (nobu)
+## \[Feature [#14371](https://bugs.ruby-lang.org/issues/14371)\] New option "recursive: true" for Hash#transform\_keys! (nobu)
 
 
 - Mrkn: This is deep\_stringify\_keys!
@@ -185,14 +185,14 @@ Next Developper Meetings
 - Mrkn: we can fix it by preserving entries that conflict.
 - Matz: I have strong opinion on this.  Isn’t the current behaviour acceptable in sake of space efficiency?
 
-## \[Bug [#14374](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14374&sa=D&source=editors&ust=1686087534732782&usg=AOvVaw23Evsh07gKVvWVGJqwzzPf)\] for does not splat elements (nobu)
+## \[Bug [#14374](https://bugs.ruby-lang.org/issues/14374)\] for does not splat elements (nobu)
 
 
 - Ko1: is it me?
 - Nobu: because it’s since 1.9
 - Matz: please fix.
 
-## \[Feature [#14313](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14313&sa=D&source=editors&ust=1686087534733360&usg=AOvVaw01wZt0etef0uPW3YdiOET2)\] Support creating KeyError with receiver and key from Ruby (mrkn/kou)
+## \[Feature [#14313](https://bugs.ruby-lang.org/issues/14313)\] Support creating KeyError with receiver and key from Ruby (mrkn/kou)
 
 
 - Mrkn: I was asked to bring this.
@@ -206,15 +206,15 @@ Next Developper Meetings
 - Mrkn: But he doesn’t have the repo access bit, nor gem release right.
 - Mame: He’s active on twitter etc.  You should ask his current status.
 
-## \[Feature [#4831](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4831&sa=D&source=editors&ust=1686087534734216&usg=AOvVaw000s7NUFCbXTK8QZm0leib)\] Integer#prime\_factors (mrkn)
+## \[Feature [#4831](https://bugs.ruby-lang.org/issues/4831)\] Integer#prime\_factors (mrkn)
 
 
 - Mrkn: name?
 - Shyouhei: yugui is on the ticket.
 
-## \[Feature [#14235](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14235&sa=D&source=editors&ust=1686087534734701&usg=AOvVaw3sHZaMuYBRg9KZEliD_l-L)\] Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
+## \[Feature [#14235](https://bugs.ruby-lang.org/issues/14235)\] Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
 
-## \[Feature [#14386](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14386&sa=D&source=editors&ust=1686087534735005&usg=AOvVaw0rq2r3IXro64FgAE0y6TSU)\] Add option to let Kernel.#system raise error instead of returning false (k0kubun)
+## \[Feature [#14386](https://bugs.ruby-lang.org/issues/14386)\] Add option to let Kernel.#system raise error instead of returning false (k0kubun)
 
 
 - Nobu: is this request to raise error when spawn fails, or when the spawned process fails?
@@ -223,7 +223,7 @@ Next Developper Meetings
 - Mrkn: I see similarity for discussion on Integer(). \[ruby-core:77171\] \[Feature#12732\]
 - Akr: There are \`exception: true\`
 
-## \[Bug [#14353](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14353&sa=D&source=editors&ust=1686087534735695&usg=AOvVaw3VLRR_Wp944LrfkBaowubO)\] $SAFE should stay at least thread-local for compatibility (ko1)
+## \[Bug [#14353](https://bugs.ruby-lang.org/issues/14353)\] $SAFE should stay at least thread-local for compatibility (ko1)
 
 
 - Matz: This feature is something to extinct in future.
@@ -249,7 +249,7 @@ Next Developper Meetings
 
 ## From non-attendees
 
-## \[Feature [#14382](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14382&sa=D&source=editors&ust=1686087534736923&usg=AOvVaw1k6X3Y-H2yxkyqjbUiHTjO)\] Make public access of a private constant call const\_missing (jeremyevans0)
+## \[Feature [#14382](https://bugs.ruby-lang.org/issues/14382)\] Make public access of a private constant call const\_missing (jeremyevans0)
 
 
 - Nobu: sounds like a bug to me
@@ -257,7 +257,7 @@ Next Developper Meetings
 - Matz: Let’s try.
 - Nobu: I’d like to review the patch.
 
-## \[Feature [#14385](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14385&sa=D&source=editors&ust=1686087534737578&usg=AOvVaw1e4UbeKafR4WFVvojciJ0F)\] Deprecate back-tick for Ruby 3 (hsbt)
+## \[Feature [#14385](https://bugs.ruby-lang.org/issues/14385)\] Deprecate back-tick for Ruby 3 (hsbt)
 
 
 - Matz: I see several objections are there.
@@ -269,7 +269,7 @@ Next Developper Meetings
 - Mame: should we also deprecate def \`; end; self.\` ? If so, warning on parsing is dangerous.
 - Matz: I think we don’t necessarily warn this as soon as 2.6.
 
-## \[Feature [#13969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13969&sa=D&source=editors&ust=1686087534738407&usg=AOvVaw08WBvi8j7alCbpQ1j1kSuU)\] Dir#each\_child (znz)
+## \[Feature [#13969](https://bugs.ruby-lang.org/issues/13969)\] Dir#each\_child (znz)
 
 
 - Matz: OK.

--- a/2018/DevMeeting-2018-03-15.md
+++ b/2018/DevMeeting-2018-03-15.md
@@ -104,7 +104,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 ## Place: Cookpad Inc.
 
-## Sign-up: [https://ruby.connpass.com/event/73509/](https://www.google.com/url?q=https://ruby.connpass.com/event/73509/&sa=D&source=editors&ust=1686087561414743&usg=AOvVaw0MvDKXts21YuDXj-jK4dBx)
+## Sign-up: [https://ruby.connpass.com/event/73509/](https://ruby.connpass.com/event/73509/)
 
 ## log edit: https://docs.google.com/document/d/1RT0ijSo8uJ4Awn3CEvuYkjH0TVeXSYgeAFNmVGYC3ak/edit#
 
@@ -133,12 +133,12 @@ Maintainers starting Apr 2018:
 
 ### From attendees
 
-- \[Feature [#12732](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12732&sa=D&source=editors&ust=1686087561417823&usg=AOvVaw2TnZIF1U2DQv_gdsTY_QRI)\] An option to pass to Integer, Float, to return nil instead of raise an exception (mrkn)
+- \[Feature [#12732](https://bugs.ruby-lang.org/issues/12732)\] An option to pass to Integer, Float, to return nil instead of raise an exception (mrkn)
 
 - Resolved
 - Mrkn will file the conclusion.
 
-- \[Feature [#14476](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14476&sa=D&source=editors&ust=1686087561419003&usg=AOvVaw1nMdUcpLTgTebmSY6mx8m5)\] Adding same\_all? for checking whether all items in an Array are same (mrkn)
+- \[Feature [#14476](https://bugs.ruby-lang.org/issues/14476)\] Adding same\_all? for checking whether all items in an Array are same (mrkn)
 
 - Definition of “same”? -> \`\==\`, for mrkn’s case
 - Empty array? -> true, \[\].all?{} #=> true
@@ -158,12 +158,12 @@ Maintainers starting Apr 2018:
 - ary.uniform\_values?
 - ary.uniform\_values?{|e| e.foo}
 
-- \[Feature [#14362](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14362&sa=D&source=editors&ust=1686087561422488&usg=AOvVaw2_hvsNqgrOfzLr6297Pr0O)\] use BigDecimal instead of Float by default (mrkn)
+- \[Feature [#14362](https://bugs.ruby-lang.org/issues/14362)\] use BigDecimal instead of Float by default (mrkn)
 
 - Reject; Unacceptable performance & too incompatible
 - Matz will respond.
 
-- \[Feature [#14044](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14044&sa=D&source=editors&ust=1686087561423466&usg=AOvVaw0GwSuqgDrE8GunO-JRw_zE)\] Introduce a new attribute step in Range (mrkn)
+- \[Feature [#14044](https://bugs.ruby-lang.org/issues/14044)\] Introduce a new attribute step in Range (mrkn)
 
 \# current
 
@@ -199,42 +199,42 @@ p 1.step(by: 2)         #=> (1.step(by:2))
 
 - do-else-end
 
-- [https://twitter.com/joker1007/status/974173396006129664](https://www.google.com/url?q=https://twitter.com/joker1007/status/974173396006129664&sa=D&source=editors&ust=1686087561426418&usg=AOvVaw2q8_CQZXSdPalY8l51qnYe)
-- [https://twitter.com/joker1007/status/974173641347756032](https://www.google.com/url?q=https://twitter.com/joker1007/status/974173641347756032&sa=D&source=editors&ust=1686087561426964&usg=AOvVaw3BcH-hjx7hhdeoEw8zk755)
-- [https://twitter.com/joker1007/status/974176512554369027](https://www.google.com/url?q=https://twitter.com/joker1007/status/974176512554369027&sa=D&source=editors&ust=1686087561427354&usg=AOvVaw3V1Mly5xFZ0U-J2GAlK3zD)
+- [https://twitter.com/joker1007/status/974173396006129664](https://twitter.com/joker1007/status/974173396006129664)
+- [https://twitter.com/joker1007/status/974173641347756032](https://twitter.com/joker1007/status/974173641347756032)
+- [https://twitter.com/joker1007/status/974176512554369027](https://twitter.com/joker1007/status/974176512554369027)
 - Will be SyntaxError in 2.6-preview2
 - All of begin/do/def (experimental)
 
-- \[Feature [#14594](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14594&sa=D&source=editors&ust=1686087561428206&usg=AOvVaw0_3PqMYBkujy7MvDqZ4PgH)\] Rethink yield\_self's name
+- \[Feature [#14594](https://bugs.ruby-lang.org/issues/14594)\] Rethink yield\_self's name
 
 - “then”?
 - (1) Possible to use this method name by other libraries (like promise)
 - (2) No built-in methods like this …
 - Comitters objected the suggestion but matz accepted it
 
-- \[Feature [#14324](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14324&sa=D&source=editors&ust=1686087561429118&usg=AOvVaw1c6q2vp2QY4pVrVrVu8RVg)\] Should Exception#full\_message include escape sequences?
+- \[Feature [#14324](https://bugs.ruby-lang.org/issues/14324)\] Should Exception#full\_message include escape sequences?
 
 - Keyword arguments
 
 - order: :top/:bottom
 - highlight: true/false
 
-- \[Feature [#12745](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12745&sa=D&source=editors&ust=1686087561430363&usg=AOvVaw1tDFqKwKQnlGDs3x0HfNHu)\] String#(g)sub(!) should pass a MatchData to the block, not a String
+- \[Feature [#12745](https://bugs.ruby-lang.org/issues/12745)\] String#(g)sub(!) should pass a MatchData to the block, not a String
 
 - akr: how about gsubm, \`m\` means MatchData
 
 ### From non-attendees
 
-- \[Feature [#14245](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14245&sa=D&source=editors&ust=1686087561432012&usg=AOvVaw0jvA6MnYelIK_DHGCz5QmG)\] Add File.read etc. (shugo)
+- \[Feature [#14245](https://bugs.ruby-lang.org/issues/14245)\] Add File.read etc. (shugo)
 
 - Accepted
 - FYI: On 2.5, deprecation warning is added for this feature. We’ll remove this feature on 2.6.
 
-- \[Feature [#14579](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14579&sa=D&source=editors&ust=1686087561432998&usg=AOvVaw0C65RhU4bMUl22QlfZ1Vjm)\] Hash value omission (shugo)
+- \[Feature [#14579](https://bugs.ruby-lang.org/issues/14579)\] Hash value omission (shugo)
 
 - Reject because matz doesn’t like it.
 
-- \[Bug [#14541](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14541&sa=D&source=editors&ust=1686087561433611&usg=AOvVaw2Tb7I-ab-vMNeUgBB4NrHV)\] Class variables have broken semantics, let's fix them (eregon). I'd like more opinions and thoughts on whether we can change them.
+- \[Bug [#14541](https://bugs.ruby-lang.org/issues/14541)\] Class variables have broken semantics, let's fix them (eregon). I'd like more opinions and thoughts on whether we can change them.
 
 - usa: I use class variables in a correct way when I love class variables
 - ideas:
@@ -290,8 +290,8 @@ B.show
 
 - Matz approved NameError
 
-- \[Bugs [#14380](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14380&sa=D&source=editors&ust=1686087561437379&usg=AOvVaw0pk0MwFPDwO3j1ab2-XQaL)\] Change Hash#transform\_keys! and break compatibility with Ruby 2.5 and ActiveSupport, or not?
+- \[Bugs [#14380](https://bugs.ruby-lang.org/issues/14380)\] Change Hash#transform\_keys! and break compatibility with Ruby 2.5 and ActiveSupport, or not?
 
 - It’s considered bug. amatsuda says ActiveSupport will follow Ruby 2.6.
 
-- \[Feature [#11473](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11473&sa=D&source=editors&ust=1686087561438106&usg=AOvVaw0y-nrmEQkQhCvcuDlyIR8Z)\] Immutable String literal in Ruby 3 (hsbt): Do you really want to change it at Ruby 3? If It's yes, We should add a warning with destructive action on Ruby 2.6.
+- \[Feature [#11473](https://bugs.ruby-lang.org/issues/11473)\] Immutable String literal in Ruby 3 (hsbt): Do you really want to change it at Ruby 3? If It's yes, We should add a warning with destructive action on Ruby 2.6.

--- a/2018/DevMeeting-2018-04-19.md
+++ b/2018/DevMeeting-2018-04-19.md
@@ -68,7 +68,7 @@ Please add your favorite ticket numbers you want to ask to discuss.  If you have
 
 ## log: TBD
 
-wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Japan](https://www.google.com/url?q=https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Japan&sa=D&source=editors&ust=1686087582530503&usg=AOvVaw07TB6EghePHnY3Frquk78e)
+wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Japan](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Japan)
 
 ## Agenda
 
@@ -85,18 +85,18 @@ wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Ja
 
 ### From attendees
 
-\[Bug [#14345](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14345&sa=D&source=editors&ust=1686087582532185&usg=AOvVaw3IWZKfF7_hWm-nwgtUzLTY)\] http\_proxy setting should respect both parent domain and subdomain (hsbt)
+\[Bug [#14345](https://bugs.ruby-lang.org/issues/14345)\] http\_proxy setting should respect both parent domain and subdomain (hsbt)
 
-\[Feature [#14559](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14559&sa=D&source=editors&ust=1686087582532577&usg=AOvVaw29ARuGoj689fSVf2Qv97VX)\] ENV.slice (hsbt)
+\[Feature [#14559](https://bugs.ruby-lang.org/issues/14559)\] ENV.slice (hsbt)
 
 - Matz: OK.
 
-\[Feature [#14643](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14643&sa=D&source=editors&ust=1686087582533063&usg=AOvVaw0dcV1X2EpkkLPz8iXjniUL)\] Remove problematic separator '\\0' of Dir.glob and Dir.\[\] (usa)
+\[Feature [#14643](https://bugs.ruby-lang.org/issues/14643)\] Remove problematic separator '\\0' of Dir.glob and Dir.\[\] (usa)
 
 - Usa: we can pass arrays to the pattern.  No need to use \\0.
 - Matz: makes sense.
 
-\[Feature [#14111](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14111&sa=D&source=editors&ust=1686087582533687&usg=AOvVaw3-M7sQsq-tX6nPxfPxNs6x)\] ArgumentErrorが発生した時メソッドのプロトタイプをメッセージに含む (nobu)
+\[Feature [#14111](https://bugs.ruby-lang.org/issues/14111)\] ArgumentErrorが発生した時メソッドのプロトタイプをメッセージに含む (nobu)
 
 - nobu : seems OK to me.
 - Mame: is the “prototype” the actual string in the source code, or reconstructed?
@@ -110,30 +110,30 @@ wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Ja
 - Nobu: would like to review the patch again.
 - Ko1: what to show for singleton methods? Might be difficult.
 
-\[Bug [#14688](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14688&sa=D&source=editors&ust=1686087582534910&usg=AOvVaw2Rta1gG7nfEHqxQmIRNJh3)\] Net::HTTPResponse#value raises "Net::HTTPServerException" in 4xx response (usa)
+\[Bug [#14688](https://bugs.ruby-lang.org/issues/14688)\] Net::HTTPResponse#value raises "Net::HTTPServerException" in 4xx response (usa)
 
-\[Feature [#14683](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14683&sa=D&source=editors&ust=1686087582535339&usg=AOvVaw19eQM71AjD0zeJgJPTYSK1)\] IRB with Ripper (aycabta)
+\[Feature [#14683](https://bugs.ruby-lang.org/issues/14683)\] IRB with Ripper (aycabta)
 
 - Ask keiju to look at it.
 - Akr: do the OP want to maintain this?  Or make it a gem to delete from the repo?
 
-\[Feature [#14694](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14694&sa=D&source=editors&ust=1686087582535827&usg=AOvVaw3AFwkFldUCAVrDfvfRhpIX)\] TracePoint#parameters (mame)
+\[Feature [#14694](https://bugs.ruby-lang.org/issues/14694)\] TracePoint#parameters (mame)
 
 - Matz: I see no problem?
 - Ko1: TracePoint#parameters sounds like it expects the parameter values, not the names.
 
-\[Feature [#14624](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14624&sa=D&source=editors&ust=1686087582536343&usg=AOvVaw3VJYGH4HbLgombVfk0xXky)\] #{nil} allocates a fresh empty string each time (nobu)
+\[Feature [#14624](https://bugs.ruby-lang.org/issues/14624)\] #{nil} allocates a fresh empty string each time (nobu)
 
 - Matz: sounds like an implementation detail.
 - Ko1: it’s too large a patch to implement this as a new VM instruction.
 - Naruse: when I tested opt\_to\_s with @k0kubun the speedup was marginal/not that much.
 
-\[Feature [#6670](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6670&sa=D&source=editors&ust=1686087582536919&usg=AOvVaw2IAX5fob7lHbyXTGjER27Y)\] str.chars.last should be possible (mame)
+\[Feature [#6670](https://bugs.ruby-lang.org/issues/6670)\] str.chars.last should be possible (mame)
 
 - Mame: I’d like to give up deprecation of this block-giving behaviour.
 - Matz: OK.
 
-\[Feature [#12912](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12912&sa=D&source=editors&ust=1686087582537436&usg=AOvVaw0n54gDht5IREMiCynjPwTW)\] An endless range (1..) (mame)
+\[Feature [#12912](https://bugs.ruby-lang.org/issues/12912)\] An endless range (1..) (mame)
 
 - Mame: I’d like to consult matz.
 - Matz: I honestly feel there should be a fluent way to do 0..Float::INFINITY.
@@ -142,7 +142,7 @@ wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Ja
 - Akr: when this is done, needs of step should reduce very much.
 - Matz: accepted.
 
-\[Feature [#14352](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14352&sa=D&source=editors&ust=1686087582538295&usg=AOvVaw3-yqykiIw3ke_ARM6v5zZU)\] Array#pack("M") Quoted-printable (matz)
+\[Feature [#14352](https://bugs.ruby-lang.org/issues/14352)\] Array#pack("M") Quoted-printable (matz)
 
 - Naruse: I’ll take care.  Let me make this a doc issue.
 
@@ -150,7 +150,7 @@ wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Ja
 
 - Matz: I can live with #then.
 
-\[Feature [#14697](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14697&sa=D&source=editors&ust=1686087582538990&usg=AOvVaw06Lv7bq1IFY7Q388WdmB8V)\] Introducing Range#% as an alias to Range#step (mrkn)
+\[Feature [#14697](https://bugs.ruby-lang.org/issues/14697)\] Introducing Range#% as an alias to Range#step (mrkn)
 
 - Matz: I have no objection.
-- Mrkn: Numo’s Range#% is here [https://github.com/ruby-numo/numo-narray/blob/master/ext/numo/narray/step.c#L464](https://www.google.com/url?q=https://github.com/ruby-numo/numo-narray/blob/master/ext/numo/narray/step.c%23L464&sa=D&source=editors&ust=1686087582539415&usg=AOvVaw2Hpfbz2TYQRfNSIoYuj2cV)
+- Mrkn: Numo’s Range#% is here [https://github.com/ruby-numo/numo-narray/blob/master/ext/numo/narray/step.c#L464](https://github.com/ruby-numo/numo-narray/blob/master/ext/numo/narray/step.c#L464)

--- a/2018/DevMeeting-2018-05-17.md
+++ b/2018/DevMeeting-2018-05-17.md
@@ -110,7 +110,7 @@ logs
 
 ## From Attendees
 
-- \[Bug [#14699](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14699&sa=D&source=editors&ust=1686088412433702&usg=AOvVaw1ttGbU3l48pozEO6DJxl64)\] Subtle behaviors with endless range (mame)
+- \[Bug [#14699](https://bugs.ruby-lang.org/issues/14699)\] Subtle behaviors with endless range (mame)
 
 - Mame: what to do with #max for endless ones?
 - Usa:
@@ -123,7 +123,7 @@ logs
 - Mrkn: I like nil. (by text chat)
 - Ko1: let’s discuss this issue with mrkn.
 
-- \[Feature [#14724](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14724&sa=D&source=editors&ust=1686088412434545&usg=AOvVaw1jUAcXq0NOu6mm5oDQT3Vd)\] chains of inequalities (Martin)
+- \[Feature [#14724](https://bugs.ruby-lang.org/issues/14724)\] chains of inequalities (Martin)
 
 - Proposal by gotoken (Kentaro Goto) to allow 0 <= a < 10 as a shortcut of 0<=a && a<10, and so on; patch by Nobu avaliable
 - Ko1: what do you think matz?
@@ -139,13 +139,13 @@ logs
 
 ## From non-attendees
 
-- \[Feature [#14697](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14697&sa=D&source=editors&ust=1686088412435626&usg=AOvVaw1A-3RSUYUxUvA4qD3qatwn)\] Introducing Range#% as an alias to Range#step (mrkn)
+- \[Feature [#14697](https://bugs.ruby-lang.org/issues/14697)\] Introducing Range#% as an alias to Range#step (mrkn)
 
 - Matz already commented LGTM. Please judge whether this is acceptable.
 - Akr: I think this should go.
 - (nobody at the meeting had any objections)
 
-- \[Feature [#14724](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14724&sa=D&source=editors&ust=1686088412436022&usg=AOvVaw305MtH6t3YM4pgM8ZiXEpc)\] chains of inequations (mrkn)
+- \[Feature [#14724](https://bugs.ruby-lang.org/issues/14724)\] chains of inequations (mrkn)
 
 - This new syntax can also reduce the duplicated evaluations of common terms, such as timeval.tv\_sec in the descriptiohn of the proposal.
 - Same issue as above. See above.
@@ -168,7 +168,7 @@ logs
 
 Functional programming: (zverok)
 
-- \[Feature [#6284](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6284&sa=D&source=editors&ust=1686088412436970&usg=AOvVaw1e6WTyZ04eKWMecLybZhN_)\] Add composition for procs
+- \[Feature [#6284](https://bugs.ruby-lang.org/issues/6284)\] Add composition for procs
 
 - 6-year-old proposal. Matz: "Positive about adding function composition. But we need method name consensus before adding it? Is #\* OK for everyone?"
 - (ko1 is describing the Ruby Hack Challenge results)
@@ -180,25 +180,25 @@ Functional programming: (zverok)
 - Matz: shouldn’t we start with Proc…
 - Matz: and I think we need both OOP-ish / FP-ish way.
 
-- \[Feature [#13581](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13581&sa=D&source=editors&ust=1686088412437700&usg=AOvVaw126jlihr_iWWOsRIkk5AK9)\] Syntax sugar for method reference
+- \[Feature [#13581](https://bugs.ruby-lang.org/issues/13581)\] Syntax sugar for method reference
 
 - 1-year-old proposal. Matz: "I am for adding syntax sugar for method reference. But I don't like proposed syntax (e.g. \->). Any other idea?"
 - (reviewed comment #21)
 - Preference by the attendees is .:
 - Matz: \`.:\` is better than \`->\`
-- Mame: there is a patch cf #12125 [https://bugs.ruby-lang.org/issues/12125](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12125&sa=D&source=editors&ust=1686088412438185&usg=AOvVaw1dW4TYF62KFZX7ahnMdfqv)
+- Mame: there is a patch cf #12125 [https://bugs.ruby-lang.org/issues/12125](https://bugs.ruby-lang.org/issues/12125)
 
-- \[Feature [#11161](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11161&sa=D&source=editors&ust=1686088412438389&usg=AOvVaw3arbQyV0LtZ4duGpWFYMG1)\] Proc/Method#rcurry working like curry but in reverse order
+- \[Feature [#11161](https://bugs.ruby-lang.org/issues/11161)\] Proc/Method#rcurry working like curry but in reverse order
 
 - 3-year-old proposal with absolutely no reaction. I've added real-life examples there several months ago.
 - Mame: I don’t think reverse currying works for variadic methods
 - Akr: the “real-life” example is adding keyword arguments, which is not what currying is talking about
 
-- \[Feature [#14390](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14390&sa=D&source=editors&ust=1686088412438732&usg=AOvVaw2QkMfPWunWxFpjcXC3FgFo)\] UnboundMethod#to\_proc
+- \[Feature [#14390](https://bugs.ruby-lang.org/issues/14390)\] UnboundMethod#to\_proc
 
 - What is the expected behaviour here?
 
-- \[Feature [#14423](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14423&sa=D&source=editors&ust=1686088412438995&usg=AOvVaw0WzSELKsMgtw7XD3fS_Dm8)\] Enumerator from single object (Object#enumerate)
+- \[Feature [#14423](https://bugs.ruby-lang.org/issues/14423)\] Enumerator from single object (Object#enumerate)
 
 - Naruse: interesting proposal
 - Akr: adding method to Object sounds too radical to me.
@@ -207,7 +207,7 @@ Functional programming: (zverok)
 
 Misc:
 
-- \[Bug [#14575](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14575&sa=D&source=editors&ust=1686088412439470&usg=AOvVaw0Hq_vgGfveiKPE_2F9thvW)\] Switch Range#=== to use cover? instead of include? (zverok)
+- \[Bug [#14575](https://bugs.ruby-lang.org/issues/14575)\] Switch Range#=== to use cover? instead of include? (zverok)
 
 - Seems there is a compatibility issue.
 - Usa: does it matter? No one actually expects Range#=== to behave as #cover?
@@ -215,21 +215,21 @@ Misc:
 
 Docs (probably not to discuss on development meeting, but I am not sure where I can post it to have it more visible) (zverok)
 
-- Method: [https://bugs.ruby-lang.org/issues/14483](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14483&sa=D&source=editors&ust=1686088412439975&usg=AOvVaw1yJEalFlTkURkExPYkMuW3)
-- Proc: [https://bugs.ruby-lang.org/issues/14610](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14610&sa=D&source=editors&ust=1686088412440184&usg=AOvVaw3kOXJ2tBJzUxz4C7BF96-G)
-- MatchData: [https://bugs.ruby-lang.org/issues/14450](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14450&sa=D&source=editors&ust=1686088412440368&usg=AOvVaw0FH8pUXFdD9100eTNadvsJ)
-- yield\_self: [https://bugs.ruby-lang.org/issues/14436](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14436&sa=D&source=editors&ust=1686088412440545&usg=AOvVaw1R6-Pbaa_2zNruuecmUsHd)
+- Method: [https://bugs.ruby-lang.org/issues/14483](https://bugs.ruby-lang.org/issues/14483)
+- Proc: [https://bugs.ruby-lang.org/issues/14610](https://bugs.ruby-lang.org/issues/14610)
+- MatchData: [https://bugs.ruby-lang.org/issues/14450](https://bugs.ruby-lang.org/issues/14450)
+- yield\_self: [https://bugs.ruby-lang.org/issues/14436](https://bugs.ruby-lang.org/issues/14436)
 
 - Naruse: This meeting is not for documents. Just assign to docs member group.
 
-- \[Feature [#14473](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14473&sa=D&source=editors&ust=1686088412440903&usg=AOvVaw2guhkrCicaME5pjIrwXDnW)\] Add Range#subrange? ( greggzst )
+- \[Feature [#14473](https://bugs.ruby-lang.org/issues/14473)\] Add Range#subrange? ( greggzst )
 
 - Shyouhei: what to do with String this case?
 - Akr: the simplest is to only concern the both ends.
 - Usa: Hash has \`>\` and \`<\`
 - Mame: use case not clear.
 
-- \[Feature [#14097](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14097&sa=D&source=editors&ust=1686088412441296&usg=AOvVaw1oJt2z3tm24I8E-48RF_HO)\] Add union and difference to Array ( ana06)
+- \[Feature [#14097](https://bugs.ruby-lang.org/issues/14097)\] Add union and difference to Array ( ana06)
 
 - Matz: create #union and #union!, or create mutating #union ?
 - Matz: I want to add mutating method but #union does not sound mutating.
@@ -237,10 +237,10 @@ Docs (probably not to discuss on development meeting, but I am not sure where I 
 - Akr: to me it seems mutating or not is not the key point of this proposal.
     The key point is provide a (readable) name addition to an operator, I guess.
 
-- \[Feature [#14105](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14105&sa=D&source=editors&ust=1686088412441681&usg=AOvVaw1MCrbehASxWzXoVnOCFbZr)\] Introduce xor as alias for Set#^ ( ana06)
+- \[Feature [#14105](https://bugs.ruby-lang.org/issues/14105)\] Introduce xor as alias for Set#^ ( ana06)
 
 - Assign to knu
 
-- \[Misc [#14760](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14760&sa=D&source=editors&ust=1686088412441929&usg=AOvVaw1qUeOTtyITJ9CgW22-Mivg)\] cross-thread IO#close semantics (normal)
+- \[Misc [#14760](https://bugs.ruby-lang.org/issues/14760)\] cross-thread IO#close semantics (normal)
 
 - Ko1: I made it theoretically possible to unblock IO#select. However there is a difficult problem for  IO#copy\_stream.

--- a/2018/DevMeeting-2018-07-18.md
+++ b/2018/DevMeeting-2018-07-18.md
@@ -104,19 +104,19 @@ Place: MoneyForward HQ (Tokyo, Japan)
 
 ## Carry-over from previous meeting(s)
 
-- \[Feature [#14784](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14784&sa=D&source=editors&ust=1686088440615193&usg=AOvVaw1WIbBdTXpsmPcBdvxjeJpp)\] One-sided Comparable#clamp (with endless/startless ranges) (zverok)
+- \[Feature [#14784](https://bugs.ruby-lang.org/issues/14784)\] One-sided Comparable#clamp (with endless/startless ranges) (zverok)
 
 - more reasonable version of Object#enumerate proposed for the previous meeting.
 - isn’t it enough with accepting nil ? (e.g. .clamp(from, nil) )
 
-- \[Feature [#14859](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14859&sa=D&source=editors&ust=1686088440615968&usg=AOvVaw3D_Xjer_gUdMb7evK2QXSg)\] Timeout in VM (normalperson)
+- \[Feature [#14859](https://bugs.ruby-lang.org/issues/14859)\] Timeout in VM (normalperson)
 
 - Still needs some work, mainly wondering if the idea of moving this part of stdlib into core VM is acceptable or not. No semantic changes except speed improvement.
 - Ko1 will check the patch and will comment in Aug.
 
 ## From Attendees
 
-- \[Feature [#14473](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14473&sa=D&source=editors&ust=1686088440616720&usg=AOvVaw0Govhy3QEutXesDitUzyPH)\] Add Range#subrange? (tarui)
+- \[Feature [#14473](https://bugs.ruby-lang.org/issues/14473)\] Add Range#subrange? (tarui)
 
 - subrange?
 -  is ambiguous
@@ -127,7 +127,7 @@ Place: MoneyForward HQ (Tokyo, Japan)
 - include? is already used as it’s an element or not
 - cover? is acceptable, let it go (matz)
 
-- \[Feature [#14912](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14912&sa=D&source=editors&ust=1686088440617694&usg=AOvVaw0VGJBxwwNJlYINR0p9da4q)\] Introduce pattern matching syntax (mame)
+- \[Feature [#14912](https://bugs.ruby-lang.org/issues/14912)\] Introduce pattern matching syntax (mame)
 
 - pattern matching
 - Matz: positive for the proposal itself, though we need to discuss many details
@@ -175,33 +175,33 @@ End
 
 ## From non-attendees
 
-- \[Feature [#14111](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14111&sa=D&source=editors&ust=1686088440620715&usg=AOvVaw19eXqE4NgNhQ8ve-NuXGMf)\] ArgumentErrorが発生した時メソッドのプロトタイプをメッセージに含む (esjee)
+- \[Feature [#14111](https://bugs.ruby-lang.org/issues/14111)\] ArgumentErrorが発生した時メソッドのプロトタイプをメッセージに含む (esjee)
 
 - Suggestion: include method parameters when generating an ArgumentError message. Nobu's patch in the issue provides functionality to make writing a ruby gem to provide this functionality possible.
 - \`method\_name\` is true method name, not \`callee\`.
 - current implementation by nobu returns callee, so, change the implement to return true name.  after then, discuss about the necessity of callee.
 
-- \[Bug [#14878](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14878&sa=D&source=editors&ust=1686088440622033&usg=AOvVaw1FgLuBLhORvVrMcZ__1Bon)\] Add command line argument to deactivate JIT (k0kubun)
+- \[Bug [#14878](https://bugs.ruby-lang.org/issues/14878)\] Add command line argument to deactivate JIT (k0kubun)
 
 - Please discuss the necessity of the flag and its name in the proposal.
 - Use \--disable-jit and \--disable=jit, because we can already use \--disable=gems and \--disable-gems
 
-- \[Feature [#12306](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12306&sa=D&source=editors&ust=1686088440622887&usg=AOvVaw1o5qv_OV5XlvGmuzxwaLNy)\] Implement String #blank? #present? and improve #strip and family to handle unicode (sam.saffron)
+- \[Feature [#12306](https://bugs.ruby-lang.org/issues/12306)\] Implement String #blank? #present? and improve #strip and family to handle unicode (sam.saffron)
 
 - blank? Is not the best name, but acceptable (space\_only? or something might be better)
 - present? Is not acceptable at all
 - matz will accept the feature itself of blank?, but hope another good name
 - TBW
 
-- \[Feature [#14913](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14913&sa=D&source=editors&ust=1686088440624295&usg=AOvVaw2Z2huq10Mgq5JAGZpLI2U4)\] Extend case to match several values at once (zverok)
+- \[Feature [#14913](https://bugs.ruby-lang.org/issues/14913)\] Extend case to match several values at once (zverok)
 
 - some steps towards better pattern matching
 
-- \[Feature [#14914](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14914&sa=D&source=editors&ust=1686088440624829&usg=AOvVaw04zAYjP29JymAHtTf-aEG4)\] Add BasicObject#instance\_exec\_with\_block (jeremyevans0)
+- \[Feature [#14914](https://bugs.ruby-lang.org/issues/14914)\] Add BasicObject#instance\_exec\_with\_block (jeremyevans0)
 
 - Real use case, please
 
-- \[Feature [#14915](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14915&sa=D&source=editors&ust=1686088440625323&usg=AOvVaw3IUznZKoCXnhaemDYlqd-N)\] Deprecate String#crypt, move implementation to string/crypt (jeremyevans0)
+- \[Feature [#14915](https://bugs.ruby-lang.org/issues/14915)\] Deprecate String#crypt, move implementation to string/crypt (jeremyevans0)
 
 - To remove String#crypt, we first need to remove the dependency to String#crypt of WEBrick.  We first listen Eric Wong (WEBrick maintainer)’s opinion.
 - If Eric agrees with the removal in future, we then ask Jeremy to release compatibility-layer gem by 2.6.  If the release is succeeded, we can deprecate the core method.
@@ -211,12 +211,12 @@ End
 
 Carry over:
 
-- \[Bug [#14887](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14887&sa=D&source=editors&ust=1686088440626815&usg=AOvVaw19GUjnurEn896nEOmL_xZ1)\] Array#delete\_if does not use #delete (shyouhei)
+- \[Bug [#14887](https://bugs.ruby-lang.org/issues/14887)\] Array#delete\_if does not use #delete (shyouhei)
 
 - Is it by design, or a bug?
 
-- \[Feature [#13050](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13050&sa=D&source=editors&ust=1686088440627339&usg=AOvVaw24kyKR75DydXkg3DM_qj8O)\] Readline: expose rl\_completion\_quote\_character variable (nobu)
-- \[Feature [#14850](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14850&sa=D&source=editors&ust=1686088440627773&usg=AOvVaw1tPARfvvKksjMiFx3QhcOu)\] Add official API for setting timezone on Time (nobu)
-- \[Feature [#14869](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14869&sa=D&source=editors&ust=1686088440628297&usg=AOvVaw0jLlAriWIl9M31eFcXh1Jz)\] Proposal to add Hash#=== (nobu)
-- \[Feature [#14877](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14877&sa=D&source=editors&ust=1686088440628942&usg=AOvVaw18RULYMfOEUhqdJVnj4FHn)\] Calculate age in Date class (nobu)
-- \[Bug [#14908](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14908&sa=D&source=editors&ust=1686088440629587&usg=AOvVaw3Z-IlBeBnIkMHyFFzXPDyn)\] Enumerator::Lazy creates unnecessary Array objects. (nobu)
+- \[Feature [#13050](https://bugs.ruby-lang.org/issues/13050)\] Readline: expose rl\_completion\_quote\_character variable (nobu)
+- \[Feature [#14850](https://bugs.ruby-lang.org/issues/14850)\] Add official API for setting timezone on Time (nobu)
+- \[Feature [#14869](https://bugs.ruby-lang.org/issues/14869)\] Proposal to add Hash#=== (nobu)
+- \[Feature [#14877](https://bugs.ruby-lang.org/issues/14877)\] Calculate age in Date class (nobu)
+- \[Bug [#14908](https://bugs.ruby-lang.org/issues/14908)\] Enumerator::Lazy creates unnecessary Array objects. (nobu)

--- a/2018/DevMeeting-2018-08-09.md
+++ b/2018/DevMeeting-2018-08-09.md
@@ -101,34 +101,34 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 ## Carry-over from previous meeting(s)
 
-- \[Bug [#14887](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14887&sa=D&source=editors&ust=1686088469374663&usg=AOvVaw3M2UJRENYOOvoFdTuXusxK)\] Array#delete\_if does not use #delete (shyouhei)
+- \[Bug [#14887](https://bugs.ruby-lang.org/issues/14887)\] Array#delete\_if does not use #delete (shyouhei)
 
 - Is it by design, or a bug?
 - Matz: delete is memory inefficient.
 - Mame: if you can override #delete, why not also #delete\_if.
 
-- \[Feature [#13050](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13050&sa=D&source=editors&ust=1686088469375357&usg=AOvVaw3dOUGfY6PwOPZtCbjoibKj)\] Readline: expose rl\_completion\_quote\_character variable (nobu)
+- \[Feature [#13050](https://bugs.ruby-lang.org/issues/13050)\] Readline: expose rl\_completion\_quote\_character variable (nobu)
 
 - Go!!!
 
 ## From Attendees
 
-- \[Feature [#5446](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5446&sa=D&source=editors&ust=1686088469375877&usg=AOvVaw3TL_jeglqXiZSt_zeYl3CQ)\] at\_fork callback API (eregon) Can we get approval for introducing this? It is solving a real-world issue, in a more reliable way than the various hacks in most Ruby servers.
+- \[Feature [#5446](https://bugs.ruby-lang.org/issues/5446)\] at\_fork callback API (eregon) Can we get approval for introducing this? It is solving a real-world issue, in a more reliable way than the various hacks in most Ruby servers.
 
 - Mrkn: I wanted to use this in pycall to call PyOS\_AfterFork\_Child, and so on from C-layer, but I noticed that I can use pthread\_atfork directly.
 - Naruse: Ruby’s fork is unsafe operation. Application programmers should understand the fact and carefully handle related operations (for example freeing resources).
 - Akr: I guess at\_fork hook would be problematic with multi-thread and/or multi-guild.  But making it Ruby’s standard feature impress this feature usable universally including multi-thread/guild. So, I’m negative for this proposal.
 - usa: Furthermore, I consider that fork must be destroyed.
 
-- \[Feature [#11258](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11258&sa=D&source=editors&ust=1686088469376503&usg=AOvVaw0CLfHRg0dcjNc-kJxXxsNC)\] add 'x' mode character for O\_EXCL (kazu)
+- \[Feature [#11258](https://bugs.ruby-lang.org/issues/11258)\] add 'x' mode character for O\_EXCL (kazu)
 
 - Matz accepted already.
 
-- \[Misc [#14907](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14907&sa=D&source=editors&ust=1686088469376827&usg=AOvVaw1jPaIAvKxubASbCGdrrFuB)\] io.c: do not close inherited FDs by default (akr)
+- \[Misc [#14907](https://bugs.ruby-lang.org/issues/14907)\] io.c: do not close inherited FDs by default (akr)
 
 - Nobody is against changing defaults
 
-- \[Feature [#14850](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14850&sa=D&source=editors&ust=1686088469377079&usg=AOvVaw0ZlqJTGTxp5cv1WKQ6j7EW)\] Add official API for setting timezone on Time (nobu)
+- \[Feature [#14850](https://bugs.ruby-lang.org/issues/14850)\] Add official API for setting timezone on Time (nobu)
 
 - Akr: localtime/timelocal analogous variant methods should suffice
 
@@ -137,19 +137,19 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 - Matz: is there any reason we need this?
 - Matz: What is actual API?
 
-- \[Feature [#14869](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14869&sa=D&source=editors&ust=1686088469377532&usg=AOvVaw0cxLfrQYJLMAhPsg3mRt1k)\] Proposal to add Hash#=== (nobu)
+- \[Feature [#14869](https://bugs.ruby-lang.org/issues/14869)\] Proposal to add Hash#=== (nobu)
 
 - After \[Feature #14912\]
 
-- \[Feature [#14877](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14877&sa=D&source=editors&ust=1686088469377859&usg=AOvVaw28An7a5BwJZIfWPIPAKkt3)\] Calculate age in Date class (nobu)
+- \[Feature [#14877](https://bugs.ruby-lang.org/issues/14877)\] Calculate age in Date class (nobu)
 
 - Matz: I don’t like the idea to implicitly use today.
 
-- \[Feature [#14973](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14973&sa=D&source=editors&ust=1686088469378179&usg=AOvVaw3m2R2DozHFNGRPyAVSOAPg)\] Proposal of percent literal to expand Hash (aycabta)
+- \[Feature [#14973](https://bugs.ruby-lang.org/issues/14973)\] Proposal of percent literal to expand Hash (aycabta)
 
 - Matz: percent literal...
 
-- \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686088469378469&usg=AOvVaw098jxAscxKmBPirqVsS4YX)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
+- \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
 
 - Naming.
 
@@ -170,21 +170,21 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 ## From non-attendees
 
-- \[Feature [#14717](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14717&sa=D&source=editors&ust=1686088469380181&usg=AOvVaw2xupBtnBi-kv2Ild511RdF)\] thread: allow disabling preempt (normalperson)
+- \[Feature [#14717](https://bugs.ruby-lang.org/issues/14717)\] thread: allow disabling preempt (normalperson)
 
 - Closed already
 
-- \[Feature [#11076](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11076&sa=D&source=editors&ust=1686088469380456&usg=AOvVaw12VuLJjSEQdMnUbFU-_Tfr)\] Enumerable method count\_by (baweaver)
-    As mentioned in the discussion, Nobu was kind enough to update this to work with current master for Ruby: [https://github.com/ruby/ruby/compare/trunk...nobu:feature/11076-Enumerable%23count\_by](https://www.google.com/url?q=https://github.com/ruby/ruby/compare/trunk...nobu:feature/11076-Enumerable%2523count_by&sa=D&source=editors&ust=1686088469380667&usg=AOvVaw3diAUqgpPhZ98Ds3hNGmKl)
+- \[Feature [#11076](https://bugs.ruby-lang.org/issues/11076)\] Enumerable method count\_by (baweaver)
+    As mentioned in the discussion, Nobu was kind enough to update this to work with current master for Ruby: [https://github.com/ruby/ruby/compare/trunk...nobu:feature/11076-Enumerable%23count\_by](https://github.com/ruby/ruby/compare/trunk...nobu:feature/11076-Enumerable%23count_by)
     As the code is already written I believe it would be an ideal target for 2.6 as a quick win on an often requested feature.
 
 - Matz: I thought #count\_by would be something different.
 - Mame: There is #count. #count\_by is very different from that.
 - K-tsj: Also, #count takes a block.
 - Matz: I’m not against the feature itself.  Also, do we need a block-less counterpart?
-- Naruse: It looks similar to [Presto’s histogram function](https://www.google.com/url?q=https://prestodb.io/docs/current/functions/aggregate.html%23histogram&sa=D&source=editors&ust=1686088469381368&usg=AOvVaw2aj2Sl2-VoiEbmeNZmtYd_)
+- Naruse: It looks similar to [Presto’s histogram function](https://prestodb.io/docs/current/functions/aggregate.html#histogram)
 
-- \[Feature [#14954](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14954&sa=D&source=editors&ust=1686088469381587&usg=AOvVaw0E48la4FeK7k1mDjm9tiBk)\] Add :wait option to RubyVM::MJIT.pause (k0kubun)
+- \[Feature [#14954](https://bugs.ruby-lang.org/issues/14954)\] Add :wait option to RubyVM::MJIT.pause (k0kubun)
 
 - Since it's not released even in preview2 yet, is it okay to change the behavior?
 - Is there any objection for having the option or the option name?
@@ -195,21 +195,21 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 - (baweaver)
 
-- \[Feature [#14869](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14869&sa=D&source=editors&ust=1686088469382267&usg=AOvVaw1y8OJ_sf1_TrU6CKEDXh7N)\] Proposal to add Hash#=== (nobu)
-- \[Feature [#14916](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14916&sa=D&source=editors&ust=1686088469382513&usg=AOvVaw1Lq5DGhYacap3PF_QsF2V7)\] Proposal to add Array#=== (aycabta)
-- \[Feature [#14912](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14912&sa=D&source=editors&ust=1686088469382733&usg=AOvVaw00mFHN1T0L61nH-4eth_3R)\] Introduce pattern matching syntax
-    I believe that these three items are related, and personally I could do a lot of very interesting things with Array#=== and Hash#=== that would get us exceptionally close to features discussed in \[Feature [#14709](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14709&sa=D&source=editors&ust=1686088469382952&usg=AOvVaw2RFpxlfoL9rXVrJ2d8ZnDA)\]
+- \[Feature [#14869](https://bugs.ruby-lang.org/issues/14869)\] Proposal to add Hash#=== (nobu)
+- \[Feature [#14916](https://bugs.ruby-lang.org/issues/14916)\] Proposal to add Array#=== (aycabta)
+- \[Feature [#14912](https://bugs.ruby-lang.org/issues/14912)\] Introduce pattern matching syntax
+    I believe that these three items are related, and personally I could do a lot of very interesting things with Array#=== and Hash#=== that would get us exceptionally close to features discussed in \[Feature [#14709](https://bugs.ruby-lang.org/issues/14709)\]
     This to say I would second the inclusion of the first two items as they relate to the third and fourth. It would give Ruby an exceptional amount of power.
 - Matz: we should discuss these after pattern match is introduced.
 
-- \[Feature [#14759](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14759&sa=D&source=editors&ust=1686088469383201&usg=AOvVaw18Rd-t2wYDduqKY2-MQUmi)\] \[PATCH\] set M\_ARENA\_MAX for glibc malloc (sam.saffron)
+- \[Feature [#14759](https://bugs.ruby-lang.org/issues/14759)\] \[PATCH\] set M\_ARENA\_MAX for glibc malloc (sam.saffron)
     I would also very much like to see it backported 2.4 and 2.5. It is of enormous value to the ecosystem
 
 - Usa: The decision should be made by Linux port maintainer
 - Naruse: up to kosaki.
 - Mame: Once kosaki said “If we merge this, we should decide when we remove this”.
 
-- \[Feature [#14944](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14944&sa=D&source=editors&ust=1686088469383714&usg=AOvVaw2LNTbLsxdZ7Q4cRs8jLxQl)\] Support optional inherit argument for Module#method\_defined? (jeremyevans0)
+- \[Feature [#14944](https://bugs.ruby-lang.org/issues/14944)\] Support optional inherit argument for Module#method\_defined? (jeremyevans0)
 
 - Usa: I want this too.
 - Mame: why?
@@ -224,11 +224,11 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 Carry over:
 
-- \[Bug [#14908](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14908&sa=D&source=editors&ust=1686088469384527&usg=AOvVaw1iiKawMCla0gIK2v6nWthI)\] Enumerator::Lazy creates unnecessary Array objects. (nobu)
-- \[Feature [#14736](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14736&sa=D&source=editors&ust=1686088469384805&usg=AOvVaw3QNlBNf0n1VM3FA2Bys3xj)\] Thread selector for flexible cooperative fiber based concurrency (ioquatix)
-- \[Feature [#14739](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14739&sa=D&source=editors&ust=1686088469385001&usg=AOvVaw3ln2whjaovVre-kZail1hz)\] Improve fiber yield/resume performance (ioquatix)
+- \[Bug [#14908](https://bugs.ruby-lang.org/issues/14908)\] Enumerator::Lazy creates unnecessary Array objects. (nobu)
+- \[Feature [#14736](https://bugs.ruby-lang.org/issues/14736)\] Thread selector for flexible cooperative fiber based concurrency (ioquatix)
+- \[Feature [#14739](https://bugs.ruby-lang.org/issues/14739)\] Improve fiber yield/resume performance (ioquatix)
 
 - Ko1: will discuss them in person
 
-- \[Bug [#14968](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14968&sa=D&source=editors&ust=1686088469385231&usg=AOvVaw0qohc33kwUXvAHWn5KnXSN)\] io.c: make all pipes nonblocking by default (normalperson)
-- \[Misc [#14937](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14937&sa=D&source=editors&ust=1686088469385416&usg=AOvVaw1wZ5GklisTu6_EEZoMphb-)\] timer-thread elimination depends on [Bug #14968](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/normalperson&sa=D&source=editors&ust=1686088469385537&usg=AOvVaw3Efb_1HeQP4bm5VJY5sjXB)
+- \[Bug [#14968](https://bugs.ruby-lang.org/issues/14968)\] io.c: make all pipes nonblocking by default (normalperson)
+- \[Misc [#14937](https://bugs.ruby-lang.org/issues/14937)\] timer-thread elimination depends on [Bug #14968](https://bugs.ruby-lang.org/issues/normalperson)

--- a/2018/DevMeeting-2018-09-13.md
+++ b/2018/DevMeeting-2018-09-13.md
@@ -84,75 +84,75 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From Attendees
 
-- \[Feature [#15022](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15022&sa=D&source=editors&ust=1686088511792331&usg=AOvVaw29H8me8Kh75OE-TrgVQnDP)\] Oneshot coverage
+- \[Feature [#15022](https://bugs.ruby-lang.org/issues/15022)\] Oneshot coverage
 
 - I'd like to introduce a new kind of coverage to record whether each line is executed or not. It provides less but still useful information compared to the traditional line coverage, and the measurement is quite faster.
 - shyouhei: clear is not atomic, isn’t it?
 - mame: oh, yes.  maybe I should add clear: true option to peek\_result.
 - all: let’s go
 
-- \[Feature [#8661](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/8661&sa=D&source=editors&ust=1686088511793102&usg=AOvVaw3xJ0eHPbW_p7za7ro0q_AP)\] Add option to print backtrace in reverse order(stack frames first & error last)
+- \[Feature [#8661](https://bugs.ruby-lang.org/issues/8661)\] Add option to print backtrace in reverse order(stack frames first & error last)
 
 - The current backtrace order is really annoying, and I'm not still used; is there any chance to revert?
 - ???: How about using pager?
 
-- \[Feature [#14609](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14609&sa=D&source=editors&ust=1686088511793570&usg=AOvVaw0FNE9xs2jPyVUYnkhClpX3)\] \`Kernel#p\` without args shows the receiver (ko1)
+- \[Feature [#14609](https://bugs.ruby-lang.org/issues/14609)\] \`Kernel#p\` without args shows the receiver (ko1)
 
 - I feel this feature is very useful and some people say :+1: so let discuss about this feature.
 - everyone except mame/ko1: not good
 - nobu: ruby -ep gets broken
 - nobu: how about Kernel#P ?
-- knu: There’s a gem: [https://github.com/esminc/tapp](https://www.google.com/url?q=https://github.com/esminc/tapp&sa=D&source=editors&ust=1686088511794301&usg=AOvVaw1dH8XHlvSPZLNDPxgWLl4W)
+- knu: There’s a gem: [https://github.com/esminc/tapp](https://github.com/esminc/tapp)
 
-- \[Misc [#14956](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14956&sa=D&source=editors&ust=1686088511794580&usg=AOvVaw3Whk1-UW6YZS-rcNq5qhJx)\] Remove stale branches in svn repository (hsbt)
+- \[Misc [#14956](https://bugs.ruby-lang.org/issues/14956)\] Remove stale branches in svn repository (hsbt)
 
 - go ahead.  not remove, but mv to tag
 
-- \[Feature [#6823](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6823&sa=D&source=editors&ust=1686088511794940&usg=AOvVaw0B5UNSypRPra4EaKnoQPLW)\] Where/how should ruby-mode issues be reported? (kazu)
+- \[Feature [#6823](https://bugs.ruby-lang.org/issues/6823)\] Where/how should ruby-mode issues be reported? (kazu)
 
 - Remove ruby-mode.el from trunk, use emacs’s instead.
 - Other \*.el’s upstream moves to github.
 
-- \[Feature [#14183](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14183&sa=D&source=editors&ust=1686088511795556&usg=AOvVaw19Yx3IlYiV-6ezKHP-k4zG)\] "Real" keyword argument
+- \[Feature [#14183](https://bugs.ruby-lang.org/issues/14183)\] "Real" keyword argument
 
 - I'd like to hear matz's current opinion and other committers' ones.
 
-- \[Feature [#14850](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14850&sa=D&source=editors&ust=1686088511795892&usg=AOvVaw35lRzG4Rx0MPG1aQD93xku)\] Add official API for setting timezone on Time (nobu)
+- \[Feature [#14850](https://bugs.ruby-lang.org/issues/14850)\] Add official API for setting timezone on Time (nobu)
 
 - nobu: a patch posted.
 - akr: it’s not good to use Time object as a container.  But, we can define the official interface as a Struct which has :year, :month, … members.  then, Time objects suit the interface accidentally :)
 
 ## From non-attendees
 
-- \[Feature [#14975](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14975&sa=D&source=editors&ust=1686088511796775&usg=AOvVaw28bA1x6_Afqlku-o__r-LG)\] String#append without changing receiver's encoding (ioquatix)
+- \[Feature [#14975](https://bugs.ruby-lang.org/issues/14975)\] String#append without changing receiver's encoding (ioquatix)
 
 - Can we review this PR? We need to decide functionality (i.e. not changing receivers encoding, rejecting encoding if it's not same, unless receiver is binary).
 - Longer term, we should consider if << and concat should be modified. Changing receiver's encoding seems like a mistake.
 
-- \[Feature [#14739](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14739&sa=D&source=editors&ust=1686088511797337&usg=AOvVaw1NKHSpuzidxHVW_aDnd0rg)\] Improve fiber yield/resume performance (ioquatix)
+- \[Feature [#14739](https://bugs.ruby-lang.org/issues/14739)\] Improve fiber yield/resume performance (ioquatix)
 
 - Can I get commit access and can we agree to merge this change?
 
-- \[Feature [#14888](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14888&sa=D&source=editors&ust=1686088511797663&usg=AOvVaw095A-6pkVRAMOeanull1za)\] Add trace point for eval (and related functions) (ioquatix)
+- \[Feature [#14888](https://bugs.ruby-lang.org/issues/14888)\] Add trace point for eval (and related functions) (ioquatix)
 
 - Can we decide if this is acceptable so I can make PR?
 
-- \[Feature [#14097](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14097&sa=D&source=editors&ust=1686088511797992&usg=AOvVaw3SV7iOGj_k1aLFds97jZBH)\] Add union and difference methods to Array ([ana06 (Ana Maria Martinez Gomez)](https://www.google.com/url?q=https://bugs.ruby-lang.org/users/13437&sa=D&source=editors&ust=1686088511798353&usg=AOvVaw0VXXYVUMHvAYgkfBBlCvwj))
+- \[Feature [#14097](https://bugs.ruby-lang.org/issues/14097)\] Add union and difference methods to Array ([ana06 (Ana Maria Martinez Gomez)](https://bugs.ruby-lang.org/users/13437))
 
 - Addition of two new methods in aim of readability, ease of use, efficiency and consistency. There are already PR for both methods.
-- [matz (Yukihiro Matsumoto)](https://www.google.com/url?q=https://bugs.ruby-lang.org/users/13&sa=D&source=editors&ust=1686088511798677&usg=AOvVaw0CdN4YhomFAnK_jbMkD_oq) told me to add this here ;) After my talk in EuRuKo and the feedback from the standing voting I hope it is clearer and easy to decide if this is wanted
+- [matz (Yukihiro Matsumoto)](https://bugs.ruby-lang.org/users/13) told me to add this here ;) After my talk in EuRuKo and the feedback from the standing voting I hope it is clearer and easy to decide if this is wanted
 
-- \[Bug [#14908](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14908&sa=D&source=editors&ust=1686088511798951&usg=AOvVaw2Ga1IZhRGEKBHHs7a3tR7S)\] Enumerator::Lazy creates unnecessary Array objects
+- \[Bug [#14908](https://bugs.ruby-lang.org/issues/14908)\] Enumerator::Lazy creates unnecessary Array objects
 
 - Proposed solution is to change arity of Enumerator::Yielder#<< to 1 from -1 and use it internally for lazy enum instead of Enumerator::Yielder#yield. Generally, method << is used with only one parameter changing arity to 1 also makes it consistent with other classes (String, Array)
 - Since, proposed solution involves spec changes (Enumerator::Yielder#<<'s arity) a discussion is requested before the provided patch can proceed.
 
-- \[Feature [#13167](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13167&sa=D&source=editors&ust=1686088511799797&usg=AOvVaw1Sdp6eu8bb9sHVfkDUMYaY)\] Dir.glob is 25x slower since Ruby 2.2 (ahorek)
+- \[Feature [#13167](https://bugs.ruby-lang.org/issues/13167)\] Dir.glob is 25x slower since Ruby 2.2 (ahorek)
 
 - improves performance of a glob pattern with braces, especially on windows but also on other platforms
-- the idea was already approved by [matz (Yukihiro Matsumoto)](https://www.google.com/url?q=https://bugs.ruby-lang.org/users/13&sa=D&source=editors&ust=1686088511800205&usg=AOvVaw2tdnEu_r0tNHv165_w9XPG) [#13873](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13873&sa=D&source=editors&ust=1686088511800413&usg=AOvVaw1l44xGci_LrUHHPI8bhtVv) but later revered (incompatibility of the order)
+- the idea was already approved by [matz (Yukihiro Matsumoto)](https://bugs.ruby-lang.org/users/13) [#13873](https://bugs.ruby-lang.org/issues/13873) but later revered (incompatibility of the order)
 - attached patch don't have the same problem
 
-- \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686088511800752&usg=AOvVaw365rBB4RE8IlTmOL0Cf6gM)\] auto-fiber name, is "Thread::Coro" OK? How should Mutex work between coroutines? Queue/SizedQueue works, now (not sure about signal handler).
+- \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] auto-fiber name, is "Thread::Coro" OK? How should Mutex work between coroutines? Queue/SizedQueue works, now (not sure about signal handler).
 
-\[Feature [#5825](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5825&sa=D&source=editors&ust=1686088511801198&usg=AOvVaw0L8rgzPBm_cDzW3a-bP-fC)\] Sweet instance var assignment in the object initializer
+\[Feature [#5825](https://bugs.ruby-lang.org/issues/5825)\] Sweet instance var assignment in the object initializer

--- a/2018/DevMeeting-2018-10-10.md
+++ b/2018/DevMeeting-2018-10-10.md
@@ -104,7 +104,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From Attendees
 
-## \[Feature [#14839](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14839&sa=D&source=editors&ust=1686088679122674&usg=AOvVaw2bQQy5J7FdfrrgTG3UxxMO)\] How to deal with capitalizing Georgian in Unicode 11.0.0 (duerst)
+## \[Feature [#14839](https://bugs.ruby-lang.org/issues/14839)\] How to deal with capitalizing Georgian in Unicode 11.0.0 (duerst)
 
 
 - I need feedback on this to be able to implement in in time for the Ruby 2.6 release.
@@ -112,7 +112,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - usa: What about keep things as is, to make Georgian people aware of the issue
 - duerst: Georgian characters can be detectable so theoretically it’s possible to have complete mapping of characters.
 
-## \[Feature [#15195](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15195&sa=D&source=editors&ust=1686088679123584&usg=AOvVaw1K4og-kfBz0kHzDNaeBvDc)\] How to deal with new Japanese era (duerst)
+## \[Feature [#15195](https://bugs.ruby-lang.org/issues/15195)\] How to deal with new Japanese era (duerst)
 
 
 - We should prepare early (even if it's just to check that we need to do nothing)
@@ -132,7 +132,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - hsbt: Efforts ongoing.
 - (details omitted from the log)
 
-- \[Misc [#14632](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14632&sa=D&source=editors&ust=1686088679125253&usg=AOvVaw2BjIHPqkpZ0sBVCytCaMRN)\] \[ANN\] git.ruby-lang.org (hsbt)
+- \[Misc [#14632](https://bugs.ruby-lang.org/issues/14632)\] \[ANN\] git.ruby-lang.org (hsbt)
 
 - hsbt: I want to switch to git in 20 Oct.
 - usa: what happens?
@@ -141,7 +141,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - mame: Any restriction on git?
 - hsbt: push --force shall be forbidden.
 
-- \[Feature [#14609](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14609&sa=D&source=editors&ust=1686088679126066&usg=AOvVaw2lnNSBGj4AgEvocyumH5NQ)\] \`Kernel#p\` without args shows the receiver (ko1)
+- \[Feature [#14609](https://bugs.ruby-lang.org/issues/14609)\] \`Kernel#p\` without args shows the receiver (ko1)
 
 - It will be useful.
 
@@ -175,7 +175,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From non-attendees
 
-## \[Feature [#15123](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15123&sa=D&source=editors&ust=1686088679128709&usg=AOvVaw2cTGv7ZudKnUpc3XJNQyEP)\] Enumerable#compact proposal (greggzst)
+## \[Feature [#15123](https://bugs.ruby-lang.org/issues/15123)\] Enumerable#compact proposal (greggzst)
 
 
 - It simplifies working with large and small collections so one doesn't have to remember that can't use #compact when enumerator is returned and have to fall back to #reject(:nil?).
@@ -184,12 +184,12 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - mrkn: Returns another enumerator.
 - matz: Use case not very clear to me.
 
-## \[Feature [#15112](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15112&sa=D&source=editors&ust=1686088679129838&usg=AOvVaw3knTOOjSSYwngR-x4IBwz-)\] Introduce the new singleton method STDERR.p (shevegen)
+## \[Feature [#15112](https://bugs.ruby-lang.org/issues/15112)\] Introduce the new singleton method STDERR.p (shevegen)
 
 
 - I am mostly curious what the ruby core team thinks about Kenta Murata's proposal; it probably will not take too much time away discussing it briefly, since the scope is small.
 
-- shyouhei: This one conflicts with [#14609](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14609&sa=D&source=editors&ust=1686088679130477&usg=AOvVaw1ndxk_xT0ZOVkbwtggTqEg)
+- shyouhei: This one conflicts with [#14609](https://bugs.ruby-lang.org/issues/14609)
 - mame: Does it really conflict with that? Does anyone bother inspecting STDERR?
 - taru: Matz wants tapp for the other ticket.
 - duerst: I propose #warn\_p.
@@ -204,7 +204,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - akr: I think STDERR.p is acceptable but IO#p is too short.
 - mame: same feeling.
 
-## \[Feature [#11505](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11505&sa=D&source=editors&ust=1686088679131882&usg=AOvVaw0DJxaVuFWbTMyBIFg3ylDm)\] Module#=== should call #kind\_of? on the object rather than rb\_obj\_is\_kind\_of which only searches the ancestor hierarchy (rafaelfranca)
+## \[Feature [#11505](https://bugs.ruby-lang.org/issues/11505)\] Module#=== should call #kind\_of? on the object rather than rb\_obj\_is\_kind\_of which only searches the ancestor hierarchy (rafaelfranca)
 
 
 - This would allow patterns as Decorator and Proxy to work with case statements.
@@ -250,7 +250,7 @@ when Array
 
 end
 
-## \[Feature [#14912](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14912&sa=D&source=editors&ust=1686088679134393&usg=AOvVaw144dZgFkft9EebgHKGHjsJ)\] Introduce pattern matching syntax (greggzst)
+## \[Feature [#14912](https://bugs.ruby-lang.org/issues/14912)\] Introduce pattern matching syntax (greggzst)
 
 
 - Many modern languages have introduced pattern matching. I used it in scala and found it very easy to utilize and understand especially in recursion. It makes extracting data easier as well.
@@ -258,7 +258,7 @@ end
 - shyouhei: Any updates?
 - mame: We should ask the status for @k-tsj
 
-## \[Feature [#15144](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15144&sa=D&source=editors&ust=1686088679135194&usg=AOvVaw2AnwhuYwKQuW-K-aX_mUEJ)\] Enumerator#chain (zverok)
+## \[Feature [#15144](https://bugs.ruby-lang.org/issues/15144)\] Enumerator#chain (zverok)
 
 
 - knu: Understand the needs. Name?
@@ -274,11 +274,11 @@ end
 - ko1: should be joke for +(...)
 - knu: I’ll be working on this in the forthcoming hackathon held on Oct 20.
 
-## [zverok (Victor Shepelev)](https://www.google.com/url?q=https://bugs.ruby-lang.org/users/710&sa=D&source=editors&ust=1686088679136691&usg=AOvVaw0Ab3wUHbjscl-pwAh5d2tl) wants to hear about stale issues:
+## [zverok (Victor Shepelev)](https://bugs.ruby-lang.org/users/710) wants to hear about stale issues:
 
 ## I am not sure if it is appropriate, but I'd also be very glad to hear about some "stale" discussions. They were typically reacted on developer meetings as "in general, good proposal (but not sure when it would be implemented/not sure about the name)", or something like that, and I'd like to know maybe we should do something to push them further? List of tickets:
 
-## \[Feature [#14799](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14799&sa=D&source=editors&ust=1686088679137240&usg=AOvVaw1BSPXlfNqL-ZwF_1tL8V4b)\] Startless range: usefulness discussed, patch provided by mame (Yusuke Endoh), waits for Matz's decision (?)
+## \[Feature [#14799](https://bugs.ruby-lang.org/issues/14799)\] Startless range: usefulness discussed, patch provided by mame (Yusuke Endoh), waits for Matz's decision (?)
 
 
 - mame: I can have 2.5 without it.
@@ -286,18 +286,18 @@ end
 - mame: What about right after when?
 - matz: Mmm…. That’s difficult.
 
-## \[Feature [#14784](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14784&sa=D&source=editors&ust=1686088679138176&usg=AOvVaw0EQnfP5CGnYujJS11wowWM)\] Comparable#clamp accepting range: comment for akr (Akira Tanaka) about "needlessly big" proposal, I answered it, is it makes the proposal more likely to be accepted?
+## \[Feature [#14784](https://bugs.ruby-lang.org/issues/14784)\] Comparable#clamp accepting range: comment for akr (Akira Tanaka) about "needlessly big" proposal, I answered it, is it makes the proposal more likely to be accepted?
 
 
 - Nobody is against #clamp accepting ranges.  The issue did not seem requesting that, rather it was for one-sided clamp.
 
-## \[Feature [#6284](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6284&sa=D&source=editors&ust=1686088679138785&usg=AOvVaw30xn7FVqiBRSttTaThEcXt)\] Composition for procs: the last thing Matz has said is the operators are chosen (<< and \>>), and "We need more discussion if we would add combination methods to the Symbol class." Is there a chance proc composition would make it way in the 2.6?
+## \[Feature [#6284](https://bugs.ruby-lang.org/issues/6284)\] Composition for procs: the last thing Matz has said is the operators are chosen (<< and \>>), and "We need more discussion if we would add combination methods to the Symbol class." Is there a chance proc composition would make it way in the 2.6?
 
 
-- usa: This has been accepted. (at [https://bugs.ruby-lang.org/issues/6284#note-55](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6284%23note-55&sa=D&source=editors&ust=1686088679139291&usg=AOvVaw3uKEYU9R4IM6vkIsf9ZVKF))
+- usa: This has been accepted. (at [https://bugs.ruby-lang.org/issues/6284#note-55](https://bugs.ruby-lang.org/issues/6284#note-55))
 - ko1: @nobu is assigned.  Waiting for him to implement.
 
-## \[Feature [#13581](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13581&sa=D&source=editors&ust=1686088679139760&usg=AOvVaw3NViQCG-e7amXwSzn_h54b)\] Syntax sugar for method reference. The last thing Matz have said is: ".: looks best to me (followed by :::). Let me consider it for a while." Are there any choices made? Could we expect this for 2.6?
+## \[Feature [#13581](https://bugs.ruby-lang.org/issues/13581)\] Syntax sugar for method reference. The last thing Matz have said is: ".: looks best to me (followed by :::). Let me consider it for a while." Are there any choices made? Could we expect this for 2.6?
 
 
 - matz: Honestly I still don’t find the right name.
@@ -308,14 +308,14 @@ end
 - ko1: It might matter you, but not for the OP.
 - shyouhei: Maybe.
 
-## \[Feature [#14781](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14781&sa=D&source=editors&ust=1686088679140744&usg=AOvVaw3CDIYP3AMZiqrMegQgYH80)\] Enumerator#generate It seems like people feel cautious enthusiasm about it, but not sure about the name. What should be done here? Voting on the name? Providing the patch with some name, and then voting for the name?
+## \[Feature [#14781](https://bugs.ruby-lang.org/issues/14781)\] Enumerator#generate It seems like people feel cautious enthusiasm about it, but not sure about the name. What should be done here? Voting on the name? Providing the patch with some name, and then voting for the name?
 
 
 - Everybody is against #generate.
 - duerst: We don’t vote. Or in other words, we have only one person who votes. That’s Matz. Everybody else is very welcome to provide ideas, opinions,...
 - knu: There are many kinds of use cases mixed in one proposal, which need to be sorted out.  How many previous elements to look back, how to define an end of a sequence, etc.          I’ll come up with an alternative concrete API proposal.
 
-- \[Feature [#12490](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12490&sa=D&source=editors&ust=1686088679141505&usg=AOvVaw1KjyxvKVFdUIRkZVRwqS9M)\] Remove warning on shadowing block params
+- \[Feature [#12490](https://bugs.ruby-lang.org/issues/12490)\] Remove warning on shadowing block params
 
 - mame: It was introduced when backward incompatibility was involved, but it is no longer a problem, so why not remove it?
 - knu: It’s painful when you have to change this just to silence the warning: user = users.find { |user| … }

--- a/2018/DevMeeting-2018-11-22.md
+++ b/2018/DevMeeting-2018-11-22.md
@@ -125,7 +125,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 - OK but 12/12 is 13:30-.
 
-## \[Feature [#15144](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15144&sa=D&source=editors&ust=1686088712085884&usg=AOvVaw224TkP6VNsxLlh6RTQcaae)\] Enumerator#chain (zverok)
+## \[Feature [#15144](https://bugs.ruby-lang.org/issues/15144)\] Enumerator#chain (zverok)
 
 
 - A.k.a. Enumerator#+
@@ -135,10 +135,10 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Matz: why not Enumerable#chain ?
 - Knu: definitely agreed!
 
-## \[[Bug #14127](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14127&sa=D&source=editors&ust=1686088712086925&usg=AOvVaw2Z35sH67fhIcvo-nrSZt2y)\] generating UTF-16LE encoded file without BOM (nobu)
+## \[[Bug #14127](https://bugs.ruby-lang.org/issues/14127)\] generating UTF-16LE encoded file without BOM (nobu)
 
 
-- Although this is not a bug of csv.rb, I'd suggest to enable "bom|" flag when writing instead. [https://github.com/nobu/ruby/tree/bug/14127-bom-header](https://www.google.com/url?q=https://github.com/nobu/ruby/tree/bug/14127-bom-header&sa=D&source=editors&ust=1686088712087403&usg=AOvVaw07eDDCfswI7U6fwA0R3jBj)
+- Although this is not a bug of csv.rb, I'd suggest to enable "bom|" flag when writing instead. [https://github.com/nobu/ruby/tree/bug/14127-bom-header](https://github.com/nobu/ruby/tree/bug/14127-bom-header)
 
 - Usa: can this be made for “r+” and / or “a”?
 - Nobu: the proposed patch writes bom only when the pos is zero.
@@ -147,7 +147,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Knu: We need a concrete specification first as to when a BOM is written.
 - Ko1: file a new ticket for this.
 
-## \[Feature [#15230](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15230&sa=D&source=editors&ust=1686088712088348&usg=AOvVaw3deEsz-Hf8yfQK_tb_PV3_)\] RubyVM.resolve\_feature\_path (mame)
+## \[Feature [#15230](https://bugs.ruby-lang.org/issues/15230)\] RubyVM.resolve\_feature\_path (mame)
 
 
 - I'd like this feature to investigate what will be loaded by require(feature).
@@ -159,7 +159,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Usa: I think it’s a good feature in general; the proposal seems like a rough cut though.
 - Matz: I have no strong objection.
 
-## \[Feature [#15231](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15231&sa=D&source=editors&ust=1686088712089554&usg=AOvVaw3_0vwrX-wvbeDBvo8epvhX)\] Remove Object#=~ (mame)
+## \[Feature [#15231](https://bugs.ruby-lang.org/issues/15231)\] Remove Object#=~ (mame)
 
 
 - The method looks useless, and made a trouble at least for me. I'd like to hear opinions from other committers.
@@ -172,14 +172,14 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Knu: people might have their own =~, so deleting !~ affect them.
 - Akira: it seems sequel defines =~ and not for !~
 
-## \[Feature [#11689](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11689&sa=D&source=editors&ust=1686088712090731&usg=AOvVaw1QbOo0e_-o7CbtOKGiGO_b)\] Add methods allow us to get visibility from Method and UnboundMethod object. (yui-knk)
+## \[Feature [#11689](https://bugs.ruby-lang.org/issues/11689)\] Add methods allow us to get visibility from Method and UnboundMethod object. (yui-knk)
 
 
 - I want to introduce this feature to help meta programming. I'd like to hear opinions from other committers.
 
 - Matz: the concept is not if a method is “visible” or not, but if a method is “callable” or not.  So I feel a bit NG to call it visibility.
 
-## \[Feature [#15286](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15286&sa=D&source=editors&ust=1686088712091500&usg=AOvVaw1TAEJbmyxvEayuVDw3aTvF)\] Proposal: Add Kernel.#expand(\*args) (aycabta)
+## \[Feature [#15286](https://bugs.ruby-lang.org/issues/15286)\] Proposal: Add Kernel.#expand(\*args) (aycabta)
 
 
 - Matz: I don’t like the name.
@@ -190,19 +190,19 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Mrkn: { a: a } is much shorter than binding.expand(a) …
 - Naruse: tell us a more realistic use-case.
 
-## \[Bug [#15285](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15285&sa=D&source=editors&ust=1686088712092361&usg=AOvVaw24KvmZ8QvBPdvTjFxTY_pR)\] lambda return behavior regression from [#14639](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14639&sa=D&source=editors&ust=1686088712092576&usg=AOvVaw33j50fJzH80cNRKsmeVlf5) (nobu)
+## \[Bug [#15285](https://bugs.ruby-lang.org/issues/15285)\] lambda return behavior regression from [#14639](https://bugs.ruby-lang.org/issues/14639) (nobu)
 
-## \[Feature [#15289](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15289&sa=D&source=editors&ust=1686088712092980&usg=AOvVaw0unzlueUD80UBrUMffkaf5)\] Accept "target" keyword on TracePoint#enable (ko1)
+## \[Feature [#15289](https://bugs.ruby-lang.org/issues/15289)\] Accept "target" keyword on TracePoint#enable (ko1)
 
 
 - Matz: OK, do it yourself.
 
-## \[Feature [#15287](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15287&sa=D&source=editors&ust=1686088712093478&usg=AOvVaw2QaM8Jxu1jN7Vj2dhgdT5w)\] New TracePoint events to support loading features (ko1)
+## \[Feature [#15287](https://bugs.ruby-lang.org/issues/15287)\] New TracePoint events to support loading features (ko1)
 
 
 - Matz: Ok except naming “loaded”. Koichi should name good name.
 
-## \[Bug [#6087](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6087&sa=D&source=editors&ust=1686088712093961&usg=AOvVaw0Zl5DkaYXuC2iRWWZJONkJ)\] How should inherited methods deal with return values of their own subclass? (mame)
+## \[Bug [#6087](https://bugs.ruby-lang.org/issues/6087)\] How should inherited methods deal with return values of their own subclass? (mame)
 
 
 - 6 years ago, matz decided that class A < Array; end; A.new.flatten.class #=> A in 2.X, Array in 3.0. Just confirm: has the decision been still unchanged?
@@ -212,7 +212,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Nobu: Methods defined by Enumerable all return an array.
 - Knu: Making all Array methods return an Array object would make it harder to define your own array-like container by subclassing Array.
 
-## \[Feature [#15317](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15317&sa=D&source=editors&ust=1686088712094822&usg=AOvVaw0BWiht9rsVqDDWwtE_dkZ5)\] How to deal with obsolete property values in Unicode 11.0.0 (duerst)
+## \[Feature [#15317](https://bugs.ruby-lang.org/issues/15317)\] How to deal with obsolete property values in Unicode 11.0.0 (duerst)
 
 
 - A clear idea on this is needed to upgrade to Unicode 11.0.0.
@@ -221,30 +221,30 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Naruse: program error is preferred here because we can be aware of such breakage before actually deploying the code.
 - Mame: what about issuing a warning instead?
 
-## \[Feature [#13890](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13890&sa=D&source=editors&ust=1686088712095732&usg=AOvVaw03cQlKTH78s-fYWBUNZdV2)\] Allow a regexp as an argument to 'count', to count more interesting things than single characters (duerst)
+## \[Feature [#13890](https://bugs.ruby-lang.org/issues/13890)\] Allow a regexp as an argument to 'count', to count more interesting things than single characters (duerst)
 
 
 - I find this missing regularly, and writing it by hand in Ruby is clumsy, so addition would be valuable.
 
 
-## \[Feature [#12698](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/12698&sa=D&source=editors&ust=1686088712096354&usg=AOvVaw0ErVMZ3NLQBNWZMFHyq0tF)\] Method to delete a substring by regex match (duerst)
+## \[Feature [#12698](https://bugs.ruby-lang.org/issues/12698)\] Method to delete a substring by regex match (duerst)
 
 
 ## From non-attendees
 
-## \[Feature [#15220](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15220&sa=D&source=editors&ust=1686088712096857&usg=AOvVaw3orANVpeO1wzaiWnTRYl5P)\] Adding OpenSSL 1.1.1 on Travis CI gcc-8 case (jaruga)
+## \[Feature [#15220](https://bugs.ruby-lang.org/issues/15220)\] Adding OpenSSL 1.1.1 on Travis CI gcc-8 case (jaruga)
 
 
 - To detect an issue for the latest OpenSSL early and guarantee a Ruby version supporting a OpenSSL version.
 
 - Shyouhei: I had already added one.
 
-## \[Feature [#15301](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15301&sa=D&source=editors&ust=1686088712097438&usg=AOvVaw08rZdhyo_hoxgXp0lUAcmI)\] Symbol#call, returning method bound with arguments (zverok)
+## \[Feature [#15301](https://bugs.ruby-lang.org/issues/15301)\] Symbol#call, returning method bound with arguments (zverok)
 
 
 - Matz: I’m very faintly against it.
 
-## \[Feature [#15302](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15302&sa=D&source=editors&ust=1686088712097954&usg=AOvVaw37vDYz8udDMp2y5h2bPMyY)\] Proc#with and Proc#by, for partial function application and currying (Ritchie Buitre)
+## \[Feature [#15302](https://bugs.ruby-lang.org/issues/15302)\] Proc#with and Proc#by, for partial function application and currying (Ritchie Buitre)
 
 
 - Convenient methods for functional programming.
@@ -254,7 +254,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Ko1: Is the naming only concern?
 - Matz: Not against the feature but I feel the notation is not right.
 
-## \[Bug [#14968](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14968&sa=D&source=editors&ust=1686088712099037&usg=AOvVaw1kbmTiRYvunskq26MzAlrW)\] make all pipes and sockets non-blocking by default (normalperson)
+## \[Bug [#14968](https://bugs.ruby-lang.org/issues/14968)\] make all pipes and sockets non-blocking by default (normalperson)
 
 
 - Shyouhei: AFAIK there is a problem on Windows.
@@ -269,12 +269,12 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Matz: maybe we should try it and fix or back out as necessary?
 - Naruse: so Eric should commit it today.
 
-## \[Feature [#13618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13618&sa=D&source=editors&ust=1686088712100090&usg=AOvVaw2Yz0V2EUrQG2cH57pWgdm3)\] Thread::Light for 2.6 [ruby-core:89900](https://www.google.com/url?q=http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/89900&sa=D&source=editors&ust=1686088712100336&usg=AOvVaw2E2xLnXfEImCceXhiNoWCQ)
+## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] Thread::Light for 2.6 [ruby-core:89900](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/89900)
 
 
 - Matz: will respond.
 
-## \[Feature [#10548](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10548&sa=D&source=editors&ust=1686088712100796&usg=AOvVaw0zEsCysogJ_umPhZc6Zb2g)\] remove callcc (Callcc is now going obsolete. Please use Fiber.) (ioquatix)
+## \[Feature [#10548](https://bugs.ruby-lang.org/issues/10548)\] remove callcc (Callcc is now going obsolete. Please use Fiber.) (ioquatix)
 
 
 - It's unofficially deprecated, unsupported in most implementations of Ruby, and not used very much. Do you think it's a good idea to drop support by 3.0?
@@ -285,7 +285,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Usa: for 3x3?
 - Matz: may not make it 3x faster.
 
-## \[Feature [#15327](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15327&sa=D&source=editors&ust=1686088712101815&usg=AOvVaw0DyqtlUC70v-eY9yFbFhNa)\] Proposal: Enable refinements to #respond\_to? (osyo)
+## \[Feature [#15327](https://bugs.ruby-lang.org/issues/15327)\] Proposal: Enable refinements to #respond\_to? (osyo)
 
 
 - Matz: Mmm.
@@ -300,12 +300,12 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - (everybody started thinking...)
 - Ko1: OK, let’s not think about it for a while.
 
-## \[Feature [#15326](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15326&sa=D&source=editors&ust=1686088712103265&usg=AOvVaw3AC8Vwzk343AgoNcmaXwTZ)\] Proposal: Enable refinements to #public\_send (osyo)
+## \[Feature [#15326](https://bugs.ruby-lang.org/issues/15326)\] Proposal: Enable refinements to #public\_send (osyo)
 
 
 - Matz: this one makes sense. Accepted.
 
-## \[Feature [#15114](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15114&sa=D&source=editors&ust=1686088712103966&usg=AOvVaw1MAJ1l4hfeQN7N5jetOuxt)\] Symbol#to\_proc does not work with refinements? (osyo)
+## \[Feature [#15114](https://bugs.ruby-lang.org/issues/15114)\] Symbol#to\_proc does not work with refinements? (osyo)
 
 
 - I want to more refinements!
@@ -313,7 +313,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Matz: sounds like a bug?
 - assign nobu
 
-## \[Feature [#15330](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15330&sa=D&source=editors&ust=1686088712104834&usg=AOvVaw2Cjz0EDUw_mngr-bISmGIQ)\] Proposal: autoload\_relative (marcandre)
+## \[Feature [#15330](https://bugs.ruby-lang.org/issues/15330)\] Proposal: autoload\_relative (marcandre)
 
 
 - This feature is actually more useful than autoload and should be added to 2.6

--- a/2018/DevMeeting-2018-12-12.md
+++ b/2018/DevMeeting-2018-12-12.md
@@ -89,7 +89,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From Attendees
 
-- \[Bug [#15303](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15303&sa=D&source=editors&ust=1686088731142125&usg=AOvVaw1iqd3uPHMKk2hSUbAZzjhE)\] Return tracepoint doesn't fire when tailcall optimization is applied (ko1)
+- \[Bug [#15303](https://bugs.ruby-lang.org/issues/15303)\] Return tracepoint doesn't fire when tailcall optimization is applied (ko1)
 
 - tailcall skips return event and it breaks a debugger's logic. there are several ideas, and we need to introduce a solution for ruby 2.6.
 
@@ -101,7 +101,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 - \-> (4)
 
-- \[Feature [#15287](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15287&sa=D&source=editors&ust=1686088731143209&usg=AOvVaw2yKD0c2aJfmiNYhqn6_Swk)\] New TracePoint events to support loading features (ko1)
+- \[Feature [#15287](https://bugs.ruby-lang.org/issues/15287)\] New TracePoint events to support loading features (ko1)
 
 - Ruby 2.6
 - I already introduced script\_compiled TracePoint event. We need to decide related methods.
@@ -135,40 +135,40 @@ foo("str" => 1, :sym => 2)
 
 ## Non-attendees
 
-- \[Feature [#15230](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15230&sa=D&source=editors&ust=1686088731144762&usg=AOvVaw1Gj69cD5cUEJtSgRpFeA_0)\] RubyVM.resolve\_feature\_path
+- \[Feature [#15230](https://bugs.ruby-lang.org/issues/15230)\] RubyVM.resolve\_feature\_path
 
 - 2.6 issue
 - Mame: no fix on 2.6. Consider on next version.
 
-- \[Feature [#13581](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13581&sa=D&source=editors&ust=1686088731145224&usg=AOvVaw1xJ2P1SPYo3gC5_Q9fdGQH)\] Syntax sugar for method reference
+- \[Feature [#13581](https://bugs.ruby-lang.org/issues/13581)\] Syntax sugar for method reference
 
 - 2.7 or later
 - knu: Introducing “…” (as in Lua) would allow for writing this way: ary.each { puts(...) }
 - Matz: Allowing omission of “self” sounds like a bad idea because that makes each(&:puts) and each(&.:puts) look very similar but act so differently.
 
-- \[Feature [#10771](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10771&sa=D&source=editors&ust=1686088731145604&usg=AOvVaw1RC0WrbLZw0AMZUE-CETKi)\] An easy way to get the source location of a constant
+- \[Feature [#10771](https://bugs.ruby-lang.org/issues/10771)\] An easy way to get the source location of a constant
 
 - 2.7 or later
 - Matz: OK, but wait for 2.7.
 
-- \[Feature [#15373](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15373&sa=D&source=editors&ust=1686088731145955&usg=AOvVaw2cemKGgYAaQib3fzPUc94n)\] Proposal: Enable refinements to #method and #instance\_method
+- \[Feature [#15373](https://bugs.ruby-lang.org/issues/15373)\] Proposal: Enable refinements to #method and #instance\_method
 
 - 2.7 or later
 - Matz: ok to introduce.
 
-- \[Feature [#15374](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15374&sa=D&source=editors&ust=1686088731146348&usg=AOvVaw2o3OR3S-JvoWs6gRMVwVaN)\] Proposal: Enable refinements to #method\_missing
+- \[Feature [#15374](https://bugs.ruby-lang.org/issues/15374)\] Proposal: Enable refinements to #method\_missing
 
 - 2.7 or later
 - Matz: let me think about it for a while.
 
-- \[Feature [#15007](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15007&sa=D&source=editors&ust=1686088731146669&usg=AOvVaw0MAOl5BllYr4oRdPC3wcBm)\] Proposal: Introduce support for cold function attributes (clang and GCC)
+- \[Feature [#15007](https://bugs.ruby-lang.org/issues/15007)\] Proposal: Introduce support for cold function attributes (clang and GCC)
 
-- reduced scope PR [https://github.com/ruby/ruby/pull/2005](https://www.google.com/url?q=https://github.com/ruby/ruby/pull/2005&sa=D&source=editors&ust=1686088731146971&usg=AOvVaw3aGQ6tKxo8okG4zsxBnrj3) (rb\_memerror, rb\_bug, rb\_warn)
+- reduced scope PR [https://github.com/ruby/ruby/pull/2005](https://github.com/ruby/ruby/pull/2005) (rb\_memerror, rb\_bug, rb\_warn)
 - Already  merged.
 
-- \[Bug [#15394](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15394&sa=D&source=editors&ust=1686088731147392&usg=AOvVaw2zuHHR0ZWkbh--6exHtCb6)\] Ruby adds unexpected HTTP header value when using symbol key
+- \[Bug [#15394](https://bugs.ruby-lang.org/issues/15394)\] Ruby adds unexpected HTTP header value when using symbol key
 
 - This is a small change I think, but could make codes less buggy
 - Already solved.
 
-- \[Feature [#15066](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15066&sa=D&source=editors&ust=1686088731147732&usg=AOvVaw2DrL4s0MzOzcVxkBXDAlVc)\] Documentation and providing better API for accessing Complex numbers functions in C extensions
+- \[Feature [#15066](https://bugs.ruby-lang.org/issues/15066)\] Documentation and providing better API for accessing Complex numbers functions in C extensions

--- a/2019/DevMeeting-2019-01-10.md
+++ b/2019/DevMeeting-2019-01-10.md
@@ -80,7 +80,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From Attendees
 
-- \[Feature [#6012](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6012&sa=D&source=editors&ust=1686088754535579&usg=AOvVaw0DYkadb4v_GKRStjMtRup4)\] Proc#source\_location (ko1)
+- \[Feature [#6012](https://bugs.ruby-lang.org/issues/6012)\] Proc#source\_location (ko1)
 
 - nobu: this breaks compatibility
 - ko1: how about specifying the new behaviour by some optional parameter?
@@ -91,7 +91,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - usa: if you really concern to keep compatibility, you should propose this feature as new method.
 - shyouhei: this feature seems not yet mature.
 
-- Frozen string literal \[Feature [#11473](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11473&sa=D&source=editors&ust=1686088754536407&usg=AOvVaw13Tnt10FAIXkkJxjodRIIB)\]
+- Frozen string literal \[Feature [#11473](https://bugs.ruby-lang.org/issues/11473)\]
 
 - Matz: give up on Ruby 3.0. Maybe far future.
 - Matz: Maybe we should provide our coding style to recommend style and obsolete bad style by something like rubocop.
@@ -119,72 +119,72 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Akr: “lambda without block” has been already warned since 2003 (ruby-1.8.0), How about changing it to an exception?
 - Matz: accepted.
 
-- \[Bug [#15404](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15404&sa=D&source=editors&ust=1686088754538170&usg=AOvVaw31ZO5mhdUmNMEYKto2oUCg)\] Endless range has inconsistent chaining behaviour (mame)
+- \[Bug [#15404](https://bugs.ruby-lang.org/issues/15404)\] Endless range has inconsistent chaining behaviour (mame)
 
 - Can we prohibit (1.. ..1) and (1..1)..1 as a SyntaxError?
 - matz: ok, prohibit
 - usa: please add test cases into test\_syntax.rb
 
-- \[Feature [#14799](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14799&sa=D&source=editors&ust=1686088754539462&usg=AOvVaw0toGN0MO7D6UC8ye2TDGmX)\] Startless range (aycabta)
+- \[Feature [#14799](https://bugs.ruby-lang.org/issues/14799)\] Startless range (aycabta)
 
 - Matz: try it.
 
-- \[Bug [#15460](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15460&sa=D&source=editors&ust=1686088754540122&usg=AOvVaw2f-5lxGDUfxHTJhp48qRuq)\] Behaviour of String#setbyte changed (shyouhei)
+- \[Bug [#15460](https://bugs.ruby-lang.org/issues/15460)\] Behaviour of String#setbyte changed (shyouhei)
 
 - What is the expected / desired way to fix this?
 
-- \[Bug [#7300](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7300&sa=D&source=editors&ust=1686088754540937&usg=AOvVaw008CVVKmO4MCizb1pQkSuD)\] Hash#\[\] の挙動が 1.9.3 と異なっている (mame)
+- \[Bug [#7300](https://bugs.ruby-lang.org/issues/7300)\] Hash#\[\] の挙動が 1.9.3 と異なっている (mame)
 
 - I think we can remove the compatibility layer for 1.9: Hash\[\[nil\]\] #=> {}
 
-- \[Misc [#15347](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15347&sa=D&source=editors&ust=1686088754541910&usg=AOvVaw1_-d4yiUVBUs42ZGifTBVb)\] Require C99 (k0kubun)
-- \[Feature [#15445](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15445&sa=D&source=editors&ust=1686088754542438&usg=AOvVaw3ANVV15DdxHMRwx7244F8Z)\] Reject '.123' in Float() method (mrkn)
+- \[Misc [#15347](https://bugs.ruby-lang.org/issues/15347)\] Require C99 (k0kubun)
+- \[Feature [#15445](https://bugs.ruby-lang.org/issues/15445)\] Reject '.123' in Float() method (mrkn)
 
 - Matz: I’d like to keep the behavior.  Rather, I’d like to allow “123.” too.
 
-- \[Bug [#15500](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15500&sa=D&source=editors&ust=1686088754542957&usg=AOvVaw0l7YusQW9g5Jj143F7ekuZ)\] Behavior of require method in 2.5 is different from 2.4 and 2.6 (mrkn)
+- \[Bug [#15500](https://bugs.ruby-lang.org/issues/15500)\] Behavior of require method in 2.5 is different from 2.4 and 2.6 (mrkn)
 
 - usa: It seems bug.  let’s ask hsbt-san
 
-- \[Feature [#15477](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15477&sa=D&source=editors&ust=1686088754543353&usg=AOvVaw2C7UzRKIlWWh_kh4OW4RRJ)\] Proc#arity returns -1 for composed lambda Procs of known arguments
+- \[Feature [#15477](https://bugs.ruby-lang.org/issues/15477)\] Proc#arity returns -1 for composed lambda Procs of known arguments
 
 - matz: ok
 
 ## Non-attendees
 
-- \[Feature [#14444](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14444&sa=D&source=editors&ust=1686088754543852&usg=AOvVaw3zLzc-nVcGyzgijBoljC-E)\] MatchData: alias for #\[\]
+- \[Feature [#14444](https://bugs.ruby-lang.org/issues/14444)\] MatchData: alias for #\[\]
 
 - Naruse: \`next\_page = response.dig('meta', 'pagination', 'next')&.slice(/&page=(\\d+)/, 1)\` is better
 
-- \[Feature [#14784](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14784&sa=D&source=editors&ust=1686088754544311&usg=AOvVaw3xlp7zd6QPlTPCpmMKKOmg)\] Comparable#clamp with a range
+- \[Feature [#14784](https://bugs.ruby-lang.org/issues/14784)\] Comparable#clamp with a range
 
 - usa: the reporter seems have no interest about startless/endless clamp.  But we recognize that we can’t approve range as parameter before accepting startless/endless clamp.
 - akr: we have to consider many corner cases if accepting Range.  Request for feedback.
 
-- \[Feature [#14145](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14145&sa=D&source=editors&ust=1686088754544742&usg=AOvVaw14g3ejganKFa9wtMpKUd9C)\] Better Method#inspect
+- \[Feature [#14145](https://bugs.ruby-lang.org/issues/14145)\] Better Method#inspect
 
 - usa: a patch is welcome.  We might need to discuss the implementation detail, though.
 - Matz: the proposal is accepted
 - Naruse: just an idea, ArgumentError which is raised by arity check should also show such signature.
 
-- \[Bug [#15428](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15428&sa=D&source=editors&ust=1686088754545283&usg=AOvVaw11AVNqySAxQODodVBWSg0L)\] Refactor Proc#>> and #<< (it regards the same problem as [#15483](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15483&sa=D&source=editors&ust=1686088754545740&usg=AOvVaw03KfHz_lopng9KsWiI68A5) above, but approaches it from a different point of view)
+- \[Bug [#15428](https://bugs.ruby-lang.org/issues/15428)\] Refactor Proc#>> and #<< (it regards the same problem as [#15483](https://bugs.ruby-lang.org/issues/15483) above, but approaches it from a different point of view)
 
 - Mame: Use a block.  You then want syntactic sugar for passing an argument, and then for partial application, blah blah blah.
 - knu: We should not add fancy new features around procs and symbols if the real problem is that block syntax is not good enough, like \`|x|\` is always necessary. (See above for the default block parameter syntax)
 - Matz: raise an error when the argument does not respond to :call
 
-- \[Misc [#15486](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15486&sa=D&source=editors&ust=1686088754546262&usg=AOvVaw3tFjfB46g2upHRhrvQ9202)\] Default gems README.md
+- \[Misc [#15486](https://bugs.ruby-lang.org/issues/15486)\] Default gems README.md
 
-- \[Misc [#15487](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15487&sa=D&source=editors&ust=1686088754546571&usg=AOvVaw2L3FVRq0lFMXE5icARUxhB)\] Clarify default gems maintenance policy
-- \[Feature [#15373](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15373&sa=D&source=editors&ust=1686088754546991&usg=AOvVaw1fpWn1tbOlszpd0Y1oQ3T3)\] Proposal: Enable refinements to #method and #instance\_method
+- \[Misc [#15487](https://bugs.ruby-lang.org/issues/15487)\] Clarify default gems maintenance policy
+- \[Feature [#15373](https://bugs.ruby-lang.org/issues/15373)\] Proposal: Enable refinements to #method and #instance\_method
 
 - matz: go ahead
 
-- \[Feature [#15374](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15374&sa=D&source=editors&ust=1686088754547871&usg=AOvVaw0TUenSfP3cWZOgmxxhKk0l)\] Proposal: Enable refinements to #method\_missing
+- \[Feature [#15374](https://bugs.ruby-lang.org/issues/15374)\] Proposal: Enable refinements to #method\_missing
 
 - matz: wait a month
 
-- \[Bug [#15416](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15416&sa=D&source=editors&ust=1686088754548505&usg=AOvVaw1-dJuOnDnBuBFzmRNI6bsy)\] 配列リテラル内の引数を伴う括弧なしのメソッド呼び出しで syntax error
+- \[Bug [#15416](https://bugs.ruby-lang.org/issues/15416)\] 配列リテラル内の引数を伴う括弧なしのメソッド呼び出しで syntax error
 
 - History:
 
@@ -198,21 +198,21 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - f.(Math.sqrt 2)
 - f\[Math.sqrt 2\]
 
-- \[Bug [#2250](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/2250&sa=D&source=editors&ust=1686088754549639&usg=AOvVaw00u1-6Bl-BN-B9niL6ZPnw)\] IO::for\_fd() objects' finalization dangerously closes underlying fds (eregon)
+- \[Bug [#2250](https://bugs.ruby-lang.org/issues/2250)\] IO::for\_fd() objects' finalization dangerously closes underlying fds (eregon)
 
 - The current behavior is dangerous and has caused many spurious test/spec failures which are hard to find and debug. I plan to submit a patch, but I'd like opinions regarding compatibility.
 
-- \[Bug [#15488](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15488&sa=D&source=editors&ust=1686088754550232&usg=AOvVaw0bVnY7a6j1_E0PYROhUWJJ)\] const\_defined?("File::NULL") の挙動
+- \[Bug [#15488](https://bugs.ruby-lang.org/issues/15488)\] const\_defined?("File::NULL") の挙動
 
 - What is the expected behavior?
 - matz: ok, try to return “true” in this case. if we find something wrong, will give up.
 
-- \[Feature [#15456](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15456&sa=D&source=editors&ust=1686088754550683&usg=AOvVaw1rbi1FBPNq7p8bIgg-spcX)\] Adopt some kind of consistent versioning mechanism
+- \[Feature [#15456](https://bugs.ruby-lang.org/issues/15456)\] Adopt some kind of consistent versioning mechanism
 
 - More uniformity within the ecosystem would be nice.
 - Naruse replied it.
 
-- \[Feature [#11473](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11473&sa=D&source=editors&ust=1686088754551064&usg=AOvVaw3nQ0Xt3ZYROzd1Qo0APNpk)\] Immutable String literal in Ruby 3
+- \[Feature [#11473](https://bugs.ruby-lang.org/issues/11473)\] Immutable String literal in Ruby 3
 
 - Mame: As I recall, matz said that this has been cancelled at the old developers' meeting. I'd like to confirm.
 

--- a/2019/DevMeeting-2019-02-07.md
+++ b/2019/DevMeeting-2019-02-07.md
@@ -75,7 +75,7 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 
 ## Next dev-meeting
 
-- 3/11 (Mon) 13:00~17:00 @MoneyForward (Minato-ku) [https://ruby.connpass.com/event/120056/](https://www.google.com/url?q=https://ruby.connpass.com/event/120056/&sa=D&source=editors&ust=1686088785981892&usg=AOvVaw0T7mN0poF3uTgIIWcm55Yl)
+- 3/11 (Mon) 13:00~17:00 @MoneyForward (Minato-ku) [https://ruby.connpass.com/event/120056/](https://ruby.connpass.com/event/120056/)
 - 4/17 (Wed) 12:00~ @ Fukuoka (before RubyKaigi)
 
 ## About 2.7 timeframe
@@ -96,40 +96,40 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 
 ## Non-attendees
 
-- \[Feature [#6470](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/6470&sa=D&source=editors&ust=1686088785983493&usg=AOvVaw1PdMl13KoY_EDVRagTkDDC)\] Make attr\_accessor return the list of generated method (eregon)
+- \[Feature [#6470](https://bugs.ruby-lang.org/issues/6470)\] Make attr\_accessor return the list of generated method (eregon)
 
 - What’s volatile?  No one understand.
 - Matz: if volatile is needed, it would be better to define volatile\_attr\_reader etc.
 
-- \[Bug [#14353](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14353&sa=D&source=editors&ust=1686088785983920&usg=AOvVaw1wZ0AoegBq2upgDAxadJtQ)\] $SAFE should stay at least thread-local for compatibility (eregon)
+- \[Bug [#14353](https://bugs.ruby-lang.org/issues/14353)\] $SAFE should stay at least thread-local for compatibility (eregon)
 
 - I would like matz's opinion on this. It seems the compatibility risks and debugging problems is not worth making $SAFE global, unless there is a good reason to be global? Should there still be $SAFE checks at all, for e.g., tainted Strings?
 - Naruse: $SAFE should be removed
 - Matz: Make $SAFE no effect in 2.7 or 3.0
 
-- \[Feature [#5653](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5653&sa=D&source=editors&ust=1686088785984400&usg=AOvVaw3uFbyJJ7z2Z1T7-bSWngqx)\] "I strongly discourage the use of autoload in any standard libraries" (eregon)
+- \[Feature [#5653](https://bugs.ruby-lang.org/issues/5653)\] "I strongly discourage the use of autoload in any standard libraries" (eregon)
 
 - It would be useful to reach a decision for this. What does it gain, and at what cost for compatibility? Is there going to be a replacement?
 - (investigated the circumstance and history of Rails…)
 - Matz: keep autoload (for a while)? Seems impossible to remove it now.  May be removed in 4.0 :-)
 
-- \[Feature [#14344](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14344&sa=D&source=editors&ust=1686088785984931&usg=AOvVaw2Mp8dfwGJY7liX9Dr_2FzK)\] refine at class level (kddeisz)
+- \[Feature [#14344](https://bugs.ruby-lang.org/issues/14344)\] refine at class level (kddeisz)
 
 - Shorter refinement syntax proposed based on common use cases. Proposed either refine\_class or using blocks for shorthand. What do you think?
 - Matz: I understand the needs, but I don’t like the style.  Please propose other styles.
 
-- \[Feature [#14680](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14680&sa=D&source=editors&ust=1686088785985502&usg=AOvVaw0oRIOx89LW09Y57IVu7vqw)\] Adding +@ and -@ to hash and array (kddeisz)
+- \[Feature [#14680](https://bugs.ruby-lang.org/issues/14680)\] Adding +@ and -@ to hash and array (kddeisz)
 
 - Since we have -@ and +@ for strings and it's very useful I'd like to propose adding the same API to hash and array.
 - Urabe: It is arguable that -@ reads better than .freeze
 - Matz: I don’t see the strong reason to add
 
-- \[Feature [#15567](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15567&sa=D&source=editors&ust=1686088785985999&usg=AOvVaw0KGNvt-nz2jlz0MEzAdkky)\] Allow ensure to match specific situations. (ioquatix)
+- \[Feature [#15567](https://bugs.ruby-lang.org/issues/15567)\] Allow ensure to match specific situations. (ioquatix)
 
 - Matz: wait real-world use case
 - Mame: I don’t want to see a strange API that depends the difference between throw and break.
 
-- \[Feature [#15560](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15560&sa=D&source=editors&ust=1686088785986447&usg=AOvVaw3B8WWcBJU9SVlKqxNwFgfx)\] Add support for read/write offsets. (ioquatix)
+- \[Feature [#15560](https://bugs.ruby-lang.org/issues/15560)\] Add support for read/write offsets. (ioquatix)
 
 - Can we get consensus on whether we can add this?
 - Doesn’t the current Ruby have this feature? … Check later.
@@ -138,35 +138,35 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 - Mrkn: How about a view (or slice) of a string?
 - Matz: Let’s discuss it the next meeting.
 
-- \[Feature [#10098](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/10098&sa=D&source=editors&ust=1686088785987121&usg=AOvVaw39R0RCNWZFI52yM8i1_53n)\] Timing-safe string comparison for OpenSSL::HMAC (bdewater)
+- \[Feature [#10098](https://bugs.ruby-lang.org/issues/10098)\] Timing-safe string comparison for OpenSSL::HMAC (bdewater)
 
 - The feature is done (the title is old, it will be implemented in String) but blocked on picking a method name. I would like to ask for opinions so this can move forward.
 -  ???
 
-- \[Feature [#15331](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15331&sa=D&source=editors&ust=1686088785987694&usg=AOvVaw2-O25QGfrjvxegzNpuWa5Z)\] \[PATCH\] Faster hashing for short string literals
+- \[Feature [#15331](https://bugs.ruby-lang.org/issues/15331)\] \[PATCH\] Faster hashing for short string literals
 
 - Looking for feedback on this patch.
 - Nobu: I tested, but cannot confirm the speed up
 - Matz: Umm.
 
-- \[Feature [#15374](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15374&sa=D&source=editors&ust=1686088785988155&usg=AOvVaw3QRqfdtSZ8EjLWR0kHX-vf)\] Proposal: Enable refinements to #method\_missing
+- \[Feature [#15374](https://bugs.ruby-lang.org/issues/15374)\] Proposal: Enable refinements to #method\_missing
 
 - waited one month.
 - Matz: will reject.
 
-- \[Feature [#14609](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14609&sa=D&source=editors&ust=1686088785988531&usg=AOvVaw0SXOh4ZEiUOe5AOEmKmKZZ)\] Kernel#p without args shows the receiver (osyo)
+- \[Feature [#14609](https://bugs.ruby-lang.org/issues/14609)\] Kernel#p without args shows the receiver (osyo)
 
 - I feel this feature is very useful and some people say :+1: so let discuss about this feature.
 - Need to discuss when we have ko1.  He left, so discuss it at the next meeting.
 
-- \[Feature [#15588](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15588&sa=D&source=editors&ust=1686088785988995&usg=AOvVaw03lNnRHutJsehMUK5ehfFh)\] String#each\_chunk and #chunks
+- \[Feature [#15588](https://bugs.ruby-lang.org/issues/15588)\] String#each\_chunk and #chunks
 
 - Looking for feedback on this patch.
 - Matz: use case.
 
 ## From Attendees
 
-- \[Feature [#15554](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15554&sa=D&source=editors&ust=1686088785989657&usg=AOvVaw2NCvhcWoJr0dNSuWYXagqT)\] warn/error passing a block to a method which never use a block (ko1)
+- \[Feature [#15554](https://bugs.ruby-lang.org/issues/15554)\] warn/error passing a block to a method which never use a block (ko1)
 
 - I want to share the ticket and survey on some product.
 - Ko1: It requires many fixes, but it actually found some real bugs.
@@ -178,24 +178,24 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 - knu: Autoloading itself is a feature that you can't miss in application development.  Especially in Rails, it takes a very long time to load all ActiveRecord model files eagerly because each one of them accesses the database to load the table schema, and it'd be painful to have to load everything just to run, for example, a single unit test.
 - Matz: OK, I give up. Autoload will stay, at least until before Ruby 4.x.
 
-- \[Feature [#15581](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15581&sa=D&source=editors&ust=1686088785990428&usg=AOvVaw30uAyGhZC4h8gyr4UZGb53)\] Split tool/\* files to tool and script directories
+- \[Feature [#15581](https://bugs.ruby-lang.org/issues/15581)\] Split tool/\* files to tool and script directories
 
 - What's a concern about this?
 
--  \[Feature [#4475](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4475&sa=D&source=editors&ust=1686088785990909&usg=AOvVaw27xlk3LKzX1DQQQCEaoCwh)\] default variable name for parameter (aycabta)
+-  \[Feature [#4475](https://bugs.ruby-lang.org/issues/4475)\] default variable name for parameter (aycabta)
 
-- In [#15483](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15483&sa=D&source=editors&ust=1686088785991192&usg=AOvVaw2bmf2CIJGOgSPuDqgsj9hC), matz said "I feel the expression ary.map(&(:to\_i << :chr)) is far less readable than ary.map{|x|x.to\_i.chr}.", and "And this can lead to the default block parameter like it."
+- In [#15483](https://bugs.ruby-lang.org/issues/15483), matz said "I feel the expression ary.map(&(:to\_i << :chr)) is far less readable than ary.map{|x|x.to\_i.chr}.", and "And this can lead to the default block parameter like it."
 - nobu is wriing a patch for \`@1\`. so, let’s try it.
 
-- \[Feature [#5632](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/5632&sa=D&source=editors&ust=1686088785991758&usg=AOvVaw2yDl8-zc2shq5i1UtP4aPt)\] Attempt to open included class shades it instead. (mame)
+- \[Feature [#5632](https://bugs.ruby-lang.org/issues/5632)\] Attempt to open included class shades it instead. (mame)
 
 - Matz: sorry, it was not mame’s task. reject it.
 
-- \[Feature [#11076](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/11076&sa=D&source=editors&ust=1686088785992194&usg=AOvVaw3pLnbJZrj2FEJ5vklFg538)\] Enumerable method count\_by
+- \[Feature [#11076](https://bugs.ruby-lang.org/issues/11076)\] Enumerable method count\_by
 
 - Matz: ok, introduce \`tally\`.
 
-- \[Feature [#15573](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15573&sa=D&source=editors&ust=1686088785992578&usg=AOvVaw2u5jvQDkSE0svJtZipOH6U)\] Permit zero step in Numeric#step and Range#step
+- \[Feature [#15573](https://bugs.ruby-lang.org/issues/15573)\] Permit zero step in Numeric#step and Range#step
 
 \>> (10 .. 0).step(-1).to\_a
 

--- a/2019/DevMeeting-2019-03-11.md
+++ b/2019/DevMeeting-2019-03-11.md
@@ -65,7 +65,7 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 ## Next dev-meeting
 
 - 4/17 (Wed) 12:00~ @ Fukuoka (before RubyKaigi)
-- [https://bugs.ruby-lang.org/issues/15459](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15459&sa=D&source=editors&ust=1686088807813014&usg=AOvVaw33GYZsSI8JRkgjBmvEg_J6)
+- [https://bugs.ruby-lang.org/issues/15459](https://bugs.ruby-lang.org/issues/15459)
 
 ## About 2.7 timeframe
 
@@ -75,11 +75,11 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 
 - waiting introducing \`@1\`. maybe at RubyKaigi
 
-- [https://bugs.ruby-lang.org/issues/4475](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/4475&sa=D&source=editors&ust=1686088807814126&usg=AOvVaw0o9b28jc1FMBO7H_M80jNn)
+- [https://bugs.ruby-lang.org/issues/4475](https://bugs.ruby-lang.org/issues/4475)
 - matz: I deny \`@0\`, and also deny assignment to \`@1\`
 
 - \[\[1,2,3\]\].each {|a,| p a }
-- →→ [https://hackmd.io/eb38KJgKQEeGEgsbSACUWg](https://www.google.com/url?q=https://hackmd.io/eb38KJgKQEeGEgsbSACUWg&sa=D&source=editors&ust=1686088807815060&usg=AOvVaw3sox1EoIqNiSX51QJ2IIGo)
+- →→ [https://hackmd.io/eb38KJgKQEeGEgsbSACUWg](https://hackmd.io/eb38KJgKQEeGEgsbSACUWg)
 
 ## Check security tickets (confidencial)
 
@@ -87,7 +87,7 @@ done
 
 ## Carry-over from previous meeting(s)
 
-- \[Feature [#14609](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14609&sa=D&source=editors&ust=1686088807816269&usg=AOvVaw1Lso0aFxPXY6p2PFqchgG0)\] Kernel#p without args shows the receiver (aycabta)
+- \[Feature [#14609](https://bugs.ruby-lang.org/issues/14609)\] Kernel#p without args shows the receiver (aycabta)
 
 - the name of the method is not determined yet.
 
@@ -97,19 +97,19 @@ done
 
 ## Non-attendees
 
-- \[Feature [#14799](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14799&sa=D&source=editors&ust=1686088807817656&usg=AOvVaw0eJLK1wzZe4nKEvT5wc7V9)\] Startless range
+- \[Feature [#14799](https://bugs.ruby-lang.org/issues/14799)\] Startless range
 
 - mame: I’ve forgotten to commit.  just a moment.
 
-- \[Bug [#15620](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15620&sa=D&source=editors&ust=1686088807818306&usg=AOvVaw1kG5EHCt9IcOrWGVl10V1x)\] Block argument usage affects lambda semantic
+- \[Bug [#15620](https://bugs.ruby-lang.org/issues/15620)\] Block argument usage affects lambda semantic
 
 - nobu: yes, it’s a bug.
 
-- \[Misc [#15617](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15617&sa=D&source=editors&ust=1686088807818847&usg=AOvVaw1ZOXNQuyq4m-K4TPc-5Lkb)\] Release 2.5.4? (blowmage)
+- \[Misc [#15617](https://bugs.ruby-lang.org/issues/15617)\] Release 2.5.4? (blowmage)
 
 - usa: nagachika-san is planning to release in this month.
 
-- \[Feature [#15323](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15323&sa=D&source=editors&ust=1686088807819427&usg=AOvVaw3Ffx7IeBOdb-IYLB1S1lTG)\] Proposal: Add Enumerable#filter\_map
+- \[Feature [#15323](https://bugs.ruby-lang.org/issues/15323)\] Proposal: Add Enumerable#filter\_map
 
 - naruse: Sequel uses \`select\_filter\` as another meaning
 - usa: also need \`select\_map\` as alias?
@@ -119,7 +119,7 @@ done
 - matz: filter\_map is not simply combination of filter and map.  so mame’s concern is needless fears.
 - matz: ok, accepted \`filter\_map\`.
 
-- \[Feature [#14145](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14145&sa=D&source=editors&ust=1686088807821271&usg=AOvVaw19TZLc6Un_f7wkINwVEvBj)\] Proposal: Better Method#inspect
+- \[Feature [#14145](https://bugs.ruby-lang.org/issues/14145)\] Proposal: Better Method#inspect
 
 - ko1: I’m against to show the name of parameters.  we only need line no.  doesn’t it?
 - matz: ask the original author.
@@ -131,7 +131,7 @@ done
 - naruse: path name is already long.
 - ko1: ah, may be so.  but source location is useful than parameters.
 
-- \[Feature [#15653](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15653&sa=D&source=editors&ust=1686088807822552&usg=AOvVaw1lFzrLjvR7z8WZaj8HaRbI)\] Proposal: Add Time#floor
+- \[Feature [#15653](https://bugs.ruby-lang.org/issues/15653)\] Proposal: Add Time#floor
 
 - naruse: isn’t it \`trunc\`?  see SQL.
 - akr: truncate means rounding to zero.  conceptually, zero is the first time, but we often assume the zero time as UNIX epoch.
@@ -141,43 +141,43 @@ done
 
 ## From Attendees
 
-- \[Misc [#15615](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15615&sa=D&source=editors&ust=1686088807823855&usg=AOvVaw3L0yJFGl4vvgDCDBK_4SP5)\] File.birthtimeがLinux環境で有効なファイル作成時刻を得られなかった場合の挙動について
+- \[Misc [#15615](https://bugs.ruby-lang.org/issues/15615)\] File.birthtimeがLinux環境で有効なファイル作成時刻を得られなかった場合の挙動について
 
 - should raises \`NotImplementedError\` both \`File.birthtime\` and \`File::Stat#birthtime\` if birthtime is not available.
 - akr: \`respond\_to?\` should always return \`true\`.
 - akr: we also have to implement \`birthtime\` to \`Pathname\`, don’t it?
 - usa: yes
 
-- \[Feature [#15195](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15195&sa=D&source=editors&ust=1686088807825181&usg=AOvVaw18hIx4cQMyqIFeAcjqeQ9j)\] How to deal with new Japanese era
+- \[Feature [#15195](https://bugs.ruby-lang.org/issues/15195)\] How to deal with new Japanese era
 
 - martin: just a reminder.
 - naruse: I’m planning to release 2.6.2 sooner.  and 2.6.3 will be released at Apr.
 - martin: ok
 
-- \[Bug [#15598](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15598&sa=D&source=editors&ust=1686088807825845&usg=AOvVaw3HxZNx9mrlaizCXJ9OsDXz)\] Deadlock on mutual reference of autoloaded constants
+- \[Bug [#15598](https://bugs.ruby-lang.org/issues/15598)\] Deadlock on mutual reference of autoloaded constants
 
 - (see next)
 
-- \[Bug [#15599](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15599&sa=D&source=editors&ust=1686088807826382&usg=AOvVaw0FC4M1IbKveX8VLd-OJICo)\] Mixing autoload and require causes deadlock and incomplete definition.
+- \[Bug [#15599](https://bugs.ruby-lang.org/issues/15599)\] Mixing autoload and require causes deadlock and incomplete definition.
 
 - akr: IMO, these are bugs.  I propose that autoload should use one global lock instead of locks per constants.
 
-- \[Feature [#15618](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15618&sa=D&source=editors&ust=1686088807827068&usg=AOvVaw1YxYIUKCrY0nOrtjUlAsM_)\] Implement Enumerator::Yielder#to\_proc
+- \[Feature [#15618](https://bugs.ruby-lang.org/issues/15618)\] Implement Enumerator::Yielder#to\_proc
 
 - matz: ok, accepted.
 
-- \[Feature [#15553](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15553&sa=D&source=editors&ust=1686088807827592&usg=AOvVaw09m8pL3nElUSPkY8PmJSjE)\] Addrinfo.getaddrinfo supports timeout
+- \[Feature [#15553](https://bugs.ruby-lang.org/issues/15553)\] Addrinfo.getaddrinfo supports timeout
 
 - akr: this implementation is not acceptable, but the feature is ok.
 - glass\_saga: I see.  BTW, is using Resolv acceptable?
 - akr: yes.
 - Even if it doesn’t support getaddrinfo with timeout (non glibc), it should ignore because we want to use the same code on macOS and Linux.
 
-- \[Bug [#15652](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15652&sa=D&source=editors&ust=1686088807828439&usg=AOvVaw0jqIkEMEGjBnSaD0J0gL3v)\] Profiler\_\_ is not working correctly (ruby 2.6)
+- \[Bug [#15652](https://bugs.ruby-lang.org/issues/15652)\] Profiler\_\_ is not working correctly (ruby 2.6)
 
 - usa, naruse: kill it
 
-- \[Feature [#15626](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15626&sa=D&source=editors&ust=1686088807828930&usg=AOvVaw0CjjyDjrMBPfxpPr2TXR48)\] Manual Compaction for MRI’s GC (\`GC.compact\`)
+- \[Feature [#15626](https://bugs.ruby-lang.org/issues/15626)\] Manual Compaction for MRI’s GC (\`GC.compact\`)
 
 - matz: current status?
 - ko1: I think this is mergeable.  But one incompatibility exists.   if an C extension keeps pointers without mark (expecting to mark via Ruby code), GC cannot change the pointers.

--- a/2019/DevMeeting-2019-04-21.md
+++ b/2019/DevMeeting-2019-04-21.md
@@ -63,7 +63,7 @@ Time: 13:00-18:30 (JST)
 
 Place: Fukuoka Ruby Content Industry Promotion Center (Fukuoka, Japan)
 
-[https://bugs.ruby-lang.org/issues/15459](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15459&sa=D&source=editors&ust=1686240817765394&usg=AOvVaw2bDQg-MqdwWc5T0JpFv2_u)
+[https://bugs.ruby-lang.org/issues/15459](https://bugs.ruby-lang.org/issues/15459)
 
 # Logs
 
@@ -73,7 +73,7 @@ Place: Fukuoka Ruby Content Industry Promotion Center (Fukuoka, Japan)
 
 ### Agenda
 
-- 13:30-14:00 (1) keyword arguments progress report \[[#14183](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14183&sa=D&source=editors&ust=1686240817766844&usg=AOvVaw2o_l_d5hi28iEIYSgdLw0h)\] (mame)
+- 13:30-14:00 (1) keyword arguments progress report \[[#14183](https://bugs.ruby-lang.org/issues/14183)\] (mame)
 
 - Mame: Presentation of problems and issues. Testing of strict implementation shows many incompatibilities.
 - Jeremy Evans: More compatible proposal, same as mame, but backwards compatible for methods that don’t accept keyword arguments.
@@ -128,7 +128,7 @@ Place: Fukuoka Ruby Content Industry Promotion Center (Fukuoka, Japan)
 
 - What about anonymous classes and e.g., Struct subclasses? (eregon)
 
-- 14:30-15:00 (3) pattern matching \[[#14912](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14912&sa=D&source=editors&ust=1686240817769933&usg=AOvVaw2evXKFgAhPdjbKYcvBRHcL)\] (k\_tsj)
+- 14:30-15:00 (3) pattern matching \[[#14912](https://bugs.ruby-lang.org/issues/14912)\] (k\_tsj)
 
 - Kazuki: Presentation of general idea and implementation.
 
@@ -178,7 +178,7 @@ Place: Fukuoka Ruby Content Industry Promotion Center (Fukuoka, Japan)
 - Matz: It is not for the VM implementation but for the users.
 
 - 16:30-17:00 break
-- 17:00-18:00 (6) RubyVM \[[#15752](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15752&sa=D&source=editors&ust=1686240817772871&usg=AOvVaw2RW2ZCBx4aAAJAxUXfShJO)\] + numbered parameters \[[#15708](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15708&sa=D&source=editors&ust=1686240817773193&usg=AOvVaw3S5K6h1oH6TlBJjl89uqYs)\] (eregon)
+- 17:00-18:00 (6) RubyVM \[[#15752](https://bugs.ruby-lang.org/issues/15752)\] + numbered parameters \[[#15708](https://bugs.ruby-lang.org/issues/15708)\] (eregon)
 
 - Presentation about RubyVM namespace issues. How to handle experimental features.
 - Many new methods are implemented directly. What should go under proposed “ExperimentalFeatures”?

--- a/2019/DevMeeting-2019-05-22.md
+++ b/2019/DevMeeting-2019-05-22.md
@@ -62,7 +62,7 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 
 # Log
 
-[https://bugs.ruby-lang.org/issues/15782](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15782&sa=D&source=editors&ust=1686088829068902&usg=AOvVaw2lvoSocyt9eVFzKGi-1P5J)
+[https://bugs.ruby-lang.org/issues/15782](https://bugs.ruby-lang.org/issues/15782)
 
 ## Next Date
 
@@ -70,7 +70,7 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 
 ## Ann
 
-- 7/14, 15 Ruby Development camp @ [https://marumo.net/gasshuku-plan001/](https://www.google.com/url?q=https://marumo.net/gasshuku-plan001/&sa=D&source=editors&ust=1686088829069631&usg=AOvVaw1vQovSxi2MlSlc1sH5dyJ5)
+- 7/14, 15 Ruby Development camp @ [https://marumo.net/gasshuku-plan001/](https://marumo.net/gasshuku-plan001/)
 
 ## About 2.7 timeframe
 
@@ -88,83 +88,83 @@ Nothing.
 
 ## Topics
 
-- [\[Misc #14632\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14632&sa=D&source=editors&ust=1686088829070677&usg=AOvVaw2MOmyhtFrdaZtYi9we0R-i) [git.ruby-lang.org](https://www.google.com/url?q=http://git.ruby-lang.org/&sa=D&source=editors&ust=1686088829070849&usg=AOvVaw3CMIaDTPqLLlZ0yDtY8mPp) (k0kubun)
+- [\[Misc #14632\]](https://bugs.ruby-lang.org/issues/14632) [git.ruby-lang.org](http://git.ruby-lang.org/) (k0kubun)
 
 - RUBY\_REVISION should be full-length hash value
 
-- [\[Bug #15745\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15745&sa=D&source=editors&ust=1686088829071202&usg=AOvVaw2KZfJ56SugMvxuOObPmGuv) There is no symmetry in the beginless range and the endless range using Range#inspect (koic)(1..).inspect      #=> "1.."
+- [\[Bug #15745\]](https://bugs.ruby-lang.org/issues/15745) There is no symmetry in the beginless range and the endless range using Range#inspect (koic)(1..).inspect      #=> "1.."
 - (..5).inspect      #=> "..5"
 - (nil..nil).inspect #=> "nil..nil"
 
-- [\[Feature #14915\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14915&sa=D&source=editors&ust=1686088829071759&usg=AOvVaw1IAFGrBYtrB492ZyTh6t00) Deprecate String#crypt (jeremyevans0)
+- [\[Feature #14915\]](https://bugs.ruby-lang.org/issues/14915) Deprecate String#crypt (jeremyevans0)
 
 - There are a few committers against the removal. They will reply into the ticket.
-- Jeremy Evans committer? -> “Go ahead” by matz ([https://bugs.ruby-lang.org/issues/15853#change-78060](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15853%23change-78060&sa=D&source=editors&ust=1686088829072214&usg=AOvVaw3SLlgoL9nFTQBT14EAtoDc), [https://bugs.ruby-lang.org/issues/15839#change-78087](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15839%23change-78087&sa=D&source=editors&ust=1686088829072421&usg=AOvVaw1Ck6TK557TLQCVUaFmTVik))
+- Jeremy Evans committer? -> “Go ahead” by matz ([https://bugs.ruby-lang.org/issues/15853#change-78060](https://bugs.ruby-lang.org/issues/15853#change-78060), [https://bugs.ruby-lang.org/issues/15839#change-78087](https://bugs.ruby-lang.org/issues/15839#change-78087))
 
-- [\[Feature #15765\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15765&sa=D&source=editors&ust=1686088829072708&usg=AOvVaw3-AOZNlScJjLpo4-0oJEmX) \[PATCH\] Module#name without global constant search (alanwu)
+- [\[Feature #15765\]](https://bugs.ruby-lang.org/issues/15765) \[PATCH\] Module#name without global constant search (alanwu)
 
 - Matz: leaf to nobu.
 - Nobu: Will check and merge.
 
-- [\[Feature #15772\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15772&sa=D&source=editors&ust=1686088829073142&usg=AOvVaw1iy8TSQH65ZmGbJvgI2_G5) Proposal: Add Time#ceil (osyo)
+- [\[Feature #15772\]](https://bugs.ruby-lang.org/issues/15772) Proposal: Add Time#ceil (osyo)
 
 - Shyouhei: Use case?
 - Matz: Okay!
 
-- [\[Feature #13645\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/13645&sa=D&source=editors&ust=1686088829073566&usg=AOvVaw3GIBKneMrbgGB5S0dVo0Yz) Syntactic sugar for indexing when using the safe navigation operator (osyo)
+- [\[Feature #13645\]](https://bugs.ruby-lang.org/issues/13645) Syntactic sugar for indexing when using the safe navigation operator (osyo)
 
 - Matz: the use case looks artificial. Reject once.
 
-- [\[Misc #15802\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15802&sa=D&source=editors&ust=1686088829073884&usg=AOvVaw1WO3Szw3TZQE-Ode5mu9Sv) \[PATCH\] Reduce the minimum string buffer size from 127 to 63 bytes (methodmissing)
+- [\[Misc #15802\]](https://bugs.ruby-lang.org/issues/15802) \[PATCH\] Reduce the minimum string buffer size from 127 to 63 bytes (methodmissing)
 
 - ko1 will check.
 
-- [\[Feature #14736\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14736&sa=D&source=editors&ust=1686088829074211&usg=AOvVaw1LY62uznmL7v4NN5-RM4tf) Thread selector for flexible cooperative fiber based concurrency (ioquatix)
+- [\[Feature #14736\]](https://bugs.ruby-lang.org/issues/14736) Thread selector for flexible cooperative fiber based concurrency (ioquatix)
 
 - (ko1, nobu, and matz talks)
 - Matz: I’m worry about the performance, it would be difficult to accept the patch as is. I’m not positive to add a hook to IO because it will bring a big overhead when buffered. I prefer auto-fiber to using traditional IOs with a hook.
 - Nobu: I’m negative to passing a FD. I agree with eregon.
 - Matz: Will reject.
-- Ko1: I’m unsure what design is best, but I think eregon wrote [a good comment](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14736%23change-77879&sa=D&source=editors&ust=1686088829074789&usg=AOvVaw3ebK71VLlVj-kdjSNIgOpI). It would be good that the proposal is much simpler than autofiber.
+- Ko1: I’m unsure what design is best, but I think eregon wrote [a good comment](https://bugs.ruby-lang.org/issues/14736#change-77879). It would be good that the proposal is much simpler than autofiber.
 
-- [\[Feature #15323\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15323&sa=D&source=editors&ust=1686088829075042&usg=AOvVaw12jzyQ-4JxlKhN5Mt8wWlx) \[PATCH\] Proposal: Add Enumerable#filter\_map (greggzst)
+- [\[Feature #15323\]](https://bugs.ruby-lang.org/issues/15323) \[PATCH\] Proposal: Add Enumerable#filter\_map (greggzst)
 
 - Matz will reply.
 
-- [\[Misc #15843\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15843&sa=D&source=editors&ust=1686088829075413&usg=AOvVaw3wFHl7RYSEDjFNDLCUpu_8) Make “trunk” a symbolic-ref of “master” on [git.ruby-lang.org](https://www.google.com/url?q=http://git.ruby-lang.org/&sa=D&source=editors&ust=1686088829075617&usg=AOvVaw0thzU36T3m9jqdz2Lhwb2M) (k0kubun)
+- [\[Misc #15843\]](https://bugs.ruby-lang.org/issues/15843) Make “trunk” a symbolic-ref of “master” on [git.ruby-lang.org](http://git.ruby-lang.org/) (k0kubun)
 
 - Go ahead?
 - Nobu: Why “master” is primary and “trunk” is secondary.
 - Akr: “Out of scope (for a short term)” is a trap! “accept” may mean accept for long term?
 
-- [\[Feature #15778\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15778&sa=D&source=editors&ust=1686088829076136&usg=AOvVaw37J8gLZH-TwPTSoIZHZ7d_) Expose an API to pry-open the stack frames in Ruby (eregon)
+- [\[Feature #15778\]](https://bugs.ruby-lang.org/issues/15778) Expose an API to pry-open the stack frames in Ruby (eregon)
 
 - Ko1: I hate Binding.of\_caller.
 - Shyouhei: How about requiring require "something" to communicate “should only be used for debugging”?
 
-- [\[Bug #7300\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/7300&sa=D&source=editors&ust=1686088829076697&usg=AOvVaw0-4My0xywohL8QXLUUbhKj) Hash#\[\] の挙動が 1.9.3 と異なっている (hsbt)
+- [\[Bug #7300\]](https://bugs.ruby-lang.org/issues/7300) Hash#\[\] の挙動が 1.9.3 と異なっている (hsbt)
 
 - Mame: I’d like to merge it.
 
-- [\[Feature #14844\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/14844&sa=D&source=editors&ust=1686088829077078&usg=AOvVaw2tPsGcvMik_gOXnCBYKoN1) Future of RubyVM::AST?
+- [\[Feature #14844\]](https://bugs.ruby-lang.org/issues/14844) Future of RubyVM::AST?
 
 - What can we do about this? The current situation is confusing for everyone, the API sounds “blessed” by being in core but it’s actually experimental and unstable. Can we document it as clearly as possible when this API should be used? Could we improve the API so it’s less fragile to parser changes and could be reasonably implemented on other Ruby implementations?
 - “Add a document to warn the result of this API may (easily) change in future”
 
-- [\[Feature #15863\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15863&sa=D&source=editors&ust=1686088829077592&usg=AOvVaw12CadwHth6JWaCZOJ8Hb25) Add Hash#slice! and ENV.slice!(bogdanvlviv)
-- [\[Feature #15831\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15831&sa=D&source=editors&ust=1686088829077983&usg=AOvVaw2eVfg0ts-1ouKsFURw3k4d) Add Array#extract, Hash#extract, and ENV.extract (bogdanvlviv)
+- [\[Feature #15863\]](https://bugs.ruby-lang.org/issues/15863) Add Hash#slice! and ENV.slice!(bogdanvlviv)
+- [\[Feature #15831\]](https://bugs.ruby-lang.org/issues/15831) Add Array#extract, Hash#extract, and ENV.extract (bogdanvlviv)
 
 - Matz: negative. (Sorry I missed to log)
 
-- [\[Feature #15864\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15864&sa=D&source=editors&ust=1686088829078493&usg=AOvVaw3xS7e62FVsmR3zW7jBZDgc) Proposal: Add methods to determine if it is an infinite range
+- [\[Feature #15864\]](https://bugs.ruby-lang.org/issues/15864) Proposal: Add methods to determine if it is an infinite range
     (osyo)
 
 - Matz: negative.
 
-- [\[Feature #15865\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15865&sa=D&source=editors&ust=1686088829078804&usg=AOvVaw3p_Fs5ZfWJtuYB6E7HiNvu) <expr> in <pattern> expression (mame)
+- [\[Feature #15865\]](https://bugs.ruby-lang.org/issues/15865) <expr> in <pattern> expression (mame)
 
 - Matz: positive.
 
-- [\[Feature #15281\]](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/15281&sa=D&source=editors&ust=1686088829079237&usg=AOvVaw1bKEfmLlIRc8wm5D6vZopG) Speed up Set#intersect with size check. (tenderlove)
+- [\[Feature #15281\]](https://bugs.ruby-lang.org/issues/15281) Speed up Set#intersect with size check. (tenderlove)
 
 - Knu will check.


### PR DESCRIPTION
## Summary

Meeting logs exported from Google Docs contain URLs wrapped in Google's redirect service:

```
https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9969&sa=D&source=editors&ust=1686086778188607&usg=AOvVaw1r1Ex8lWi1rHAWqywICQXs
```

These add unnecessary indirection and will break if Google ever removes the redirect endpoint.

## Changes

Replace all Google redirect URLs with their direct targets, decoding percent-encoded characters:

```diff
-[#9969](https://www.google.com/url?q=https://bugs.ruby-lang.org/issues/9969&sa=D&source=editors&ust=1686086778188607&usg=AOvVaw1r1Ex8lWi1rHAWqywICQXs)
+[#9969](https://bugs.ruby-lang.org/issues/9969)
```

1217 URLs unwrapped across 47 files. The vast majority (1133) point to `bugs.ruby-lang.org`, with the remainder linking to GitHub, connpass, Google Docs, and other sites.

## Affected files

47 files across 2014-2019 (full list in the diff).

---

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.