### PR TITLE
Normalize ticket link format to match modern convention (2014-2019)

### DIFF
--- a/2014/DevMeeting-2014-05-17.md
+++ b/2014/DevMeeting-2014-05-17.md
@@ -37,7 +37,7 @@ online: matz, n0kada,
 
 [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20140517Japan](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20140517Japan)
 
-## \[Feature [#9772](https://bugs.ruby-lang.org/issues/9772)\] IO#statfs and File::Statfs
+## [[Feature #9772]](https://bugs.ruby-lang.org/issues/9772) IO#statfs and File::Statfs
 
 本当に必要なのか？(rubygem でいいんでないのという議論)
 
@@ -49,7 +49,7 @@ statvfsという名前で入れる
 
 Matz: 色々込み入ってるので core には入れないで test 配下へ. 欲しいということがあったら gem にしてください.
 
-## \[Feature [#9647](https://bugs.ruby-lang.org/issues/9647)\] File::Stat#birthtime
+## [[Feature #9647]](https://bugs.ruby-lang.org/issues/9647) File::Stat#birthtime
 
 何に使うのこれ
 
@@ -75,7 +75,7 @@ python にもあるが、stat() を直接返すらしく、対応していない
 
 ないときはNotImplementedError
 
-## \[Feature [#9816](https://bugs.ruby-lang.org/issues/9816)\] 文字列内の数字を数値として比較するメソッド
+## [[Feature #9816]](https://bugs.ruby-lang.org/issues/9816) 文字列内の数字を数値として比較するメソッド
 
 numericcmpという名前はない
 
@@ -103,13 +103,13 @@ numericcmpとかではなくバージョンを比較するものであるとわ�
 
 bundle gem にして、time が依存する箇所だけ ext に持っていく. 切り離す準備だけしておくのはどうか. いつやるかは未定.
 
-## \[Feature [#9513](https://bugs.ruby-lang.org/issues/9513)\] Hide Rational internal (akr)
+## [[Feature #9513]](https://bugs.ruby-lang.org/issues/9513) Hide Rational internal (akr)
 
 これはOKなのでは
 
 →matzがOKと返信する
 
-## \[Feature [#9826](https://bugs.ruby-lang.org/issues/9826)\] Enumerable#slice\_between (akr)
+## [[Feature #9826]](https://bugs.ruby-lang.org/issues/9826) Enumerable#slice\_between (akr)
 
 ニーズはある
 
@@ -117,7 +117,7 @@ matz: 機能としては採用してあげたいけど、この名前では採�
 
 #slice? → Array#slice があるのでNG
 
-## \[Feature [#9071](https://bugs.ruby-lang.org/issues/9071)\] Enumerable#slice\_after (akr)
+## [[Feature #9071]](https://bugs.ruby-lang.org/issues/9071) Enumerable#slice\_after (akr)
 
 対称性
 
@@ -125,7 +125,7 @@ matz: 機能としては採用してあげたいけど、この名前では採�
 
 →accept
 
-## \[Feature [#9770](https://bugs.ruby-lang.org/issues/9770)\] Etc.uname (akr)
+## [[Feature #9770]](https://bugs.ruby-lang.org/issues/9770) Etc.uname (akr)
 
 test の中で uname -r を叩いているのを見かけるので組み込みで用意してもよさそう.
 
@@ -139,17 +139,17 @@ test の中で uname -r を叩いているのを見かけるので組み込み�
 
 →accept
 
-## \[Feature [#9842](https://bugs.ruby-lang.org/issues/9842)\] system configuration variables (sysconf(), confstr(), pathconf() and fpathconf()) (akr)
+## [[Feature #9842]](https://bugs.ruby-lang.org/issues/9842) system configuration variables (sysconf(), confstr(), pathconf() and fpathconf()) (akr)
 
 Matz: sysconf と confstr で同じ機能だけど、数値と文字列を返すかで違う、何とかマージできないかなあ
 
 Windows でどうしよう →NotImplementedError
 
-## \[Feature [#9834](https://bugs.ruby-lang.org/issues/9834)\] Float#{next\_float,prev\_float} (akr)
+## [[Feature #9834]](https://bugs.ruby-lang.org/issues/9834) Float#{next\_float,prev\_float} (akr)
 
 これは用途があまり明らかでない→テストで便利(printfのテストとか)。
 
-## \[Feature [#9632](https://bugs.ruby-lang.org/issues/9632)\] \[offtopic\] remove doxygen?
+## [[Feature #9632]](https://bugs.ruby-lang.org/issues/9632) \[offtopic\] remove doxygen?
 
 ccan フォルダの追加に伴って doxygen の警告が凄いでてきた、そもそも使ってないなら消したい
 
@@ -157,7 +157,7 @@ ko1: 消すのではなくて、デフォルトで動くのはやめて make dox
 
 Matz: デフォルトでは動かさないようにして、何かレポートきたら誰か頑張る.
 
-## \[Feature [#9711](https://bugs.ruby-lang.org/issues/9711)\] Remove test-unit and minitest from stdlib. Can I remove test-unit? /cc sora\_h (hsbt)
+## [[Feature #9711]](https://bugs.ruby-lang.org/issues/9711) Remove test-unit and minitest from stdlib. Can I remove test-unit? /cc sora\_h (hsbt)
 
 lib/test, lib/minitest を使うのはもうやめている.
 

--- a/2014/DevMeeting-2014-07-26.md
+++ b/2014/DevMeeting-2014-07-26.md
@@ -33,13 +33,13 @@ log: https://docs.google.com/document/d/1g2mu2qngyxw3ge-EbDGLsDDZR-Uj_6fWaVb0YPw
 - attendee: ko1, sora\_h, akr, naruse, knu, duerst
 - on-line: matz, zzak, nobu, kosaki
 
-# \[Feature [#7797](https://bugs.ruby-lang.org/issues/7797)\] Hash should be renamed to StrictHash and a new Hash should be created to behave like AS HashWithIndifferentAccess
+# [[Feature #7797]](https://bugs.ruby-lang.org/issues/7797) Hash should be renamed to StrictHash and a new Hash should be created to behave like AS HashWithIndifferentAccess
 
 matz: I have to reject, since it breaks compatibility
 
 → reject
 
-# \[Feature [#9980](https://bugs.ruby-lang.org/issues/9980)\] Create HashWithIndiferentAccess using new syntax {a: 1}i
+# [[Feature #9980]](https://bugs.ruby-lang.org/issues/9980) Create HashWithIndiferentAccess using new syntax {a: 1}i
 
 matz: Suffix \`i\` is used for complex (imaginary) numbers. It's bit confusing.
 
@@ -47,21 +47,21 @@ Maybe what you want can be gained by shorter/nicer name for Hash#compare\_by\_id
 
 → reject
 
-# \[Feature [#9064](https://bugs.ruby-lang.org/issues/9064)\] Add support for packages, like in Java
+# [[Feature #9064]](https://bugs.ruby-lang.org/issues/9064) Add support for packages, like in Java
 
 Action: Matz  to write a few questions back to the proposer
 
-# \[Feature [#8631](https://bugs.ruby-lang.org/issues/8631)\] Add a new method to ERB to allow assigning the local variables from a hash
+# [[Feature #8631]](https://bugs.ruby-lang.org/issues/8631) Add a new method to ERB to allow assigning the local variables from a hash
 
 Now it can be implemnted with Pure Ruby.
 
 If hash is given, what will be \`self\` of ERB?
 
-# \[Bug [#8543](https://bugs.ruby-lang.org/issues/8543)\] rb\_iseq\_load
+# [[Bug #8543]](https://bugs.ruby-lang.org/issues/8543) rb\_iseq\_load
 
 Modify it (best effort).
 
-# \[Feature [#10084](https://bugs.ruby-lang.org/issues/10084)\] Add Unicode String Normalization to String class
+# [[Feature #10084]](https://bugs.ruby-lang.org/issues/10084) Add Unicode String Normalization to String class
 
 Proposed method names by Matz: unicode\_normalize or normalize\_kd,... (not too short)
 
@@ -81,25 +81,25 @@ encodng: UTF-32BE/LE, UTF-16BE/LE, UTF-8
 
 allow UTF8-MAC is confusing.
 
-# \[Feature [#10085](https://bugs.ruby-lang.org/issues/10085)\] Add non-ASCII case conversion to String#upcase/downcase/swapcase/capitalize
+# [[Feature #10085]](https://bugs.ruby-lang.org/issues/10085) Add non-ASCII case conversion to String#upcase/downcase/swapcase/capitalize
 
-# \[Feature [#4276](https://bugs.ruby-lang.org/issues/4276)\] Allow use of quotes in symbol syntactic sugar for hashes
+# [[Feature #4276]](https://bugs.ruby-lang.org/issues/4276) Allow use of quotes in symbol syntactic sugar for hashes
 
 Compare with JSON, it is ambiguous (String or Symbol).
 
-# \[Feature [#9924](https://bugs.ruby-lang.org/issues/9924)\] Revisitting GC.stat keys
+# [[Feature #9924]](https://bugs.ruby-lang.org/issues/9924) Revisitting GC.stat keys
 
 no objection.
 
 approval.
 
-# \[Feature [#9781](https://bugs.ruby-lang.org/issues/9781)\] Feature Proposal: Method#super\_method
+# [[Feature #9781]](https://bugs.ruby-lang.org/issues/9781) Feature Proposal: Method#super\_method
 
 super: ambiguous which is calling method or getting method object of super.
 
 \-> “super\_method”
 
-# \[Feature [#10095](https://bugs.ruby-lang.org/issues/10095)\] Object#as
+# [[Feature #10095]](https://bugs.ruby-lang.org/issues/10095) Object#as
 
 many bike shedding.
 

--- a/2014/DevMeeting-2014-09-04.md
+++ b/2014/DevMeeting-2014-09-04.md
@@ -45,7 +45,7 @@ Attendees: sign up required: http://cruby.doorkeeper.jp/events/13742
 - attendee: ko1, sora\_h, akr, naruse, ayumin, a\_matsuda
 - on-line: matz, nobu
 
-## \[Feature [#10199](https://bugs.ruby-lang.org/issues/10199)\] Drop to support Symbian (hsbt)
+## [[Feature #10199]](https://bugs.ruby-lang.org/issues/10199) Drop to support Symbian (hsbt)
 
 Matz: agreed.
 
@@ -55,7 +55,7 @@ akr: no need to think about it now.
 
 hsbt: I will remove.
 
-## \[Feature [#10200](https://bugs.ruby-lang.org/issues/10200)\] Symbol API (static count, dynamic count, all\_symbols and so on) (ko1)
+## [[Feature #10200]](https://bugs.ruby-lang.org/issues/10200) Symbol API (static count, dynamic count, all\_symbols and so on) (ko1)
 
 Symbol.all\_symbols:
 
@@ -73,7 +73,7 @@ matz: remove it and ask people
 
 Couting immortal symbols is not solved. ko1 will make prototype of such methods.
 
-## \[Feature [#9880](https://bugs.ruby-lang.org/issues/9880)\] Dir#fileno (akr)
+## [[Feature #9880]](https://bugs.ruby-lang.org/issues/9880) Dir#fileno (akr)
 
 matz: portability?
 
@@ -83,7 +83,7 @@ akr: For windows and so on, not implemented error can be acceptable.
 
 matz: ok. write document for compatibility.
 
-## \[Feature [#10201](https://bugs.ruby-lang.org/issues/10201)\] Dynamically changing GC tuning parameters (ko1)
+## [[Feature #10201]](https://bugs.ruby-lang.org/issues/10201) Dynamically changing GC tuning parameters (ko1)
 
 ko1 will try.
 

--- a/2014/DevMeeting-2014-10-29.md
+++ b/2014/DevMeeting-2014-10-29.md
@@ -39,7 +39,7 @@ Remote participation: Google hangout?
 
 # Log
 
-# \[Bug [#10416](https://bugs.ruby-lang.org/issues/10416)\] Create mechanism for updating of Unicode data files downstreams when we want (duerst
+# [[Bug #10416]](https://bugs.ruby-lang.org/issues/10416) Create mechanism for updating of Unicode data files downstreams when we want (duerst
 
 summary:
 
@@ -64,7 +64,7 @@ akr: ディレクトリ構造にバージョンを入れれば反映出来るだ
 
 ダウンロードおよび置き場に関してはnobuが実装するので、どうしたいかだけ伝えればOK
 
-# \[Feature [#5458](https://bugs.ruby-lang.org/issues/5458)\] DL should be removed (hsbt)
+# [[Feature #5458]](https://bugs.ruby-lang.org/issues/5458) DL should be removed (hsbt)
 
 akr: dlを消す時にlibffiのソースを添付するという話だった。（libffiをWindowsでビルドするのは大変なので、CRubyにバンドルし、ビルド時に一緒にビルドして欲しい）
 
@@ -80,7 +80,7 @@ akr: libffiソースバンドルチケットを作って、remove dlの依存先
 
 hsbt が関係者(tenderloveとunak)に remove 作業の詳細をもう一度確認して、どこまでやるかのラインを決めてもらう
 
-# \[Bug [#10314](https://bugs.ruby-lang.org/issues/10314)\] Default argument lookup fails in Ruby 2.2 for circular shadowed variable names (hsbt)
+# [[Bug #10314]](https://bugs.ruby-lang.org/issues/10314) Default argument lookup fails in Ruby 2.2 for circular shadowed variable names (hsbt)
 
 matz: ローカル変数代入と同じように見えるから、挙動もあわせるべき
 
@@ -88,7 +88,7 @@ akr: （foo = fooでnilが代入されるというのは）役に立つ挙動で
 
 matzがこれに関しては一貫性を取る（このリグレッションは諦めてもらう）と決定
 
-# \[Feature [#9612](https://bugs.ruby-lang.org/issues/9612)\] Gemify OpenSSL(hsbt)
+# [[Feature #9612]](https://bugs.ruby-lang.org/issues/9612) Gemify OpenSSL(hsbt)
 
 akr: experimental 実装について gemのバージョンは、OpenSSL (OpenSSL::OPENSSL\_VERSION)そのものではなく、OpenSSL拡張ライブラリのバージョン (OpenSSL::VERSION) にするべき（※libsslランタイムのバージョンはOpenSSL::OPENSSL\_LIBRARY\_VERSION）
 
@@ -108,7 +108,7 @@ akr: 「議論はしましたがいい名前が浮かばない」
 
 ko1: matz にふっておきましょう
 
-# \[Feature [#8976](https://bugs.ruby-lang.org/issues/8976)\] file-scope freeze\_string directive (akr)
+# [[Feature #8976]](https://bugs.ruby-lang.org/issues/8976) file-scope freeze\_string directive (akr)
 
 matz: 遠い未来には賛成
 
@@ -141,7 +141,7 @@ matz: 嫌な予感がするので2.2では（実験的実装も含めて）や�
 
 2.3（以降）に照準を合わせる
 
-# \[Feature [#10344](https://bugs.ruby-lang.org/issues/10344)\] \[PATCH\] Implement Fiber#raise (ko1)
+# [[Feature #10344]](https://bugs.ruby-lang.org/issues/10344) \[PATCH\] Implement Fiber#raise (ko1)
 
 ko1: Thread#raiseは危険なのでなくした経緯
 
@@ -152,7 +152,7 @@ ko1: セミコルーチンの親子・裏表関係からして気持ち悪さが
 反対はなし
 matzは賛成
 
-# \[Feature [#10440](https://bugs.ruby-lang.org/issues/10440)\] Optimize keyword and splat argument (ko1)
+# [[Feature #10440]](https://bugs.ruby-lang.org/issues/10440) Optimize keyword and splat argument (ko1)
 
 ko1: 99%は互換
 

--- a/2015/DevMeeting-2015-04-08.md
+++ b/2015/DevMeeting-2015-04-08.md
@@ -150,11 +150,11 @@ matz, akr, hsbt, nurse, nobu, ayumin, sora, ko1
 
 - Methods to certify packages (chatting)
 
-## \[Feature [#8259](https://bugs.ruby-lang.org/issues/8259)\] atomic attribute accessors (tenderlove)
+## [[Feature #8259]](https://bugs.ruby-lang.org/issues/8259) atomic attribute accessors (tenderlove)
 
 (matz) Let me survy more about it.
 
-## \[Feature [#10932](https://bugs.ruby-lang.org/issues/10932)\] Enable allocation tracing ASAP (tenderlove)
+## [[Feature #10932]](https://bugs.ruby-lang.org/issues/10932) Enable allocation tracing ASAP (tenderlove)
 
 (ko1) no problem except the name and “include ObjectSpace”.
 
@@ -162,7 +162,7 @@ matz, akr, hsbt, nurse, nobu, ayumin, sora, ko1
 
 (matz) approved.
 
-## \[Feature [#10728](https://bugs.ruby-lang.org/issues/10728)\] Warning for Fixnum#size to use RbConfig::SIZEOF 'long' (akr)
+## [[Feature #10728]](https://bugs.ruby-lang.org/issues/10728) Warning for Fixnum#size to use RbConfig::SIZEOF 'long' (akr)
 
 (matz) reject.
 

--- a/2015/DevMeeting-2015-05-14.md
+++ b/2015/DevMeeting-2015-05-14.md
@@ -49,7 +49,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 Attendee: ko1,ayumin,akr,hsbt,naruse; matz,sora\_h
 
-## \[Feature [#11084](https://bugs.ruby-lang.org/issues/11084)\] Use rb-readline instead of ext/readline
+## [[Feature #11084]](https://bugs.ruby-lang.org/issues/11084) Use rb-readline instead of ext/readline
 
 hsbt: Ruby needs readline. openssl, zlib to build. rb-readline is a pure Ruby library. Replacing current readline with rb-readline (as a bundled gem) helps build problems. Current readline will be a gem. Now windows ruby installer already use rb-readline.
 
@@ -87,7 +87,7 @@ Next action:
 
 hsbt: I continue to use rb-readline and try it.
 
-## \[Feature [#11083](https://bugs.ruby-lang.org/issues/11083)\] Gemify net-telnet
+## [[Feature #11083]](https://bugs.ruby-lang.org/issues/11083) Gemify net-telnet
 
 hsbt: no maintainer so it should be gemify.
 
@@ -97,7 +97,7 @@ hsbt: Not sure.
 
 Matz: I accept bundled gem.
 
-## \[Feature [#11082](https://bugs.ruby-lang.org/issues/11082)\] Remove condition of RUBY\_VERSION < 1.9 (hsbt)
+## [[Feature #11082]](https://bugs.ruby-lang.org/issues/11082) Remove condition of RUBY\_VERSION < 1.9 (hsbt)
 
 hsbt: Title is wrong. Not < 1.9, but <= 1.9.
 
@@ -123,7 +123,7 @@ ayumin: Positive because using newer features helps to evaluate such features.
 
 ko1: Use newer features with keeping compatibility.
 
-## \[Feature [#11049](https://bugs.ruby-lang.org/issues/11049)\] Enumerable#grep\_v (inversed grep) (sorah)
+## [[Feature #11049]](https://bugs.ruby-lang.org/issues/11049) Enumerable#grep\_v (inversed grep) (sorah)
 
 matz: are you okay to use the name “grep\_v”
 
@@ -141,7 +141,7 @@ matz: but grep\_v() is okay. -> accept on ticket.
 
 naruse: How about reject(pattern) ?
 
-## \[Bug [#10967](https://bugs.ruby-lang.org/issues/10967)\] Remove "private attribute?" warning (zzak)
+## [[Bug #10967]](https://bugs.ruby-lang.org/issues/10967) Remove "private attribute?" warning (zzak)
 
 akr: self.private\_something\_method is accepted recently.
 
@@ -149,7 +149,7 @@ naruse: test can find problem, so warning is not needed.
 
 matz: accept .
 
-## \[Feature [#10984](https://bugs.ruby-lang.org/issues/10984)\] Hash#contain? (zzak)
+## [[Feature #10984]](https://bugs.ruby-lang.org/issues/10984) Hash#contain? (zzak)
 
 akr: “contain” is too general. “subhash”?
 
@@ -157,7 +157,7 @@ n0kada: “contain?” seems similiar to “include?”
 
 akr: do we really use? we need concrete examples.
 
-## \[Bug [#10856](https://bugs.ruby-lang.org/issues/10856)\] Splat with empty keyword args
+## [[Bug #10856]](https://bugs.ruby-lang.org/issues/10856) Splat with empty keyword args
 
 def foo
 
@@ -185,13 +185,13 @@ foo(\*\*{}) #=> okay
 
 The first one seems wrong code, so an error is reasonable.
 
-## \[Feature [#11140](https://bugs.ruby-lang.org/issues/11140)\] autoload should call Kernel.require to give rubygems a chance to handle loading (tenderlove)
+## [[Feature #11140]](https://bugs.ruby-lang.org/issues/11140) autoload should call Kernel.require to give rubygems a chance to handle loading (tenderlove)
 
 nobu: no problem. -r already calls replaced require().
 
 matz: accept.
 
-## \[Feature [#11151](https://bugs.ruby-lang.org/issues/11151)\] Numeric#positive? and Numeric#negative?
+## [[Feature #11151]](https://bugs.ruby-lang.org/issues/11151) Numeric#positive? and Numeric#negative?
 
 akr: well usecase.
 

--- a/2015/DevMeeting-2015-06-12.md
+++ b/2015/DevMeeting-2015-06-12.md
@@ -55,7 +55,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 Attendee: akr, hsbt, ko1, matz, naruse, nobu
 
-## \[Feature [#7148](https://bugs.ruby-lang.org/issues/7148)\] Improved Tempfile w/o DelegateClass (glass\_saga)
+## [[Feature #7148]](https://bugs.ruby-lang.org/issues/7148) Improved Tempfile w/o DelegateClass (glass\_saga)
 
 matz: I have some issue on this proposal. Tempfile should not be a subclass of File. It is different concept from File. I’m okay to implement Tempfile without delegator. However, I’m not sure it implemeted with subclass of File.
 
@@ -63,7 +63,7 @@ File is a wrapper of fd. Tempfile is not only a wrapper but handle other informa
 
 Action: Matz will reply this issue.
 
-## \[Feature [#11218](https://bugs.ruby-lang.org/issues/11218)\] File.open FILE\_SHARE\_DELETE (naruse)
+## [[Feature #11218]](https://bugs.ruby-lang.org/issues/11218) File.open FILE\_SHARE\_DELETE (naruse)
 
 naruse: (explain about this proposal). This proposal is only for Windows.
 
@@ -85,7 +85,7 @@ naruse: I need modestr2modeint for add the new integer flag (rb\_io\_modestr\_of
 
 Action: Discuss on ticket
 
-## \[Feature [#11251](https://bugs.ruby-lang.org/issues/11251)\] pthread\_set\_name\_np (naruse)
+## [[Feature #11251]](https://bugs.ruby-lang.org/issues/11251) pthread\_set\_name\_np (naruse)
 
 ko1: Interface?
 
@@ -103,19 +103,19 @@ Action: naruse will implement it
 
 Action: reply on issue.
 
-## \[Feature [#5455](https://bugs.ruby-lang.org/issues/5455)\] $SAFE should be removed(hsbt)
+## [[Feature #5455]](https://bugs.ruby-lang.org/issues/5455) $SAFE should be removed(hsbt)
 
 matz: $2 and $3 can be removed.
 
 Action: Matz will reply on ticket. hsbt-san will try implent.
 
-## \[Feature [#10730](https://bugs.ruby-lang.org/issues/10730)\] Implement Array#bsearch\_index(hsbt)
+## [[Feature #10730]](https://bugs.ruby-lang.org/issues/10730) Implement Array#bsearch\_index(hsbt)
 
 matz: go ahead.
 
 Action: Matz will reply. nobu will merge.
 
-## \[Feature [#10017](https://bugs.ruby-lang.org/issues/10017)\] Add Hash#values\_at!(hsbt)
+## [[Feature #10017]](https://bugs.ruby-lang.org/issues/10017) Add Hash#values\_at!(hsbt)
 
 matz: approved (Hash#fetch\_values).
 

--- a/2015/DevMeeting-2015-07-28.md
+++ b/2015/DevMeeting-2015-07-28.md
@@ -101,7 +101,7 @@ Also, additional TracePoint will be introduced.
 
 Resolved.
 
-## \[Feature [#8919](https://bugs.ruby-lang.org/issues/8919)\] Queue as embedded class: please determine whether or not it should be introduced. (glass\_saga)
+## [[Feature #8919]](https://bugs.ruby-lang.org/issues/8919) Queue as embedded class: please determine whether or not it should be introduced. (glass\_saga)
 
 Matz: seems good.
 
@@ -117,6 +117,6 @@ akr: What happens on pushing/popping closed Queue?
 
 ko1: there are discussions on ticket. I’ll take it.
 
-## \[Feature [#11297](https://bugs.ruby-lang.org/issues/11297)\] Allow private method of self to be called (a\_matsuda)
+## [[Feature #11297]](https://bugs.ruby-lang.org/issues/11297) Allow private method of self to be called (a\_matsuda)
 
 Matz: seems good

--- a/2015/DevMeeting-2015-10-21.md
+++ b/2015/DevMeeting-2015-10-21.md
@@ -41,7 +41,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 # Log
 
-# Decide whether -\*- should be required for frozen\_string\_literal magic comments \[Feature [#8976](https://bugs.ruby-lang.org/issues/8976)\]
+# Decide whether -\*- should be required for frozen\_string\_literal magic comments [[Feature #8976]](https://bugs.ruby-lang.org/issues/8976)
 
 naruse: vim’s indicator is “vim: …” [http://vim.wikia.com/wiki/Modeline\_magic](http://vim.wikia.com/wiki/Modeline_magic)
 

--- a/2015/DevMeeting-2015-11-09.md
+++ b/2015/DevMeeting-2015-11-09.md
@@ -44,7 +44,7 @@ Attendees: matz, nobu, hsbt, akr, naruse, sorah, yuki, ko1
 
 2015/12/07 Mon 14:00 JST at SFDC
 
-## \[Feature [#8976](https://bugs.ruby-lang.org/issues/8976)\] file-scope freeze\_string directive
+## [[Feature #8976]](https://bugs.ruby-lang.org/issues/8976) file-scope freeze\_string directive
 
 ## freeze dynamic string literal or not?
 
@@ -91,7 +91,7 @@ Attendees: matz, nobu, hsbt, akr, naruse, sorah, yuki, ko1
 
 - We don’t need an option name if it is always enabled.
 
-## \[Feature [#4840](https://bugs.ruby-lang.org/issues/4840)\] Allow returning from require
+## [[Feature #4840]](https://bugs.ruby-lang.org/issues/4840) Allow returning from require
 
 \### Before
 
@@ -204,7 +204,7 @@ def foo
 
 end
 
-## \[Feature [#9098](https://bugs.ruby-lang.org/issues/9098)\] Indent heredoc against the left margin by default when "indented closing identifier" is turned on.
+## [[Feature #9098]](https://bugs.ruby-lang.org/issues/9098) Indent heredoc against the left margin by default when "indented closing identifier" is turned on.
 
 \# 2 spaces
 
@@ -237,7 +237,7 @@ Matz: acecptable, but there could be a problem if hard tabs and spaces are both 
 
 Nishijima-san suggested another way to write strings like DATA for each files. It will be proposed as another ticket.
 
-## \[Feature [#11643](https://bugs.ruby-lang.org/issues/11643)\] A new method on Hash to grab values out of nested hashes, failing gracefully
+## [[Feature #11643]](https://bugs.ruby-lang.org/issues/11643) A new method on Hash to grab values out of nested hashes, failing gracefully
 
 Matz: acceptable, but name is problem.
 
@@ -278,7 +278,7 @@ Nishijima-san mentioned past rejected proposals in Rails [\[1\]](https://groups.
 
 - e.g. {a: {b: {c: 1}}}.dig(:a, :b, :x) == nil (not {c: 1})
 
-## \[Feature [#11665](https://bugs.ruby-lang.org/issues/11665)\] Support nested functions for better code organization
+## [[Feature #11665]](https://bugs.ruby-lang.org/issues/11665) Support nested functions for better code organization
 
 class C
 
@@ -320,11 +320,11 @@ end
 
 - matz: commented at [https://bugs.ruby-lang.org/issues/11665#note-3](https://bugs.ruby-lang.org/issues/11665#note-3)
 
-## \[Feature [#11666](https://bugs.ruby-lang.org/issues/11666)\] IPAddr#private?
+## [[Feature #11666]](https://bugs.ruby-lang.org/issues/11666) IPAddr#private?
 
 Matz accepted this feature. Pass to knu -san (maintainer).
 
-## \[Feature [#11588](https://bugs.ruby-lang.org/issues/11588)\] Implement structured warnings
+## [[Feature #11588]](https://bugs.ruby-lang.org/issues/11588) Implement structured warnings
 
 - pros
 
@@ -344,7 +344,7 @@ Matz accepted this feature. Pass to knu -san (maintainer).
 
 - no conclusion.
 
-## \[Feature [#11653](https://bugs.ruby-lang.org/issues/11653)\] Add to\_proc on Hash
+## [[Feature #11653]](https://bugs.ruby-lang.org/issues/11653) Add to\_proc on Hash
 
 class Hash
 
@@ -368,7 +368,7 @@ Matz: acceptable
 
 Matz: to\_proc is intended for & argument operator. So it is reasonable to add.
 
-## \[Feature [#10984](https://bugs.ruby-lang.org/issues/10984)\] Hash#contain? to check whether hash contains other hash
+## [[Feature #10984]](https://bugs.ruby-lang.org/issues/10984) Hash#contain? to check whether hash contains other hash
 
 Matz: Feature is acceptable. But naming issue;
 
@@ -391,7 +391,7 @@ Method name candidates:
 
 Matz: I vote for “<”, “>”, “<=” and “>=” (no “<=>” and “===”).
 
-## \[Feature [#9108](https://bugs.ruby-lang.org/issues/9108)\]\[Feature [#8499](https://bugs.ruby-lang.org/issues/8499)\] Importing Hash#slice, Hash#slice!, Hash#except, and Hash#except! from ActiveSupport
+## [[Feature #9108]](https://bugs.ruby-lang.org/issues/9108)[[Feature #8499]](https://bugs.ruby-lang.org/issues/8499) Importing Hash#slice, Hash#slice!, Hash#except, and Hash#except! from ActiveSupport
 
 Current status: naming issue, select and reject are acceptable for Matz.
 

--- a/2016/DevMeeting-2016-01-18.md
+++ b/2016/DevMeeting-2016-01-18.md
@@ -68,7 +68,7 @@ Attendees: unak, mrkn, naruse, ayumin, ko1, sorah, zack, martin
 - Shibata-san
 - Usa-san
 
-## \[Feature [#11949](https://bugs.ruby-lang.org/issues/11949)\] Allow @/$ prefix in Regexp's named captures (naruse)
+## [[Feature #11949]](https://bugs.ruby-lang.org/issues/11949) Allow @/$ prefix in Regexp's named captures (naruse)
 
 /(?<[@timestamp](https://github.com/timestamp)\>\[^ \]\*): / =~
 
@@ -114,7 +114,7 @@ valid: > /(?<a@-あfoo>a)/.match("a")
 
 Conclusion: acceptable confusion or not. Matz is positive to accept this feature
 
-## \[Feature [#11987](https://bugs.ruby-lang.org/issues/11987)\] daemons can't show the backtrace of rb\_bug
+## [[Feature #11987]](https://bugs.ruby-lang.org/issues/11987) daemons can't show the backtrace of rb\_bug
 
 Process.daemon closes STDERR (or redirect to /dev/null).
 

--- a/2016/DevMeeting-2016-02-16.md
+++ b/2016/DevMeeting-2016-02-16.md
@@ -101,7 +101,7 @@ Members: hsbt, akr, mrkn, shyouhei, naruse, nobu, ko1, sorah, matz (skype)
 
 GitHub: web [https://github.com/ruby/www.ruby-lang.org/issues](https://github.com/ruby/www.ruby-lang.org/issues)
 
-## \[Feature [#11666](https://bugs.ruby-lang.org/issues/11666)\] IPAddr#private? (glass\_saga)
+## [[Feature #11666]](https://bugs.ruby-lang.org/issues/11666) IPAddr#private? (glass\_saga)
 
 - feature issues
 
@@ -118,7 +118,7 @@ GitHub: web [https://github.com/ruby/www.ruby-lang.org/issues](https://github.co
 
 - The name “ipv4\_private?” is clear that the method returns false on IPv6 addresses.
 
-## \[Feature [#12046](https://bugs.ruby-lang.org/issues/12046)\] Allow attr\_reader :foo? to define instance method foo? for accessing @foo (mrkn)
+## [[Feature #12046]](https://bugs.ruby-lang.org/issues/12046) Allow attr\_reader :foo? to define instance method foo? for accessing @foo (mrkn)
 
 - matz: Still negative; I’m not good to have difference in ivar name and method name
 - behavior issues:
@@ -133,7 +133,7 @@ Reported by ko1.
 
 ---
 
-## \[Feature [#11999](https://bugs.ruby-lang.org/issues/11999)\] MatchData#to\_h to get a Hash from named captures (sorah)
+## [[Feature #11999]](https://bugs.ruby-lang.org/issues/11999) MatchData#to\_h to get a Hash from named captures (sorah)
 
 - #to\_h is inappropriate name while non-named capture exists
 
@@ -157,7 +157,7 @@ Reported by ko1.
 
 - #captures return \[\] when no capture, so #named\_captures returns {} when no named capture
 
-## \[Bug [#9810](https://bugs.ruby-lang.org/issues/9810)\] Numeric#step behavior with mixed Float, String arguments inconsistent with documentation
+## [[Bug #9810]](https://bugs.ruby-lang.org/issues/9810) Numeric#step behavior with mixed Float, String arguments inconsistent with documentation
 
 This issue is because of invalid type, not mismatch the number of arguments.
 
@@ -183,18 +183,18 @@ def foo;return a: 1; end
 
 matz rejected it because return is not a method call.  Matz wants to split kwargs versus trailing-hash-arg in a long term.  He wants to distinguish them mentally.  Rocket notation is not always related to kwargs while colon notation is tightly-connected, even though it is also used in hash literals.  When it comes to a method, calling a method with keyword-argument does not always create hashes.
 
-## \[Feature [#10121](https://bugs.ruby-lang.org/issues/10121)\] Dir.empty?
+## [[Feature #10121]](https://bugs.ruby-lang.org/issues/10121) Dir.empty?
 
 - \`Dir.entries(dir).size == 2\` is not efficient.  Also not platform-agnostic.
 - It is useful to write spec which checkes test files are crrectly cleaned.
 - matz: accepted.
 
-## \[Feature [#12075](https://bugs.ruby-lang.org/issues/12075)\] some container#nonempty?
+## [[Feature #12075]](https://bugs.ruby-lang.org/issues/12075) some container#nonempty?
 
 - nobu: you can write \`ary&.empty?.!\`.
 - mrkn: How about \`ary.include\_something?\` ?
 
-## \[Feature [#12024](https://bugs.ruby-lang.org/issues/12024)\] Add String.buffer, for creating strings with large capacities
+## [[Feature #12024]](https://bugs.ruby-lang.org/issues/12024) Add String.buffer, for creating strings with large capacities
 
 akr: Once matz rejected String.new(size) proposed on [#905](https://bugs.ruby-lang.org/issues/905), but now we have kwargs. given that there already is String.new with encoding argument, isn’t it OK to add kwargs to that method?
 
@@ -202,9 +202,9 @@ matz: accepted.
 
 ---
 
-## \[Bug [#11991](https://bugs.ruby-lang.org/issues/11991)\] Symbol#match
+## [[Bug #11991]](https://bugs.ruby-lang.org/issues/11991) Symbol#match
 
-## \[Feature [#12043](https://bugs.ruby-lang.org/issues/12043)\] NoMethodError#private\_call?
+## [[Feature #12043]](https://bugs.ruby-lang.org/issues/12043) NoMethodError#private\_call?
 
 bikeshed problem (naming issue).
 

--- a/2016/DevMeeting-2016-03-16.md
+++ b/2016/DevMeeting-2016-03-16.md
@@ -115,7 +115,7 @@ Attendees: Matz, ko1, nobu, akr, naruse, mrkn, shyouhei, sorah, martin, hsbt
 
 - true/false.  -1/0/1 makes almost no sense for us.
 
-## \[Feature [#12125](https://bugs.ruby-lang.org/issues/12125)\] Proposal: Shorthand operator for Object#method (hsbt)
+## [[Feature #12125]](https://bugs.ruby-lang.org/issues/12125) Proposal: Shorthand operator for Object#method (hsbt)
 
 - (Matz) I want this. But all proposed syntax so far don’t feel right.
 
@@ -156,7 +156,7 @@ github.com/k-takata/Onigmo
 
 - Matz: maybe it’s from Python.
 
-## \[Bug [#11844](https://bugs.ruby-lang.org/issues/11844)\] Please update unicode-licensed files (license issue) (shyouhei)
+## [[Bug #11844]](https://bugs.ruby-lang.org/issues/11844) Please update unicode-licensed files (license issue) (shyouhei)
 
 - This table was from NetBSD.
 - The table is a data, not an “expression of author” that a copyright should apply.
@@ -165,7 +165,7 @@ github.com/k-takata/Onigmo
 - It seems unicode.org has version 2 of those files.
 - Lets update our copy to the latest ones.
 
-## \[Bug [#11816](https://bugs.ruby-lang.org/issues/11816)\] Partial safe navigation operator (shyouhei)
+## [[Bug #11816]](https://bugs.ruby-lang.org/issues/11816) Partial safe navigation operator (shyouhei)
 
 - (shyouhei) current status?
 
@@ -184,7 +184,7 @@ github.com/k-takata/Onigmo
 - Swift : it does
 - C# : it does
 
-## \[Feature [#12142](https://bugs.ruby-lang.org/issues/12142)\] Hash tables with open addressing (in particular, question about 32/64-bit indices) (duerst)
+## [[Feature #12142]](https://bugs.ruby-lang.org/issues/12142) Hash tables with open addressing (in particular, question about 32/64-bit indices) (duerst)
 
 - 4G entry hash is rare, but not an unrealistic thing in long term.
 - It is definitely a good thing to provide a fast alternative for 99% use case, however.
@@ -201,18 +201,18 @@ github.com/k-takata/Onigmo
 
 - Switch 16bit->32bit->64bit smoothly?
 
-## \[Feature [#12020](https://bugs.ruby-lang.org/issues/12020)\] Documenting Ruby memory model (shyouhei)
+## [[Feature #12020]](https://bugs.ruby-lang.org/issues/12020) Documenting Ruby memory model (shyouhei)
 
 - Koichi is going to dump his opinion to reply the thread.
 - (Matz) I don’t want to bother such in-detail memory
 
-## \[Bug [#12039](https://bugs.ruby-lang.org/issues/12039)\] Fixnum#infinite?/Bignum#infinite or Numeric#infinte, consistent with Float#infinite? and BigDecimal#infinite? (shyouhei)
+## [[Bug #12039]](https://bugs.ruby-lang.org/issues/12039) Fixnum#infinite?/Bignum#infinite or Numeric#infinte, consistent with Float#infinite? and BigDecimal#infinite? (shyouhei)
 
 - For about JSON, #finite? (not #infinite?) is much better because JSON also has to reject NaNs.
 - (Matz) positive.  Float <-> Integer polymorphism is a good thing.
 - Add both #finite? and #infinite?
 
-## \[Feature [#12005](https://bugs.ruby-lang.org/issues/12005)\] Unify Fixnum and Bignum into Integer (shyouhei)
+## [[Feature #12005]](https://bugs.ruby-lang.org/issues/12005) Unify Fixnum and Bignum into Integer (shyouhei)
 
 - Nobody is negative.
 - Mrkn is assigned for this
@@ -244,7 +244,7 @@ github.com/k-takata/Onigmo
 - Normal pull-request is the ideal way.
 - We have to look at actual code to judge details.
 
-## \[Feature [#12026](https://bugs.ruby-lang.org/issues/12026)\] Support warning filters (jeremyevans0)
+## [[Feature #12026]](https://bugs.ruby-lang.org/issues/12026) Support warning filters (jeremyevans0)
 
 - This is related to [https://bugs.ruby-lang.org/issues/11588](https://bugs.ruby-lang.org/issues/11588)
 - (Matz) I thought structured warning was overkill.
@@ -252,7 +252,7 @@ github.com/k-takata/Onigmo
 - (ko1) regular expression seems too shortcoming.
 - (akr) It’s not a bad idea to provide a primitive to do something on warnings.
 
-## \[Feature [#12092](https://bugs.ruby-lang.org/issues/12092)\] Allow Object#clone to yield cloned object before freezing (jeremyevans0)
+## [[Feature #12092]](https://bugs.ruby-lang.org/issues/12092) Allow Object#clone to yield cloned object before freezing (jeremyevans0)
 
 - Use case?
 - There are two ways to create a cloned object, namely #clone and #dup.  The difference is singleton classes, and frozenness.
@@ -260,7 +260,7 @@ github.com/k-takata/Onigmo
 
 - That way you have to manage all and every calls to extend
 
-## \[Feature [#12172](https://bugs.ruby-lang.org/issues/12172)\] Array#max and Array#min (mame)
+## [[Feature #12172]](https://bugs.ruby-lang.org/issues/12172) Array#max and Array#min (mame)
 
 - Nobody is against Array#max
 - (shyouhei): Why only opt\_newarray\_max?
@@ -273,81 +273,81 @@ github.com/k-takata/Onigmo
 - Koichi afraids that increase VM complexity and other people want to add other methods.
 - However, \[...\].min or .max are used CPU intensive cases. So that it is acceptable. If other techniques are invented, then Koichi will remove them.
 
-## \[Feature [#9969](https://bugs.ruby-lang.org/issues/9969)\] Add File.empty? as alias to File.zero? (shyouhei)
+## [[Feature #9969]](https://bugs.ruby-lang.org/issues/9969) Add File.empty? as alias to File.zero? (shyouhei)
 
 - (akr) File.zero? is too bad in naming.
 - Nobody is against it.
 
-## \[Bug [#12121](https://bugs.ruby-lang.org/issues/12121)\]異なる名前空間にある同名の定数により Module.constants の結果の並びが変わる (shyouhei)
+## [[Bug #12121]](https://bugs.ruby-lang.org/issues/12121)異なる名前空間にある同名の定数により Module.constants の結果の並びが変わる (shyouhei)
 
 - The reason behind this is we introduced id\_table, which does not preserve order.
 - We did not, and do not want to, warrant such thing.
 - This is a doc issue.
 
-## \[Bug [#12112](https://bugs.ruby-lang.org/issues/12112)\] Resolv.getname with IPv6 noop (shyouhei)
+## [[Bug #12112]](https://bugs.ruby-lang.org/issues/12112) Resolv.getname with IPv6 noop (shyouhei)
 
 - Assign to akr
 
-## \[Bug [#12162](https://bugs.ruby-lang.org/issues/12162)\] OpenSSL::PKCS7 seems to create broken objects (nested asn.1 error) (shyouhei)
+## [[Bug #12162]](https://bugs.ruby-lang.org/issues/12162) OpenSSL::PKCS7 seems to create broken objects (nested asn.1 error) (shyouhei)
 
 - Assign to openssl
 
-## \[Bug [#12091](https://bugs.ruby-lang.org/issues/12091)\] Freezing a SortedSet breaks Enumerable (shyouhei)
+## [[Bug #12091]](https://bugs.ruby-lang.org/issues/12091) Freezing a SortedSet breaks Enumerable (shyouhei)
 
 - Assign to knu
 
-## \[Bug [#12126](https://bugs.ruby-lang.org/issues/12126)\] \[PATCH\] openssl: accept moving write buffer for write\_nonblock (shyouhei)
+## [[Bug #12126]](https://bugs.ruby-lang.org/issues/12126) \[PATCH\] openssl: accept moving write buffer for write\_nonblock (shyouhei)
 
 - Seems ok
 
-## \[Feature [#10617](https://bugs.ruby-lang.org/issues/10617)\] Change multiple assignment in conditional from parse error to warning (shyouhei)
+## [[Feature #10617]](https://bugs.ruby-lang.org/issues/10617) Change multiple assignment in conditional from parse error to warning (shyouhei)
 
 - Koichi: i want to make it “void” expression for performance.
 
-## \[Feature [#12094](https://bugs.ruby-lang.org/issues/12094)\] parameterized property assignment: o.prop(arg) = 1 (shyouhei)
+## [[Feature #12094]](https://bugs.ruby-lang.org/issues/12094) parameterized property assignment: o.prop(arg) = 1 (shyouhei)
 
 - Nobu is going to update the current status
 
-## \[Feature [#12096](https://bugs.ruby-lang.org/issues/12096)\] New notation for instance variables and class variables (shyouhei)
+## [[Feature #12096]](https://bugs.ruby-lang.org/issues/12096) New notation for instance variables and class variables (shyouhei)
 
 - This is metaprogramming.  And having a metaprogramming in syntax is \`\`wrong’’.
 - Being able to write identical variable in different form is problematic (both for users and editors)
 
-## \[Bug [#12104](https://bugs.ruby-lang.org/issues/12104)\] Procs keyword arguments affect value of previous argument (shyouhei)
+## [[Bug #12104]](https://bugs.ruby-lang.org/issues/12104) Procs keyword arguments affect value of previous argument (shyouhei)
 
 - Ko1 will update his current opinion.
 
-## \[Bug [#12106](https://bugs.ruby-lang.org/issues/12106)\] Behavior of double splatting of hashes with non symbol key is different according to splatted hash position (shyouhei)
+## [[Bug #12106]](https://bugs.ruby-lang.org/issues/12106) Behavior of double splatting of hashes with non symbol key is different according to splatted hash position (shyouhei)
 
 - Assign to nobu.
 
-## \[Feature [#11997](https://bugs.ruby-lang.org/issues/11997)\] A method to read a file with interpolations (shyouhei)
+## [[Feature #11997]](https://bugs.ruby-lang.org/issues/11997) A method to read a file with interpolations (shyouhei)
 
 - Nobu thinks this is not that simple to do.  He will add comments about it.
 
-## \[Feature [#12116](https://bugs.ruby-lang.org/issues/12116)\] Fixnum#divmod, Bignum#divmod with multiple arguments (shyouhei)
+## [[Feature #12116]](https://bugs.ruby-lang.org/issues/12116) Fixnum#divmod, Bignum#divmod with multiple arguments (shyouhei)
 
 Good example.
 
-## \[Feature [#12119](https://bugs.ruby-lang.org/issues/12119)\] next\_prime for lib/prime.rb (shyouhei)
+## [[Feature #12119]](https://bugs.ruby-lang.org/issues/12119) next\_prime for lib/prime.rb (shyouhei)
 
 - Assign to yugui.
 
-## \[Feature [#12134](https://bugs.ruby-lang.org/issues/12134)\] Comparison between true and false (shyouhei)
+## [[Feature #12134]](https://bugs.ruby-lang.org/issues/12134) Comparison between true and false (shyouhei)
 
 - Use partition method.
 
-## \[Feature [#11547](https://bugs.ruby-lang.org/issues/11547)\] remove top-level constant lookup (shyouhei)
+## [[Feature #11547]](https://bugs.ruby-lang.org/issues/11547) remove top-level constant lookup (shyouhei)
 
 - Matz issue.
 
-## \[Misc [#12124](https://bugs.ruby-lang.org/issues/12124)\] Use Automake (shyouhei)
+## [[Misc #12124]](https://bugs.ruby-lang.org/issues/12124) Use Automake (shyouhei)
 
 - (naruse) common.mk is also used by nmake.
 - (naruse) Current patch fails CI.
 - Generally ok, but it must works with nmake.
 
-## \[Bug [#12139](https://bugs.ruby-lang.org/issues/12139)\] return OpenSSL::Random.random\_bytes(n) call takes to long. OpenSSL:: bug on windows. (naruse)
+## [[Bug #12139]](https://bugs.ruby-lang.org/issues/12139) return OpenSSL::Random.random\_bytes(n) call takes to long. OpenSSL:: bug on windows. (naruse)
 
 - (naruse) How about using Random.naw\_seed on Windows
 - (akr) ok while it doesn’t cost too much entropy.

--- a/2016/DevMeeting-2016-04-13.md
+++ b/2016/DevMeeting-2016-04-13.md
@@ -74,7 +74,7 @@ Attendees: matz, sorah, naruse, ko1, mame, kosaki, hsbt, nobu, tarui, akr, shyou
 
 venue: TBD
 
-## \[Feature [#9969](https://bugs.ruby-lang.org/issues/9969)\] Add File.empty? as alias to File.zero? (shyouhei)
+## [[Feature #9969]](https://bugs.ruby-lang.org/issues/9969) Add File.empty? as alias to File.zero? (shyouhei)
 
 (discussing about current behavior of related methods)
 
@@ -83,7 +83,7 @@ venue: TBD
 - matz: ok
 - kosaki: do you say “zero sized file”?
 
-## \[Feature [#10617](https://bugs.ruby-lang.org/issues/10617)\] Change multiple assignment in conditional from parse error to warning (shyouhei)
+## [[Feature #10617]](https://bugs.ruby-lang.org/issues/10617) Change multiple assignment in conditional from parse error to warning (shyouhei)
 
 - ko1: counter proposal. returning array can affect performance. how about to make mltiple assignment as a void expression?
 
@@ -103,70 +103,70 @@ venue: TBD
 - ko1: i can’t understand what happen on it.
 - matz: I want to use it. accept.
 
-## \[Feature [#11547](https://bugs.ruby-lang.org/issues/11547)\] remove top-level constant lookup (shyouhei)
+## [[Feature #11547]](https://bugs.ruby-lang.org/issues/11547) remove top-level constant lookup (shyouhei)
 
 - matz: lets try this to see how much codes break with it.
 
-## \[Feature [#12020](https://bugs.ruby-lang.org/issues/12020)\] Documenting Ruby memory model (shyouhei)
+## [[Feature #12020]](https://bugs.ruby-lang.org/issues/12020) Documenting Ruby memory model (shyouhei)
 
-## \[Feature [#11210](https://bugs.ruby-lang.org/issues/11210)\] IPAddr has no public method to get the current subnet mask (eregon) Who can review this?
+## [[Feature #11210]](https://bugs.ruby-lang.org/issues/11210) IPAddr has no public method to get the current subnet mask (eregon) Who can review this?
 
 - assign to knu-san
 - naruse: mentioned to knu
 
-## \[Feature [#6647](https://bugs.ruby-lang.org/issues/6647)\] Exceptions raised in threads should be logged, Thread#report\_on\_exception= (eregon) Can we agree on the feature?
+## [[Feature #6647]](https://bugs.ruby-lang.org/issues/6647) Exceptions raised in threads should be logged, Thread#report\_on\_exception= (eregon) Can we agree on the feature?
 
 Matz is positive to provide Thread#report\_on\_exception, but negative to turning it on by default.
 
-## \[Feature [#12026](https://bugs.ruby-lang.org/issues/12026)\] Support warning processor
+## [[Feature #12026]](https://bugs.ruby-lang.org/issues/12026) Support warning processor
 
 - matz: agree with customizable warning
 
 - should not use global variables
 - there are many design choise. continue to discuss
 
-## \[Feature [#12092](https://bugs.ruby-lang.org/issues/12092)\] Allow Object#clone to yield cloned object before freezing (jeremyevans0)
+## [[Feature #12092]](https://bugs.ruby-lang.org/issues/12092) Allow Object#clone to yield cloned object before freezing (jeremyevans0)
 
 ## \[Feature #[12217](https://bugs.ruby-lang.org/issues/12217)\] Introducing Enumerable#sum for precision compensated summation and revert r54237 (mrkn)
 
 - matz: Adding Array#sum is ok
 - Revert r54237 and optimization for Float
 
-## \[Bug [#12271](https://bugs.ruby-lang.org/issues/12271)\] Time#to\_time removes timezone information
+## [[Bug #12271]](https://bugs.ruby-lang.org/issues/12271) Time#to\_time removes timezone information
 
 - nobu: It is a bug, so I commited
 - yui\_knk: ActiveSupport was testing this behavior (FYI)
 
-## \[Feature [#12157](https://bugs.ruby-lang.org/issues/12157)\] Is the option hash necessary for future Rubys?
+## [[Feature #12157]](https://bugs.ruby-lang.org/issues/12157) Is the option hash necessary for future Rubys?
 
 - We have no matz for time when discussed this issue, so pend until next meeting.
 
-## \[Bug [#12181](https://bugs.ruby-lang.org/issues/12181)\] ブロックがたくさんあるファイルを編集するとruby-modeが重い
+## [[Bug #12181]](https://bugs.ruby-lang.org/issues/12181) ブロックがたくさんあるファイルを編集するとruby-modeが重い
 
 - Who can look this issue? Nobu?
 - nobu will investigate and make some action.
 
-## \[Bug [#12179](https://bugs.ruby-lang.org/issues/12179)\] Build failure due to VPATH expansion
+## [[Bug #12179]](https://bugs.ruby-lang.org/issues/12179) Build failure due to VPATH expansion
 
 - Weird. Nobu will investigate.
 
-## \[Bug [#12183](https://bugs.ruby-lang.org/issues/12183)\] require "win32ole" すると終了ステータスが必ず 0 になる
+## [[Bug #12183]](https://bugs.ruby-lang.org/issues/12183) require "win32ole" すると終了ステータスが必ず 0 になる
 
 - Assigned to appropriate maintainer.
 
-## \[Bug [#12184](https://bugs.ruby-lang.org/issues/12184)\] Cygwin LANG=ja\_JP.SJIS 環境でコマンドライン引数に日本語が渡せない
+## [[Bug #12184]](https://bugs.ruby-lang.org/issues/12184) Cygwin LANG=ja\_JP.SJIS 環境でコマンドライン引数に日本語が渡せない
 
 - nobu: Cygwin only supports UTF-8
 - nobu(?) will reply something
 
-## \[Feature [#7361](https://bugs.ruby-lang.org/issues/7361)\] Adding Pathname#touch
+## [[Feature #7361]](https://bugs.ruby-lang.org/issues/7361) Adding Pathname#touch
 
 - actually touch(1) does lot of thing. What ticket author wanted?
 - Encourage author to make feature request more solid.
 
-## \[Feature [#12236](https://bugs.ruby-lang.org/issues/12236)\] Introduce mmap managed heap (ko1)
+## [[Feature #12236]](https://bugs.ruby-lang.org/issues/12236) Introduce mmap managed heap (ko1)
 
-## \[Feature [#11925](https://bugs.ruby-lang.org/issues/11925)\] Struct construction with kwargs (ko1)
+## [[Feature #11925]](https://bugs.ruby-lang.org/issues/11925) Struct construction with kwargs (ko1)
 
 - Understood and +1 for this feature, but maybe naming is a problem
 - We also have to wait a Matz.

--- a/2016/DevMeeting-2016-05-17.md
+++ b/2016/DevMeeting-2016-05-17.md
@@ -105,7 +105,7 @@ Milestones
 - previrew 1 maybe?  Then we can call for slides.
 - conclusion: Next meeting will confirm to release preview1
 
-## \[Feature [#12324](https://bugs.ruby-lang.org/issues/12324)\] Support OpenSSL 1.1.0 (and drop support for 0.9.6/0.9.7) (hsbt) We need to get aproval of Matz
+## [[Feature #12324]](https://bugs.ruby-lang.org/issues/12324) Support OpenSSL 1.1.0 (and drop support for 0.9.6/0.9.7) (hsbt) We need to get aproval of Matz
 
 - matz: OK to give him a commit grant.
 - compatibility? is it OK to drop OpenSSL < 1.0?
@@ -115,7 +115,7 @@ Milestones
 
 - introduce ruby/openssl subproject goal and status.
 
-## \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei)
+## [[Misc #12283]](https://bugs.ruby-lang.org/issues/12283) Obsolete ChangeLog and commit message in Git-style (shyouhei)
 
 - (shyouhei) seems nobody is against.
 - (Martin) I support it.
@@ -126,11 +126,11 @@ Milestones
 - (conclusion) lets auto-generate ChangeLog, like we do in version.h.
 - nobu and naruse will look at it.
 
-## \[Feature [#12352](https://bugs.ruby-lang.org/issues/12352)\] New hash syntax broken for numeric keys (shyouhei)
+## [[Feature #12352]](https://bugs.ruby-lang.org/issues/12352) New hash syntax broken for numeric keys (shyouhei)
 
 - matz: reject.  If this syntax is allowed { 1: 2 } should be considered { :’1’ => 2 }.
 
-## \[Feature [#6647](https://bugs.ruby-lang.org/issues/6647)\] Exceptions raised in threads should be logged (shyouhei) what was the reason against defaulting true?
+## [[Feature #6647]](https://bugs.ruby-lang.org/issues/6647) Exceptions raised in threads should be logged (shyouhei) what was the reason against defaulting true?
 
 - Thread\[.#\]report\_on\_exception= is accepted
 - Matz does not want this default true, because it breaks current situations where programmer expects dead threads to silently exit.
@@ -138,7 +138,7 @@ Milestones
 
 - Threads dead before join shall report exceptions.  If that is not a desired behaviour, explicitly set false.
 
-## \[Feature [#12244](https://bugs.ruby-lang.org/issues/12244)\] Add a way to integer - integer % num (shyouhei)
+## [[Feature #12244]](https://bugs.ruby-lang.org/issues/12244) Add a way to integer - integer % num (shyouhei)
 
 - shyouhei: it’s slow.
 - ko1: you can speed this up by dispatch in Ruby, say, in prelude.
@@ -146,7 +146,7 @@ Milestones
 - matz: API OK, speed concern.
 - ko1: @naruse please show us speed comparison.
 
-## \[Feature [#12005](https://bugs.ruby-lang.org/issues/12005)\] Unify Fixnum and Bignum into Integer (naruse,mrkn,akr)
+## [[Feature #12005]](https://bugs.ruby-lang.org/issues/12005) Unify Fixnum and Bignum into Integer (naruse,mrkn,akr)
 
 - akr: there is only one problem for this: do this now, or don’t.
 - pros/cons:
@@ -156,12 +156,12 @@ Milestones
 
 - matz: let’s try.
 
-## \[Bug [#12337](https://bugs.ruby-lang.org/issues/12337)\] inconsistency between Fixnum#coerce and Bignum#coerce (akr)
+## [[Bug #12337]](https://bugs.ruby-lang.org/issues/12337) inconsistency between Fixnum#coerce and Bignum#coerce (akr)
 
 - Matz: TypeError was an intended behavior, to prevent data loss.  So no need to backport this behaviour to previous releases.
 - But as we try Fixnunm/Bignum unification, things gets much simpler.
 
-## \[Feature [#10548](https://bugs.ruby-lang.org/issues/10548)\] remove callcc (hsbt)
+## [[Feature #10548]](https://bugs.ruby-lang.org/issues/10548) remove callcc (hsbt)
 
 - hsbt: current status?
 - ko1: we historically tried callcc but was not successful.  The intension of this issue is we wish to treat callcc-related issues to be 3rd-party issue.
@@ -176,16 +176,16 @@ Milestones
 - hsbt: will look for a way to prevent assignment.
 - Yui changed all “Assignee: ruby-core” to “Assignee: nobody” with a global operation. Thanks! But this doesn’t yet prevent future assignments.
 
-## \[Feature [#12263](https://bugs.ruby-lang.org/issues/12263)\] Feature request: &&. operator (shorthand for foo && foo.method) (shyouhei)
+## [[Feature #12263]](https://bugs.ruby-lang.org/issues/12263) Feature request: &&. operator (shorthand for foo && foo.method) (shyouhei)
 
 - matz: example seems illustrative.  any real-world use-case?
 
-## \[Bug [#4388](https://bugs.ruby-lang.org/issues/4388)\] open-uriで環境変数http\_proxyを使うときに認証付きのProxyが使えません
+## [[Bug #4388]](https://bugs.ruby-lang.org/issues/4388) open-uriで環境変数http\_proxyを使うときに認証付きのProxyが使えません
 
 - akr: hsbt already introduced this at r54432.
 - lets ask if trunk is ok.
 
-## \[Feature [#5899](https://bugs.ruby-lang.org/issues/5899)\] chaining comparisons
+## [[Feature #5899]](https://bugs.ruby-lang.org/issues/5899) chaining comparisons
 
 - Hmm.
 - This is about language design.  Matz should decide.
@@ -196,21 +196,21 @@ Milestones
 
 - Matz: doesn’t sould yummy.
 
-## \[Feature [#12157](https://bugs.ruby-lang.org/issues/12157)\] Is the option hash necessary for future Rubys? (shyouhei)
+## [[Feature #12157]](https://bugs.ruby-lang.org/issues/12157) Is the option hash necessary for future Rubys? (shyouhei)
 
 - Matz: positive.  It is good in long term
 - akr: migration path?
 
 - warning when a kwargs-called method receives that in option hash.
 
-## \[Feature [#11925](https://bugs.ruby-lang.org/issues/11925)\] Struct construction with kwargs (ko1)
+## [[Feature #11925]](https://bugs.ruby-lang.org/issues/11925) Struct construction with kwargs (ko1)
 
 - convenient, but is #create an appropriate name?
 - no one is against? (except naming)
 - nobu: Hash#to\_struct(klass)
 - create! doesnt follow naming convention.
 
-## \[Feature [#6739](https://bugs.ruby-lang.org/issues/6739)\] One-line rescue statement should support specifying an exception class
+## [[Feature #6739]](https://bugs.ruby-lang.org/issues/6739) One-line rescue statement should support specifying an exception class
 
 - no good syntax so far.
 - nobu: all the proposed syntax, except for rescue when, generated syntx conflicts.
@@ -218,18 +218,18 @@ Milestones
 - naruse: practical use case is io.close rescue nil
 - mrkn: another real world application is if expr resuce false
 
-## \[Feature [#7314](https://bugs.ruby-lang.org/issues/7314)\] Convert Proc to Lambda doesn't work in MRI
+## [[Feature #7314]](https://bugs.ruby-lang.org/issues/7314) Convert Proc to Lambda doesn't work in MRI
 
 - The current behaviour is not “unpredictable” in a sense.
 
-## \[Feature [#8895](https://bugs.ruby-lang.org/issues/8895)\] Destructuring Assignment for Hash
+## [[Feature #8895]](https://bugs.ruby-lang.org/issues/8895) Destructuring Assignment for Hash
 
 - ko1: elixir does this.
 - shyouhei: maybe 99% use case of hash destruction was already solved by kwargs?
 - akr: the OP propses use case with MatchData.
 - matz: reject this specific one
 
-## \[Bug [#10708](https://bugs.ruby-lang.org/issues/10708)\] In a function call, double splat of an empty hash still calls the function with an argument
+## [[Bug #10708]](https://bugs.ruby-lang.org/issues/10708) In a function call, double splat of an empty hash still calls the function with an argument
 
 - This is a side-effect of optional hash argument treatment.
 - akr: this should be fixed by abondoning optional hash.
@@ -248,7 +248,7 @@ Milestones
 - naruse: script encoding doesn’t work well if the code uses variables.
 - naruse will think about it a bit more.
 
-## \[Feature [#12306](https://bugs.ruby-lang.org/issues/12306)\] Object/String#blank (duerst)
+## [[Feature #12306]](https://bugs.ruby-lang.org/issues/12306) Object/String#blank (duerst)
 
 - akr: regexp match without object allocation can be an alternative. (see #[8110](https://bugs.ruby-lang.org/issues/8110))
 - akr: How about the name Regexp#match?(str)
@@ -256,13 +256,13 @@ Milestones
 - naruse will write an implementation
 - matz isn’t very positive, but may be okay for String only (for other classes, this will remain the responsibility of Rails)
 
-## \[Feature [#8110](https://bugs.ruby-lang.org/issues/8110)\] Regex methods not changing global variables (akr)
+## [[Feature #8110]](https://bugs.ruby-lang.org/issues/8110) Regex methods not changing global variables (akr)
 
 - matz: approved.
 - implementation is very easy
 - name: “match?” ?
 
-## \[Feature [#12075](https://bugs.ruby-lang.org/issues/12075)\] some container#nonempty? (naruse)
+## [[Feature #12075]](https://bugs.ruby-lang.org/issues/12075) some container#nonempty? (naruse)
 
 - matz: I want this in ActiveSupport.
 - matz: Enumerable#any? seems useful.
@@ -278,7 +278,7 @@ Milestones
 
 - matz: OK.
 
-## \[Feature [#12357](https://bugs.ruby-lang.org/issues/12357)\] Random#initialize with a String (nobu)
+## [[Feature #12357]](https://bugs.ruby-lang.org/issues/12357) Random#initialize with a String (nobu)
 
 - akr: you can pass bignum to Random.new\_seed
 - naruse: bignum is not useful when people port code from different languages e.g. python
@@ -294,7 +294,7 @@ Milestones
 - nobu: I intend MT and
 - akr: how about split utility methods into a module
 
-## \[Feature [#11735](https://bugs.ruby-lang.org/issues/11735)\] String#squish and String#squish!
+## [[Feature #11735]](https://bugs.ruby-lang.org/issues/11735) String#squish and String#squish!
 
 - shyouhei: useful when writing a long SQL
 - nobu: is this unicode aware?

--- a/2016/DevMeeting-2016-06-13.md
+++ b/2016/DevMeeting-2016-06-13.md
@@ -106,7 +106,7 @@ This release doesn’t prevent further big changes for Ruby 2.4.
 
 (This release is different from an usual preview1 (even more ‘previewy’))
 
-## \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
+## [[Misc #12283]](https://bugs.ruby-lang.org/issues/12283) Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 
 Any progress? → Nothing
 
@@ -129,7 +129,7 @@ A: Use empty commit.
 - Try this service.
 - Should we decide whether reports are eligible for bounty?
 
-## \[Feature [#12333](https://bugs.ruby-lang.org/issues/12333)\] String#concat, Array#concat, String#prepend to take multiple arguments (shyouhei)
+## [[Feature #12333]](https://bugs.ruby-lang.org/issues/12333) String#concat, Array#concat, String#prepend to take multiple arguments (shyouhei)
 
 matz: acceptable
 
@@ -160,16 +160,16 @@ ary.delete(:a, :f, :c) #=> ???
 - x, y, z = ary.delete(:a, :f, :c)
 - Especially for Hash#delete (this is out of scope, but we should consier consistency)
 
-## \[Bug [#12295](https://bugs.ruby-lang.org/issues/12295)\] Ripper not emitting on\_parse\_error for global variable name syntax errors (shyouhei) is this the right design?
+## [[Bug #12295]](https://bugs.ruby-lang.org/issues/12295) Ripper not emitting on\_parse\_error for global variable name syntax errors (shyouhei) is this the right design?
 
 Assigned to Minero Aoki.
 
-## \[Feature [#12484](https://bugs.ruby-lang.org/issues/12484)\] Optimizing Rational (hsbt, mrkn)
+## [[Feature #12484]](https://bugs.ruby-lang.org/issues/12484) Optimizing Rational (hsbt, mrkn)
 
 - matz approved to add commit permission to Tadashi-san.
 - mrkn will reivew the proposed patch
 
-## \[Feature [#12281](https://bugs.ruby-lang.org/issues/12281)\] Allow lexically scoped use of refinements with using {} block syntax (shyouhei)
+## [[Feature #12281]](https://bugs.ruby-lang.org/issues/12281) Allow lexically scoped use of refinements with using {} block syntax (shyouhei)
 
 Assigned to shugo.
 
@@ -181,7 +181,7 @@ Motivation is replace self and using context.
 
 Matz will comment it.
 
-## \[Feature [#12447](https://bugs.ruby-lang.org/issues/12447)\] Integer#digits for extracting digits of place-value notation in any base (mrkn)
+## [[Feature #12447]](https://bugs.ruby-lang.org/issues/12447) Integer#digits for extracting digits of place-value notation in any base (mrkn)
 
 - Q. Endian? #=> Little endian
 - Q. how about negative integers? #=> Math::DomainError
@@ -189,7 +189,7 @@ Matz will comment it.
 
 matz: i’m not sure how it is convinience. but ok.
 
-## \[Feature [#12299](https://bugs.ruby-lang.org/issues/12299)\] Add Warning module for customized warning handling (jeremyevans)
+## [[Feature #12299]](https://bugs.ruby-lang.org/issues/12299) Add Warning module for customized warning handling (jeremyevans)
 
 naruse: it sounds useful with Gem.loaded\_specs\[ gem\_name \].full\_gem\_path.
 
@@ -199,7 +199,7 @@ matz: ok (except naming).
 
 h[ttps://bugs.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms) says it’s for Ruby 1.9; needs some updating.
 
-## \[Feature [#12460](https://bugs.ruby-lang.org/issues/12460)\] Make Unicode Version directly available in Ruby (duerst)
+## [[Feature #12460]](https://bugs.ruby-lang.org/issues/12460) Make Unicode Version directly available in Ruby (duerst)
 
 Approved; name as proposed by Nobu: RbConfig::CONFIG\['UNICODE\_VERSION'\]; implementation: Nobu or Martin.
 
@@ -207,7 +207,7 @@ Approved; name as proposed by Nobu: RbConfig::CONFIG\['UNICODE\_VERSION'\]; impl
 
 See [https://github.com/rdoc/rdoc/issues/409](https://github.com/rdoc/rdoc/issues/409). Intent is understandable. May work by just using &#(x)... HTML/XML convention; needs to be checked further.
 
-## \[Bug [#12427](https://bugs.ruby-lang.org/issues/12427)\] the way that extension libraries know if Integer is integrated (nobu)
+## [[Bug #12427]](https://bugs.ruby-lang.org/issues/12427) the way that extension libraries know if Integer is integrated (nobu)
 
 Nobu prepared a patch to show warning for rb\_cFixnum and rb\_cBignum, so developers can recognize this change. However, there are risks to compile broken code (assume passed parameters are Fixnum, but passed BIgnums. In this case, it is difficult to check Fixnum asusmed methods because Bignum may be rare to use, in general).
 

--- a/2016/DevMeeting-2016-07-19.md
+++ b/2016/DevMeeting-2016-07-19.md
@@ -146,72 +146,72 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 
 - ToDo
 
-- \[Feature [#8526](https://bugs.ruby-lang.org/issues/8526)\] gemify tk (hsbt)
+- [[Feature #8526]](https://bugs.ruby-lang.org/issues/8526) gemify tk (hsbt)
 
 ## Carry-over from previous meeting(s)
 
-- \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
+- [[Misc #12283]](https://bugs.ruby-lang.org/issues/12283) Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 
 - naruse: no progress.
 - Martin: PLEASE DO!
 
-- \[Feature [#12299](https://bugs.ruby-lang.org/issues/12299)\] Add Warning module for customized warning handling (jeremyevans)
+- [[Feature #12299]](https://bugs.ruby-lang.org/issues/12299) Add Warning module for customized warning handling (jeremyevans)
 
 - no progress this month.
 - \---- update: read again.
 - matz: I read the new patch. the implementation seems fine (not sure about the constant name, but the clear separation between core and lib is good).  Is Daniel OK wih this?  I don’t have strong negative feeling to it.
 
-- \[Feature [#12300](https://bugs.ruby-lang.org/issues/12300)\] Allow Object#clone to take freeze: false keyword argument to not freeze the clone (jeremyevans)
+- [[Feature #12300]](https://bugs.ruby-lang.org/issues/12300) Allow Object#clone to take freeze: false keyword argument to not freeze the clone (jeremyevans)
 
 - shyouhei: no objection.
 - nobu: me too.
 - akr: this one is preferrable over [#12092](https://bugs.ruby-lang.org/issues/12092)
 - matz: sounds reasonable.
 
-- \[Feature [#11090](https://bugs.ruby-lang.org/issues/11090)\] Enumerable#each\_uniq and #each\_uniq\_by (shyouhei)
+- [[Feature #11090]](https://bugs.ruby-lang.org/issues/11090) Enumerable#each\_uniq and #each\_uniq\_by (shyouhei)
 
 - akr: the definition of uniq is not clear here.
 - Martin: where is the difference between each\_uniq and each.uniq ?
 - mrkn: Enumerable has no #uniq now.  Isn’t this a problem?
 - matz: Enumerable#uniq sounds reasonable, also Lasy#uniq.
 
-- \[Feature [#12275](https://bugs.ruby-lang.org/issues/12275)\] String unescape (shyouhei) lets limit the scope to "invert #dump's effect"
+- [[Feature #12275]](https://bugs.ruby-lang.org/issues/12275) String unescape (shyouhei) lets limit the scope to "invert #dump's effect"
 
 - akr: thing like this is a good thing to have.
 - Martin: is there a in-core routine to do this already?
 - naruse: no.
 - akr: name? why not undump ?
 
-- \[Feature [#12345](https://bugs.ruby-lang.org/issues/12345)\] A module's private constants are given with Module#constant(false) (shyouhei) intended behaviour?
+- [[Feature #12345]](https://bugs.ruby-lang.org/issues/12345) A module's private constants are given with Module#constant(false) (shyouhei) intended behaviour?
 
 - shyouhei: is this a bug?
 - matz: yes.
 
-- \[Feature [#12138](https://bugs.ruby-lang.org/issues/12138)\] Support Kernel#load\_with\_env (shyouhei)
+- [[Feature #12138]](https://bugs.ruby-lang.org/issues/12138) Support Kernel#load\_with\_env (shyouhei)
 
 - shyouhei: I understand the needs of such feature, but not this name.
 - ko1: maybe the OP wants C’s #include<...> like token pasting?
 - matz: this name is NG, the passed context info is not sure, and use case?
 
-- \[Feature [#12334](https://bugs.ruby-lang.org/issues/12334)\] Final/Readonly Support for Fields / Instance Variables (shyouhei)
+- [[Feature #12334]](https://bugs.ruby-lang.org/issues/12334) Final/Readonly Support for Fields / Instance Variables (shyouhei)
 
 - shyouhei: in fact it enables some sort of optimizations
 - ko1: we should focus to the feature as a language, not implementation.
 
-- \[Feature [#12350](https://bugs.ruby-lang.org/issues/12350)\] Introduce Array#find! that raises an error if element not found (shyouhei)
+- [[Feature #12350]](https://bugs.ruby-lang.org/issues/12350) Introduce Array#find! that raises an error if element not found (shyouhei)
 
 - naruse: why not fetch ?
 - akr: find and fetch are different in a way they are called.
 - matz: open to such feature but find! naming is wrong.
 
-- \[Feature [#12360](https://bugs.ruby-lang.org/issues/12360)\] More useful return values from bang methods (shyouhei)
+- [[Feature #12360]](https://bugs.ruby-lang.org/issues/12360) More useful return values from bang methods (shyouhei)
 
 - matz: returning nil for bang methods are intentional; wanted to forbid method chain for bang methods.
 - akr: is it more “useful”? Enough to break backwards compat?
 
 ## From attendees
 
-- \[Misc [#12529](https://bugs.ruby-lang.org/issues/12529)\] LEGAL file covering all the license information within Ruby (shyouhei)
+- [[Misc #12529]](https://bugs.ruby-lang.org/issues/12529) LEGAL file covering all the license information within Ruby (shyouhei)
 
 - Martin: Unicode-related files needs updates.  For other files, the LEGAL file should be updated.
 
@@ -219,19 +219,19 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 
 - hsbt: I’ll take care.
 
-- \[Feature [#8526](https://bugs.ruby-lang.org/issues/8526)\] gemify tk (hsbt)
+- [[Feature #8526]](https://bugs.ruby-lang.org/issues/8526) gemify tk (hsbt)
 
 - shyouhei: is there any contra?
 - akr: what about「let us tentatively gemify; please revert if there is any problem」
 
-- \[Feature [#3187](https://bugs.ruby-lang.org/issues/3187)\] Allow dynamic Fiber stack size (shyouhei)
+- [[Feature #3187]](https://bugs.ruby-lang.org/issues/3187) Allow dynamic Fiber stack size (shyouhei)
 
 - ko1: it seems they implemented Thread.new(stack\_size: nnn)
 - matz: but it’s Fiber.
 - ko1: yes but Fiber and Thread are API-compatible now.  Should we break it?
 - matz: I prefer Rubinius way (Fiber.new to eat the kwarg).
 
-- \[Feature [#12543](https://bugs.ruby-lang.org/issues/12543)\] explicit tail call syntax: foo() then return (shyouhei)
+- [[Feature #12543]](https://bugs.ruby-lang.org/issues/12543) explicit tail call syntax: foo() then return (shyouhei)
 
 - naruse: why not tail call by deault?
 - akr: ruby -O0 to disable tail call?
@@ -241,16 +241,16 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - matz: I can accept tail call as transparent optimization but should we encourage such thing?
 - Martin: is there any language where one have to explicitly state “this is a tail call”?
 
-- \[Feature [#11813](https://bugs.ruby-lang.org/issues/11813)\] Extend safe navigation operator for \[\] and \[\]= with syntax sugar (shyouhei)
+- [[Feature #11813]](https://bugs.ruby-lang.org/issues/11813) Extend safe navigation operator for \[\] and \[\]= with syntax sugar (shyouhei)
 
 - rejected
 
-- \[Feature [#12589](https://bugs.ruby-lang.org/issues/12589)\] VM performance improvement proposal (shyouhei)
+- [[Feature #12589]](https://bugs.ruby-lang.org/issues/12589) VM performance improvement proposal (shyouhei)
 
 - ko1: Shouldn’t we call him?
 - matz: RA might be able to grant.
 
-- \[Feature [#12481](https://bugs.ruby-lang.org/issues/12481)\] Add Array#view to allow opt-in copy-on-write sharing of Array contents (shyouhei)
+- [[Feature #12481]](https://bugs.ruby-lang.org/issues/12481) Add Array#view to allow opt-in copy-on-write sharing of Array contents (shyouhei)
 
 - matz: why Array.new(0) then view?  Why not ary1.view…
 - nurse: possible use case might be Array#each\_cons(3) and such.
@@ -259,26 +259,26 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - nobu: should this be mutatable?
 - mrkn: seems not because of the subject’s containing “CoW”.
 
-- \[Feature [#12057](https://bugs.ruby-lang.org/issues/12057)\] Allow methods with yield to be called without a block (shyouhei)
+- [[Feature #12057]](https://bugs.ruby-lang.org/issues/12057) Allow methods with yield to be called without a block (shyouhei)
 
 - akr: we already have Enumerator.
 - akr: maybe this is automation of enum\_for(\_\_method\_\_) unless block\_given?
 
-- \[Feature [#12297](https://bugs.ruby-lang.org/issues/12297)\] Ruby stdlib date can parse non-existent date with year 0 (shyouhei)
+- [[Feature #12297]](https://bugs.ruby-lang.org/issues/12297) Ruby stdlib date can parse non-existent date with year 0 (shyouhei)
 
 - Wasn't this intentional? cf [https://en.wikipedia.org/wiki/0\_(year)](https://en.wikipedia.org/wiki/0_(year))
 - [http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/10241](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/10241)
 
-- \[Feature [#12461](https://bugs.ruby-lang.org/issues/12461)\] Hash & keys to make subset. (shyouhei)
+- [[Feature #12461]](https://bugs.ruby-lang.org/issues/12461) Hash & keys to make subset. (shyouhei)
 
 - https://bugs.ruby-lang.org/issues/8499
 
-- \[Feature [#12515](https://bugs.ruby-lang.org/issues/12515)\] Create "Boolean" superclass of TrueClass / FalseClass (shyouhei)
+- [[Feature #12515]](https://bugs.ruby-lang.org/issues/12515) Create "Boolean" superclass of TrueClass / FalseClass (shyouhei)
 
 - hmm…
 - akr: what’s useful with this?
 
-- \[Feature [#12512](https://bugs.ruby-lang.org/issues/12512)\] Import Hash#transform\_values and its destructive version from ActiveSupport (shyouhei, mrkn)
+- [[Feature #12512]](https://bugs.ruby-lang.org/issues/12512) Import Hash#transform\_values and its destructive version from ActiveSupport (shyouhei, mrkn)
 
 - shyouhei: no one is against the feature itself but name.
 - akr: should this yield what? → it seems values only.
@@ -287,7 +287,7 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - matz: the naming doesn’t charm me.
 - akr: what about #map\_v?
 
-- \[Feature [#10208](https://bugs.ruby-lang.org/issues/10208)\] Passing block to Enumerable#to\_h (shyouhei)
+- [[Feature #10208]](https://bugs.ruby-lang.org/issues/10208) Passing block to Enumerable#to\_h (shyouhei)
 
 - matz: I don’t like the name.
 - shyouhei: knu proposes #to\_h again.
@@ -295,31 +295,31 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - ko1: what about collect\_\*?
 - matz: collect implies Array because it collects something.
 
-- \[Feature [#11741](https://bugs.ruby-lang.org/issues/11741)\] Migrate Ruby to Git from Subversion (shyouhei) Situation?
+- [[Feature #11741]](https://bugs.ruby-lang.org/issues/11741) Migrate Ruby to Git from Subversion (shyouhei) Situation?
 
 - not updated.
 
-- \[Feature [#12463](https://bugs.ruby-lang.org/issues/12463)\] ruby lacks plus-plus (shyouhei)
+- [[Feature #12463]](https://bugs.ruby-lang.org/issues/12463) ruby lacks plus-plus (shyouhei)
 
 - shyouhei: explained.
 - ko1 is going to comment
 
-- \[Feature [#12455](https://bugs.ruby-lang.org/issues/12455)\] Add a way for class String to determine whether it has only numbers / digits or not (shyouhei)
+- [[Feature #12455]](https://bugs.ruby-lang.org/issues/12455) Add a way for class String to determine whether it has only numbers / digits or not (shyouhei)
 
 - nobu: use case?
 - zzak: there is no constructor method that takes arguments like this.
 
-- \[Bug [#12577](https://bugs.ruby-lang.org/issues/12577)\] Is '$' punctuation or not? Inconsistency between us-ascii and UTF-8 (duerst)
+- [[Bug #12577]](https://bugs.ruby-lang.org/issues/12577) Is '$' punctuation or not? Inconsistency between us-ascii and UTF-8 (duerst)
 
 - naruse: this is the difference between POSIX’s ispunct(3) and Unicode’s definition.
 - Matz: we can do nothing to it.  This is a matter of Unicode consortium versus POSIX group.
 - cf: [http://pubs.opengroup.org/onlinepubs/9699919799/functions/ispunct.html](http://pubs.opengroup.org/onlinepubs/9699919799/functions/ispunct.html)
 
-- \[Feature [#12546](https://bugs.ruby-lang.org/issues/12546)\] Remove UnicodeNormalize::UNICODE\_VERSION (duerst)
+- [[Feature #12546]](https://bugs.ruby-lang.org/issues/12546) Remove UnicodeNormalize::UNICODE\_VERSION (duerst)
 
 - Matz: OK.
 
-- \[Bug [#12547](https://bugs.ruby-lang.org/issues/12547)\] Remove ONIG\_UNICODE\_VERSION\_... in enc/unicode/case-folding.rb, casefold.h (duerst)
+- [[Bug #12547]](https://bugs.ruby-lang.org/issues/12547) Remove ONIG\_UNICODE\_VERSION\_... in enc/unicode/case-folding.rb, casefold.h (duerst)
 
 - Martin: why is it?
 - nobu: I’d like to check unicode version of each generated file.
@@ -327,30 +327,30 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - Martin: why the C constant everywhere?
 - nobu: we should check in-core Unicode version in enc/unicode.o and lib/unicode\_normalize propagated from common.mk (or command line) each other.
 
-- \[Bug [#12597](https://bugs.ruby-lang.org/issues/12597)\] Produce test failure if some tests cannot be executed due to lacking data (duerst)
+- [[Bug #12597]](https://bugs.ruby-lang.org/issues/12597) Produce test failure if some tests cannot be executed due to lacking data (duerst)
 
 - nobu: this should be skip instead, not failure.
 - akr: skip is silently discarded so not helpful.
 - nobu: false. skip says something when it has message argument.
 
-- \[Feature [#12386](https://bugs.ruby-lang.org/issues/12386)\] Move definition of ONIG\_CASE\_MAPPING compilation switch outside onigumo files (duerst)
+- [[Feature #12386]](https://bugs.ruby-lang.org/issues/12386) Move definition of ONIG\_CASE\_MAPPING compilation switch outside onigumo files (duerst)
 
 - Martin: I’d like to ask nobu where is a proper place to define this macro.
 - naruse: you can simply delete this #ifdef.  This part is ruby-specitic.
 
-- \[Feature [#12578](https://bugs.ruby-lang.org/issues/12578)\] Instance Variables Assigned In parameters ( ala Crystal? ) (duerst)
+- [[Feature #12578]](https://bugs.ruby-lang.org/issues/12578) Instance Variables Assigned In parameters ( ala Crystal? ) (duerst)
 
 - nobu: instance variables only? what about global variables?
 - mrkn: block variable also?
 - matz: I’m negative.
 
-- \[Feature [#12419](https://bugs.ruby-lang.org/issues/12419)\] Improve String#dump for Unicode output (from "\\u{130}" to "\\u0130") (duerst)
+- [[Feature #12419]](https://bugs.ruby-lang.org/issues/12419) Improve String#dump for Unicode output (from "\\u{130}" to "\\u0130") (duerst)
 
 - Matz: accepted
 
 ## From non-attendees
 
-- \[Feature [#12086](https://bugs.ruby-lang.org/issues/12086)\] using: option for instance\_eval etc. (shugo)
+- [[Feature #12086]](https://bugs.ruby-lang.org/issues/12086) using: option for instance\_eval etc. (shugo)
 
 - Can I commit it?
 - matz: Charles Nutter must be consulted before committing this.

--- a/2016/DevMeeting-2016-08-09.md
+++ b/2016/DevMeeting-2016-08-09.md
@@ -140,16 +140,16 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 
 ## Carry-over from previous meeting(s)
 
-- \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
+- [[Misc #12283]](https://bugs.ruby-lang.org/issues/12283) Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 
 - naruse: no progress
 
-- \[Bug [#12466](https://bugs.ruby-lang.org/issues/12466)\] Enumerable should yield multiple values when possible (shyouhei)
+- [[Bug #12466]](https://bugs.ruby-lang.org/issues/12466) Enumerable should yield multiple values when possible (shyouhei)
 
 - nobu: not easy
 - Matz: reject
 
-- \[Bug [#12402](https://bugs.ruby-lang.org/issues/12402)\] Inline rescue behavior inconsistent for method calls with arguments and assignment (shyouhei)
+- [[Bug #12402]](https://bugs.ruby-lang.org/issues/12402) Inline rescue behavior inconsistent for method calls with arguments and assignment (shyouhei)
 
 - ko1: var1 is surprising.
 - nobu: it is interpreted as “(var1 = Date.parse var1) rescue nil”
@@ -158,28 +158,28 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - nobu: What happens when you combine rescue\_mod with massign?
 - assigning to nobu.
 
-- \[Bug [#12489](https://bugs.ruby-lang.org/issues/12489)\] hppa problems on Debian GNU/Linux (shyouhei) who to look at it?
+- [[Bug #12489]](https://bugs.ruby-lang.org/issues/12489) hppa problems on Debian GNU/Linux (shyouhei) who to look at it?
 
 - nobu: it’s hard to track without actual environment.
 - naruse: make it feedback with no assignee.
 - nobu: the fail log lacks C level backtrace.
 
-- \[Bug [#12497](https://bugs.ruby-lang.org/issues/12497)\] GMP version of divmod may be slower(shyouhei)
+- [[Bug #12497]](https://bugs.ruby-lang.org/issues/12497) GMP version of divmod may be slower(shyouhei)
 
 - assign akr
 
-- \[Feature [#12490](https://bugs.ruby-lang.org/issues/12490)\] Remove warning on shadowing block params(shyouhei)
+- [[Feature #12490]](https://bugs.ruby-lang.org/issues/12490) Remove warning on shadowing block params(shyouhei)
 
 - naruse: negative.  shadowing itself is a bad idea and should be warned.
 - Matz: reject.
 
-- \[Feature [#3511](https://bugs.ruby-lang.org/issues/3511)\] rb\_path\_to\_class should call custom const\_defined? methods (shyouhei)
+- [[Feature #3511]](https://bugs.ruby-lang.org/issues/3511) rb\_path\_to\_class should call custom const\_defined? methods (shyouhei)
 
 - akr: this is dangerous to implement.
 - ko1: is this backward compatible? akr: it seems.
 - Matz: It seems it hurts than it gains.
 
-- \[Feature [#12508](https://bugs.ruby-lang.org/issues/12508)\] Integer#mod\_pow(shyouhei)
+- [[Feature #12508]](https://bugs.ruby-lang.org/issues/12508) Integer#mod\_pow(shyouhei)
 
 - Matz: 2-argument version of pow is seen in other language (e.g. python)
 - akr: there is no pow method in Ruby sadly
@@ -191,26 +191,26 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - mrkn: Julia has powermod [http://docs.julialang.org/en/latest/stdlib/math/#Base.powermod](http://docs.julialang.org/en/latest/stdlib/math/#Base.powermod)
 - Matz: accept Integer#pow
 
-- \[Feature [#12521](https://bugs.ruby-lang.org/issues/12521)\] Syntax for retrieving argument without removing it from double-splat catch-all(shyouhei)
+- [[Feature #12521]](https://bugs.ruby-lang.org/issues/12521) Syntax for retrieving argument without removing it from double-splat catch-all(shyouhei)
 
 - Matz: what’s good with it?  compared to taking everything with \*\*arg.
 
-- \[Feature [#11195](https://bugs.ruby-lang.org/issues/11195)\] Add "no\_proxy" parameter to Net::HTTP.new (shyouhei)
+- [[Feature #11195]](https://bugs.ruby-lang.org/issues/11195) Add "no\_proxy" parameter to Net::HTTP.new (shyouhei)
 
 - shyouhei: would like to assign this to someone.
 - akr: what about requesting a patch
 
-- \[Feature [#12142](https://bugs.ruby-lang.org/issues/12142)\] Hash tables with open addressing (shyouhei) merge?
+- [[Feature #12142]](https://bugs.ruby-lang.org/issues/12142) Hash tables with open addressing (shyouhei) merge?
 
 - ko1: evaluation undergoing.
 
-- \[Feature [#12586](https://bugs.ruby-lang.org/issues/12586)\] Hash#sample (shyouhei)
+- [[Feature #12586]](https://bugs.ruby-lang.org/issues/12586) Hash#sample (shyouhei)
 
 - mrkn: use case?
 - naruse: doesn’t hash\[hash.keys.sample\] make sense?
 - mrkn: I want to see a real-world use case.  Is there a need of to\_h?
 
-- \[Feature [#12553](https://bugs.ruby-lang.org/issues/12553)\] IO.readlines(filename, chomp: true) (shyouhei)
+- [[Feature #12553]](https://bugs.ruby-lang.org/issues/12553) IO.readlines(filename, chomp: true) (shyouhei)
 
 - shyouhei: should how the “chomp” work?  Does this work with $/ ?
 - mrkn: readlines itself takes argument to reflect $/
@@ -219,7 +219,7 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - naruse: IO.readlines, IO.foreach, IO#each\_line
 - Matz: accept for those three
 
-- \[Bug [#12548](https://bugs.ruby-lang.org/issues/12548)\] Rounding modes inconsistency between round versus sprintf (shyouhei) maybe round(mode: "even") or something like that?
+- [[Bug #12548]](https://bugs.ruby-lang.org/issues/12548) Rounding modes inconsistency between round versus sprintf (shyouhei) maybe round(mode: "even") or something like that?
 
 - shyouhei: should we “fix” this by modifying #round to be banker’s tie-break, or to add mode to it?
 - akr: I prefer banker’s round
@@ -227,64 +227,64 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - Matz: I have never needed to specify rounding mode
 - conclusion: change default rounding mode to even.
 
-- \[Feature [#12596](https://bugs.ruby-lang.org/issues/12596)\] Add Pathname#empty? to be consistent with Dir.empty? and File.empty? (shyouhei)
-- \[Feature [#12573](https://bugs.ruby-lang.org/issues/12573)\] Introduce a straightforward way to discover whether a process is running (nobu)
+- [[Feature #12596]](https://bugs.ruby-lang.org/issues/12596) Add Pathname#empty? to be consistent with Dir.empty? and File.empty? (shyouhei)
+- [[Feature #12573]](https://bugs.ruby-lang.org/issues/12573) Introduce a straightforward way to discover whether a process is running (nobu)
 
 - Matz : I undertand the mood but it seems not useful
 
-- \[Bug [#9569](https://bugs.ruby-lang.org/issues/9569)\] SecureRandom should try /dev/urandom first (shyouhei) I'd like to hear other opinions.
-- \[Feature [#7882](https://bugs.ruby-lang.org/issues/7882)\] Allow rescue/else/ensure in do..end
+- [[Bug #9569]](https://bugs.ruby-lang.org/issues/9569) SecureRandom should try /dev/urandom first (shyouhei) I'd like to hear other opinions.
+- [[Feature #7882]](https://bugs.ruby-lang.org/issues/7882) Allow rescue/else/ensure in do..end
 
 - matz: will respond
 
 ## From attendees
 
-- \[Feature [#11818](https://bugs.ruby-lang.org/issues/11818)\] Hash#compact (mrkn)
+- [[Feature #11818]](https://bugs.ruby-lang.org/issues/11818) Hash#compact (mrkn)
 
 - Matz: accept.
 
-- \[Feature [#3511](https://bugs.ruby-lang.org/issues/3511)\] rb\_path\_to\_class should call custom const\_defined? methods (shyouhei)
-- \[Feature [#10098](https://bugs.ruby-lang.org/issues/10098)\] \[PATCH\] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
-- \[Feature [#12591](https://bugs.ruby-lang.org/issues/12591)\] Allow ruby to either catch misspelled "ailas" statements or, possibly more accurately, be more specific in what it reports as an error to the end-user (shyouhei)
-- \[Feature [#12594](https://bugs.ruby-lang.org/issues/12594)\] The class does not inherit from a module the modules that were included after the inclusion (shyouhei)
-- \[Feature [#12596](https://bugs.ruby-lang.org/issues/12596)\] Add Pathname#empty? to be consistent with Dir.empty? and File.empty? (shyouhei)
-- \[Feature [#12593](https://bugs.ruby-lang.org/issues/12593)\] Allow compound assignements to work when destructuring arrays (shyouhei)
+- [[Feature #3511]](https://bugs.ruby-lang.org/issues/3511) rb\_path\_to\_class should call custom const\_defined? methods (shyouhei)
+- [[Feature #10098]](https://bugs.ruby-lang.org/issues/10098) \[PATCH\] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
+- [[Feature #12591]](https://bugs.ruby-lang.org/issues/12591) Allow ruby to either catch misspelled "ailas" statements or, possibly more accurately, be more specific in what it reports as an error to the end-user (shyouhei)
+- [[Feature #12594]](https://bugs.ruby-lang.org/issues/12594) The class does not inherit from a module the modules that were included after the inclusion (shyouhei)
+- [[Feature #12596]](https://bugs.ruby-lang.org/issues/12596) Add Pathname#empty? to be consistent with Dir.empty? and File.empty? (shyouhei)
+- [[Feature #12593]](https://bugs.ruby-lang.org/issues/12593) Allow compound assignements to work when destructuring arrays (shyouhei)
 
 - matz wil respond
 
-- \[Feature [#12602](https://bugs.ruby-lang.org/issues/12602)\] Add NilClass#to\_d (shyouhei)
-- \[Feature [#12607](https://bugs.ruby-lang.org/issues/12607)\] Ruby needs an atomic integer (shyouhei)
-- \[Feature [#12608](https://bugs.ruby-lang.org/issues/12608)\] Proposal to replace unless in Ruby (shyouhei)
+- [[Feature #12602]](https://bugs.ruby-lang.org/issues/12602) Add NilClass#to\_d (shyouhei)
+- [[Feature #12607]](https://bugs.ruby-lang.org/issues/12607) Ruby needs an atomic integer (shyouhei)
+- [[Feature #12608]](https://bugs.ruby-lang.org/issues/12608) Proposal to replace unless in Ruby (shyouhei)
 
 - Matz: reject
 
-- \[Feature [#12615](https://bugs.ruby-lang.org/issues/12615)\] Pathname#rename does not work across filesystem boundaries. (shyouhei) is this by design or...?
-- \[Feature [#12624](https://bugs.ruby-lang.org/issues/12624)\] !== (other) (shyouhei)
+- [[Feature #12615]](https://bugs.ruby-lang.org/issues/12615) Pathname#rename does not work across filesystem boundaries. (shyouhei) is this by design or...?
+- [[Feature #12624]](https://bugs.ruby-lang.org/issues/12624) !== (other) (shyouhei)
 
 - matz: will respond
 
-- \[Feature [#12625](https://bugs.ruby-lang.org/issues/12625)\] TypeError.assert, ArgumentError.assert (shyouhei)
-- \[Feature [#12626](https://bugs.ruby-lang.org/issues/12626)\] Add ceiling alias for ceil on Numeric objects (shyouhei)
+- [[Feature #12625]](https://bugs.ruby-lang.org/issues/12625) TypeError.assert, ArgumentError.assert (shyouhei)
+- [[Feature #12626]](https://bugs.ruby-lang.org/issues/12626) Add ceiling alias for ceil on Numeric objects (shyouhei)
 
 - matz wil respond
 
-- \[Feature [#12623](https://bugs.ruby-lang.org/issues/12623)\] rescue in blocks without begin/end (shyouhei)
-- \[Feature [#12635](https://bugs.ruby-lang.org/issues/12635)\] Shuffling/Reassigning "namespaces" more easily (shyouhei)
+- [[Feature #12623]](https://bugs.ruby-lang.org/issues/12623) rescue in blocks without begin/end (shyouhei)
+- [[Feature #12635]](https://bugs.ruby-lang.org/issues/12635) Shuffling/Reassigning "namespaces" more easily (shyouhei)
 
 - matz wil respond
 
-- \[Feature [#12374](https://bugs.ruby-lang.org/issues/12374)\] SingletonClass (sawa)
+- [[Feature #12374]](https://bugs.ruby-lang.org/issues/12374) SingletonClass (sawa)
 
 - ko1: this is GoF’s singleton pattern.
 - sawa: I want to have a reverse of Object#singleton\_class
 - akr: what use case?
 - Matz: this is technically possible, but what poupose?  There is singleton\_class?
 
-- \[Feature [#9704](https://bugs.ruby-lang.org/issues/9704)\] Refinements as files instead of modules (shyouhei)
-- \[Feature [#12637](https://bugs.ruby-lang.org/issues/12637)\] Unified and consistent method naming for safe and dangerous methods (shyouhei)
-- \[Feature [#8643](https://bugs.ruby-lang.org/issues/8643)\] Add Binding.from\_hash (shyouhei)
-- \[Feature [#12650](https://bugs.ruby-lang.org/issues/12650)\] Use UTF-8 encoding for ENV on Windows (shyouhei)
-- \[Feature [#12648](https://bugs.ruby-lang.org/issues/12648)\] Enumerable#sort\_by with descending option (shyouhei)
+- [[Feature #9704]](https://bugs.ruby-lang.org/issues/9704) Refinements as files instead of modules (shyouhei)
+- [[Feature #12637]](https://bugs.ruby-lang.org/issues/12637) Unified and consistent method naming for safe and dangerous methods (shyouhei)
+- [[Feature #8643]](https://bugs.ruby-lang.org/issues/8643) Add Binding.from\_hash (shyouhei)
+- [[Feature #12650]](https://bugs.ruby-lang.org/issues/12650) Use UTF-8 encoding for ENV on Windows (shyouhei)
+- [[Feature #12648]](https://bugs.ruby-lang.org/issues/12648) Enumerable#sort\_by with descending option (shyouhei)
 
 - akr: sort\_by with multiple arguments is odd.
 - shyouhei: I sometimes need secondary sort key
@@ -294,22 +294,22 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - Matz: I understand the needs of reverse sort.
 - sawa: I can settle with sort\_by.reverse
 
-- \[Feature [#12574](https://bugs.ruby-lang.org/issues/12574)\] Remove TRUE, FALSE, and NIL (shyouhei)
-- \[Feature [#12655](https://bugs.ruby-lang.org/issues/12655)\] accessing a method visibility (shyouhei)
-- \[Feature [#9612](https://bugs.ruby-lang.org/issues/9612)\] Gemify OpenSSL (hsbt)
-- \[Feature [#8539](https://bugs.ruby-lang.org/issues/8539)\] Unbundle ext/tk (hsbt)
-- \[Feature [#12512](https://bugs.ruby-lang.org/issues/12512)\] Import Hash#transform\_values and its destructive version from ActiveSupport
+- [[Feature #12574]](https://bugs.ruby-lang.org/issues/12574) Remove TRUE, FALSE, and NIL (shyouhei)
+- [[Feature #12655]](https://bugs.ruby-lang.org/issues/12655) accessing a method visibility (shyouhei)
+- [[Feature #9612]](https://bugs.ruby-lang.org/issues/9612) Gemify OpenSSL (hsbt)
+- [[Feature #8539]](https://bugs.ruby-lang.org/issues/8539) Unbundle ext/tk (hsbt)
+- [[Feature #12512]](https://bugs.ruby-lang.org/issues/12512) Import Hash#transform\_values and its destructive version from ActiveSupport
 
 - Matz: accept Enumerable#map\_v
 - Matz: not now for map\_k, map\_kv
 
 ## From non-attendees
 
-- \[Feature [#12299](https://bugs.ruby-lang.org/issues/12299)\] Add Warning module for customized warning handling (jeremyevans)
+- [[Feature #12299]](https://bugs.ruby-lang.org/issues/12299) Add Warning module for customized warning handling (jeremyevans)
 
 - Matz: accept the fundamental concept (library needs more consideration)
 
-- \[Feature [#10594](https://bugs.ruby-lang.org/issues/10594)\] Comparable#clamp (nerdinand)
+- [[Feature #10594]](https://bugs.ruby-lang.org/issues/10594) Comparable#clamp (nerdinand)
 
 - shyouhei: shoudl this be a method of Comparable?
 - nobu: can be a method of Range

--- a/2016/DevMeeting-2016-09-07.md
+++ b/2016/DevMeeting-2016-09-07.md
@@ -110,41 +110,41 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 
 ## Carry-over from previous meeting(s)
 
-- \[Feature [#10098](https://bugs.ruby-lang.org/issues/10098)\] \[PATCH\] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
+- [[Feature #10098]](https://bugs.ruby-lang.org/issues/10098) \[PATCH\] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
 
 - naruse: I don’t feel comfortable to its naming.
 - naruse: I think CRYPTO\_memcmp() is a bad interface so I don’t want to introduce it.
 
-- \[Feature [#12591](https://bugs.ruby-lang.org/issues/12591)\] Allow ruby to either catch misspelled "ailas" statements or, possibly more accurately, be more specific in what it reports as an error to the end-user (shyouhei)
+- [[Feature #12591]](https://bugs.ruby-lang.org/issues/12591) Allow ruby to either catch misspelled "ailas" statements or, possibly more accurately, be more specific in what it reports as an error to the end-user (shyouhei)
 
 - matz: use an editor that supports ruby syntax.
 
-- \[Feature [#9704](https://bugs.ruby-lang.org/issues/9704)\] Refinements as files instead of modules (shyouhei) conclusion?
+- [[Feature #9704]](https://bugs.ruby-lang.org/issues/9704) Refinements as files instead of modules (shyouhei) conclusion?
 
 - shugo: matz please respond.
 
-- \[Feature [#8643](https://bugs.ruby-lang.org/issues/8643)\] Add Binding.from\_hash (shyouhei) conclusion?
+- [[Feature #8643]](https://bugs.ruby-lang.org/issues/8643) Add Binding.from\_hash (shyouhei) conclusion?
 
 - ko1: I’ll ask seki-san.
 
-- \[Feature [#12650](https://bugs.ruby-lang.org/issues/12650)\] Use UTF-8 encoding for ENV on Windows (shyouhei)
+- [[Feature #12650]](https://bugs.ruby-lang.org/issues/12650) Use UTF-8 encoding for ENV on Windows (shyouhei)
 
 - duerst: is it just we dont want to touch this, or we have agreements we would move to UTF-8 later?
 - naruse: I’ll ask usa-san
 
-- \[Bug [#9569](https://bugs.ruby-lang.org/issues/9569)\] SecureRandom should try /dev/urandom first (shyouhei) I'd like to hear other opinions.
+- [[Bug #9569]](https://bugs.ruby-lang.org/issues/9569) SecureRandom should try /dev/urandom first (shyouhei) I'd like to hear other opinions.
 
 - akr: we can’t but neglect this issue as-is.
 - shyouhei: we have no critical security issue right now.
 
-- \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
+- [[Misc #12283]](https://bugs.ruby-lang.org/issues/12283) Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 
 - naruse: no move
 - duerst: PLEASE!
 
 ## From attendees
 
-- \[Feature [#12512](https://bugs.ruby-lang.org/issues/12512)\] Import Hash#transform\_values and its destructive version from ActiveSupport (eregon): we should discuss the name and maybe other methods like #map\_keys, #map\_pairs.
+- [[Feature #12512]](https://bugs.ruby-lang.org/issues/12512) Import Hash#transform\_values and its destructive version from ActiveSupport (eregon): we should discuss the name and maybe other methods like #map\_keys, #map\_pairs.
 
 - matz: I have a plan to have similar methods also on Enumerable.  In doing so, map\_pairs is problematic because “pairs” does not always fit (they might not be key-value pairs).  This prevents me to introduce map\_keys/values/pairs.
 - matz: OK, I accept #transform\_values.
@@ -152,7 +152,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 - mrkn: Yes.
 - eregon: #map\_values, keys, pairs is intuitive on Hash and has been asked many times. The Enumerable method to create a Hash is a different issue: the input might aready be key-value pairs in which case #to\_h is enough or it might not, in which case we might want a new method (build\_hash, associate ?).
 
-- \[Bug [#12689](https://bugs.ruby-lang.org/issues/12689)\] Thread isolation of $~ and $\_ (eregon): Who can describe the semantics? Is the current sharing expected?
+- [[Bug #12689]](https://bugs.ruby-lang.org/issues/12689) Thread isolation of $~ and $\_ (eregon): Who can describe the semantics? Is the current sharing expected?
 
 - ko1: I intentioanlly made VM this way, to behave simiarly with 1.8.x.
 - ko1: Toplevel $-variables are thread local, others like variables inside of methods are not. They are normal (local) variables, subject to be shared among threads.
@@ -180,7 +180,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
     nil
     #<MatchData "foo">
 
-- \[Feature [#6842](https://bugs.ruby-lang.org/issues/6842)\] Add Optional Arguments to String#strip (sonots): I am currently working on implementing this, but am wondering about specification for regular expression argument, and arguments for strip
+- [[Feature #6842]](https://bugs.ruby-lang.org/issues/6842) Add Optional Arguments to String#strip (sonots): I am currently working on implementing this, but am wondering about specification for regular expression argument, and arguments for strip
 
 - sonots: I want this when I write fluentd’s routing engine.
 - nobu: I think we can have this sort of thing, but #strip is not the right place to add it.
@@ -190,7 +190,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 - mrkn: it seems python does not have things like this.
 - matz: please re-submit this with proposing new name.
 
-- \[Feature [#859](https://bugs.ruby-lang.org/issues/859)\] open-uri doesn't allow redirection to https (duerst): This seems overdue
+- [[Feature #859]](https://bugs.ruby-lang.org/issues/859) open-uri doesn't allow redirection to https (duerst): This seems overdue
 
 - duerst: these days http->https redirects happen more often than before.
 - naruse: I don’t remember where exactly is the specification inside of HTML5 where HTTPS redirection is defined
@@ -203,7 +203,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
     s2 = uri2.scheme.downcase
     s1 == s2 || ALLOW\_REDIRECTS\["#{s1}:#{s2}"\]
 
-- \[Feature [#7418](https://bugs.ruby-lang.org/issues/7418)\] Kernel#used\_refinements (shugo)
+- [[Feature #7418]](https://bugs.ruby-lang.org/issues/7418) Kernel#used\_refinements (shugo)
 
 - shyouhei: what is returned from this method?
 - shugo: list of refinements (modules).
@@ -217,7 +217,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 - akr: I don’t think it should be a global function unless this is very frequently used.
 - matz: accept Module.used\_refinements
 
-- \[Feature [#9451](https://bugs.ruby-lang.org/issues/9451)\] Refinements and unary & (to\_proc) (shugo)
+- [[Feature #9451]](https://bugs.ruby-lang.org/issues/9451) Refinements and unary & (to\_proc) (shugo)
 
 - matz: I started thinking this can be okay.
 - nobu: I doubt if we can do this.
@@ -226,65 +226,65 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 - matz: Object#method\_with\_refinements or something can be possible.
 - matz: for &(proc), it is a good-to-have. if possible.
 
-- \[Bug [#10103](https://bugs.ruby-lang.org/issues/10103)\] Unable to refine class with CONSTANT (shugo)
+- [[Bug #10103]](https://bugs.ruby-lang.org/issues/10103) Unable to refine class with CONSTANT (shugo)
 
 - shugo: is it okay to close?
 
-- \[Bug [#11182](https://bugs.ruby-lang.org/issues/11182)\] Refinement with alias causes strange behavior (shugo)
-- \[Feature [#11476](https://bugs.ruby-lang.org/issues/11476)\] Methods defined in Refinements cannot be called via send (shugo)
+- [[Bug #11182]](https://bugs.ruby-lang.org/issues/11182) Refinement with alias causes strange behavior (shugo)
+- [[Feature #11476]](https://bugs.ruby-lang.org/issues/11476) Methods defined in Refinements cannot be called via send (shugo)
 
 - matz: either add Object#refined\_send method or Object#method\_with\_refinements.
 - nobu: or to have a send-like operator.
 - ko1: what’s wrong with send being refinements-aware?
 - matz: how is it difficult to modify send?  I want that way.
 
-- \[Feature [#11525](https://bugs.ruby-lang.org/issues/11525)\] Add Module#used (refinement hook) (shugo)
+- [[Feature #11525]](https://bugs.ruby-lang.org/issues/11525) Add Module#used (refinement hook) (shugo)
 
 - matz: reject because it is too dynamic.
 
-- \[Bug [#11704](https://bugs.ruby-lang.org/issues/11704)\] Refinements only get "used" once in loop (shugo)
+- [[Bug #11704]](https://bugs.ruby-lang.org/issues/11704) Refinements only get "used" once in loop (shugo)
 
 - akr: this is a problem of benchmark
 - shyouhei: I understand what OP wanted to do
 
-- \[Feature [#12079](https://bugs.ruby-lang.org/issues/12079)\] Loosening the condition for refinement (shugo)
+- [[Feature #12079]](https://bugs.ruby-lang.org/issues/12079) Loosening the condition for refinement (shugo)
 
 - duplicated.
 
-- \[Feature [#12086](https://bugs.ruby-lang.org/issues/12086)\] using: option for instance\_eval etc. (shugo)
+- [[Feature #12086]](https://bugs.ruby-lang.org/issues/12086) using: option for instance\_eval etc. (shugo)
 
 - waiting for JRuby guys.
 - shugo: please nudge.
 
-- \[Feature [#12533](https://bugs.ruby-lang.org/issues/12533)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shugo)
-- \[Feature [#12534](https://bugs.ruby-lang.org/issues/12534)\] Refinements: refine modules as well (shugo)
+- [[Feature #12533]](https://bugs.ruby-lang.org/issues/12533) Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shugo)
+- [[Feature #12534]](https://bugs.ruby-lang.org/issues/12534) Refinements: refine modules as well (shugo)
 
 - nobu: why we can’t?
 - shugo: it’s difficult because when “super” is called, module’s method have to seek for proper ICLASS.
 - matz: maybe we can restrict calling super from inside of a refined module?
 
-- \[Feature [#11650](https://bugs.ruby-lang.org/issues/11650)\] Add custom error message arg to Timeout.timeout (nobu)
+- [[Feature #11650]](https://bugs.ruby-lang.org/issues/11650) Add custom error message arg to Timeout.timeout (nobu)
 
 - nobu: I have no reason to reject this.
 - shugo: does this mean Timeout.timeout to pass its arguments to #new?
 - akr: It is considered an idiom to have message right after exception class.
 - matz: accepted.
 
-- \[Bug [#12548](https://bugs.ruby-lang.org/issues/12548)\] Rounding modes inconsistency between round versus sprintf (nobu)
+- [[Bug #12548]](https://bugs.ruby-lang.org/issues/12548) Rounding modes inconsistency between round versus sprintf (nobu)
 
 - add optional second argument, like BigDecimal, to take symbol.
 
-- \[Bug [#12588](https://bugs.ruby-lang.org/issues/12588)\] When an exception is re-raised in the "rescue" clause, the back trace does not contain the line in that clause (nobu)
+- [[Bug #12588]](https://bugs.ruby-lang.org/issues/12588) When an exception is re-raised in the "rescue" clause, the back trace does not contain the line in that clause (nobu)
 
 - matz: backtrace can be obtained if raised manually.
 
-- \[Feature [#12690](https://bugs.ruby-lang.org/issues/12690)\] Improve GC with external library that may use large memory (nobu)
+- [[Feature #12690]](https://bugs.ruby-lang.org/issues/12690) Improve GC with external library that may use large memory (nobu)
 
 - ko1: accept.
 
-- \[Feature [#12695](https://bugs.ruby-lang.org/issues/12695)\] File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set (nobu)
-- \[Feature [#12700](https://bugs.ruby-lang.org/issues/12700)\] regexg heredoc support (nobu)
+- [[Feature #12695]](https://bugs.ruby-lang.org/issues/12695) File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set (nobu)
+- [[Feature #12700]](https://bugs.ruby-lang.org/issues/12700) regexg heredoc support (nobu)
 
 - matz: rejected
 
-- \[Bug [#12709](https://bugs.ruby-lang.org/issues/12709)\] POSIX-noncompliant setenv (nobu)
+- [[Bug #12709]](https://bugs.ruby-lang.org/issues/12709) POSIX-noncompliant setenv (nobu)

--- a/2016/DevMeeting-2016-10-11.md
+++ b/2016/DevMeeting-2016-10-11.md
@@ -153,7 +153,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-- \[Misc [#12283](https://bugs.ruby-lang.org/issues/12283)\] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
+- [[Misc #12283]](https://bugs.ruby-lang.org/issues/12283) Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 
 - naruse: no move.
 - shyouhei: I write git-style commit log.
@@ -161,111 +161,111 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - Martin: the problem is not commit log, but to auto-generate ChanegLog.
 - naruse: I’ll do this on camp.
 
-- \[Feature [#12695](https://bugs.ruby-lang.org/issues/12695)\] File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set (shyouhei) conclusion?
+- [[Feature #12695]](https://bugs.ruby-lang.org/issues/12695) File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set (shyouhei) conclusion?
 
 - waiting for matz.
 
-- \[Feature [#12733](https://bugs.ruby-lang.org/issues/12733)\] Bundle bundler to ruby core (shyouhei)
+- [[Feature #12733]](https://bugs.ruby-lang.org/issues/12733) Bundle bundler to ruby core (shyouhei)
 
 - hsbt: no progress.
 - hsbt: rubygems master bundles bundler by default.  It sheds some light into its darkness.
 - nobu: it will be merged when rubygems side is OK.
 - hsbt: carefully watching rubygems’ progress.
 
-- \[Feature [#6647](https://bugs.ruby-lang.org/issues/6647)\] Exceptions raised in threads should be logged (shyouhei) Look at [\[ruby-core:77259\]](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/77259)
+- [[Feature #6647]](https://bugs.ruby-lang.org/issues/6647) Exceptions raised in threads should be logged (shyouhei) Look at [\[ruby-core:77259\]](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/77259)
 
 - akr: the proposal can be okay, but we currently do not implemnt thread GC mode.
 
-- \[Feature [#12744](https://bugs.ruby-lang.org/issues/12744)\] Add str.reverse\_each\_char and str.reverse\_chars (shyouhei) conclusion?
+- [[Feature #12744]](https://bugs.ruby-lang.org/issues/12744) Add str.reverse\_each\_char and str.reverse\_chars (shyouhei) conclusion?
 
 - naruse: I agree this makes things faster a bit, but will it really be needed?
 - Martin: array allocation is avoided in the patch, but each\_char generates lots of strings anyways.
 
-- \[Bug [#11195](https://bugs.ruby-lang.org/issues/11195)\] Add "no\_proxy" parameter to Net::HTTP.new (shyouhei) Roman Bigler volunteers.
+- [[Bug #11195]](https://bugs.ruby-lang.org/issues/11195) Add "no\_proxy" parameter to Net::HTTP.new (shyouhei) Roman Bigler volunteers.
 
 - akr: +1 to refacor find\_proxy, then use it from Net::HTTP.
 - let’s request a patch, then mentor by naruse.
 
-- \[Bug [#12594](https://bugs.ruby-lang.org/issues/12594)\] The class does not inherit from a module the modules that were included after the inclusion (shyouhei)
+- [[Bug #12594]](https://bugs.ruby-lang.org/issues/12594) The class does not inherit from a module the modules that were included after the inclusion (shyouhei)
 
 - nobu: I’ll fix this someday. hopefully before 2.4?
 
 ## From attendees
 
-- \[Bug [#12649](https://bugs.ruby-lang.org/issues/12649)\] DateTime method calls hang (shyouhei) seems like a real bug?
+- [[Bug #12649]](https://bugs.ruby-lang.org/issues/12649) DateTime method calls hang (shyouhei) seems like a real bug?
 
 - assign nobu.
 
-- \[Bug [#12652](https://bugs.ruby-lang.org/issues/12652)\] For Dir.home encode passed user (shyouhei) seems like a real bug?
+- [[Bug #12652]](https://bugs.ruby-lang.org/issues/12652) For Dir.home encode passed user (shyouhei) seems like a real bug?
 
 - assign naruse
 
-- \[Bug [#12509](https://bugs.ruby-lang.org/issues/12509)\] Using qsort\_s in mingw-w64 causes failures (shyouhei) who to handle this?
+- [[Bug #12509]](https://bugs.ruby-lang.org/issues/12509) Using qsort\_s in mingw-w64 causes failures (shyouhei) who to handle this?
 
 - assign nobu
 
-- \[Bug [#8996](https://bugs.ruby-lang.org/issues/8996)\] pthread\_mutex\_lock EINVAL (shyouhei) seems like a real bug?
+- [[Bug #8996]](https://bugs.ruby-lang.org/issues/8996) pthread\_mutex\_lock EINVAL (shyouhei) seems like a real bug?
 
 - assign ko1
 
-- \[Bug [#12776](https://bugs.ruby-lang.org/issues/12776)\] Flaky test case: TestThread#test\_thread\_name (shyouhei) seems like a real bug, or....?
+- [[Bug #12776]](https://bugs.ruby-lang.org/issues/12776) Flaky test case: TestThread#test\_thread\_name (shyouhei) seems like a real bug, or....?
 
 - closed, lets backport.
 
-- \[Feature [#12656](https://bugs.ruby-lang.org/issues/12656)\] Expand short paths with File.expand\_path (shyouhei)
+- [[Feature #12656]](https://bugs.ruby-lang.org/issues/12656) Expand short paths with File.expand\_path (shyouhei)
 
 - assign cruby-windows
 
-- \[Bug [#7877](https://bugs.ruby-lang.org/issues/7877)\] E::Lazy#with\_index should be lazy (shyouhei)
+- [[Bug #7877]](https://bugs.ruby-lang.org/issues/7877) E::Lazy#with\_index should be lazy (shyouhei)
 
 - assign nobu
 
-- \[Feature [#12664](https://bugs.ruby-lang.org/issues/12664)\] Multiline pretty-printing of multiline strings (shyouhei)
+- [[Feature #12664]](https://bugs.ruby-lang.org/issues/12664) Multiline pretty-printing of multiline strings (shyouhei)
 
 - nudge akr
 
-- \[Feature [#4897](https://bugs.ruby-lang.org/issues/4897)\] Define Math::TAU and BigMath.TAU. The "true" circle constant, Tau=2\*Pi. See [http://tauday.com/](http://tauday.com/) (shyouhei)
+- [[Feature #4897]](https://bugs.ruby-lang.org/issues/4897) Define Math::TAU and BigMath.TAU. The "true" circle constant, Tau=2\*Pi. See [http://tauday.com/](http://tauday.com/) (shyouhei)
 
 - mrkn: I suggest Math::TWOPI
 - akr: C has PI\_2, but this means π/2
 - wating for matz (or time?)
 
-- \[Bug [#12674](https://bugs.ruby-lang.org/issues/12674)\] io/wait: not handling the case when the socket is closed before doing wait\_readable/writable with timeout (shyouhei) might be a design issue?
+- [[Bug #12674]](https://bugs.ruby-lang.org/issues/12674) io/wait: not handling the case when the socket is closed before doing wait\_readable/writable with timeout (shyouhei) might be a design issue?
 
 - assign nobu
 
-- \[Bug [#12678](https://bugs.ruby-lang.org/issues/12678)\] No way to set a timeout for TLS handshake when using Net::SMTP (shyouhei) should who handle this?
+- [[Bug #12678]](https://bugs.ruby-lang.org/issues/12678) No way to set a timeout for TLS handshake when using Net::SMTP (shyouhei) should who handle this?
 
 - assign shugo
 
-- \[Bug [#6783](https://bugs.ruby-lang.org/issues/6783)\] Infinite loop in inspect, not overriding inspect, to\_s, and no known circular references. Stepping into inspect in debugger locks it up with 100% CPU. (shyouhei)
+- [[Bug #6783]](https://bugs.ruby-lang.org/issues/6783) Infinite loop in inspect, not overriding inspect, to\_s, and no known circular references. Stepping into inspect in debugger locks it up with 100% CPU. (shyouhei)
 
 - akr: I have a conception of ritcher inspection framework that passes-around contexts, but have not implemented yet.
 
-- \[Bug [#10222](https://bugs.ruby-lang.org/issues/10222)\] require\_relative and require should be compatible with each other (shyouhei)
+- [[Bug #10222]](https://bugs.ruby-lang.org/issues/10222) require\_relative and require should be compatible with each other (shyouhei)
 
 - akr: require\_relative expands real path, while require doesn’t.
 - naruse: if we expand realpath on require, we need disk access every time we call require (even when the library is already loaded).
 - naruse: what about adding both real path and expanded path to $LOADED\_FEATURES at once for require?
 - shyouhei: I think for this shown use case b.rb shall not be called twice.
 
-- \[Bug [#12705](https://bugs.ruby-lang.org/issues/12705)\] yielding args to a lambda uses block/proc rather than lambda/method semantics (shyouhei)
+- [[Bug #12705]](https://bugs.ruby-lang.org/issues/12705) yielding args to a lambda uses block/proc rather than lambda/method semantics (shyouhei)
 
 - akr: I think it’s a bug.  They should be consistent.
 - akr: someone broke here at 2.2.
 - ko1: maybe me.
 
-- \[Bug [#4537](https://bugs.ruby-lang.org/issues/4537)\] Incorrectly creating private method via attr\_accessor (shyouhei) cf. \[Bug [#9005](https://bugs.ruby-lang.org/issues/9005)\]
+- [[Bug #4537]](https://bugs.ruby-lang.org/issues/4537) Incorrectly creating private method via attr\_accessor (shyouhei) cf. [[Bug #9005]](https://bugs.ruby-lang.org/issues/9005)
 
 - shyouhei: is this fixed already?
 - nobu: seems not.
 - shyouhei: updated ruby -v field.
 
-- \[Feature [#12721](https://bugs.ruby-lang.org/issues/12721)\] public\_module\_function (shyouhei)
+- [[Feature #12721]](https://bugs.ruby-lang.org/issues/12721) public\_module\_function (shyouhei)
 
 - waiting for matz.
 
-- \[Feature [#12732](https://bugs.ruby-lang.org/issues/12732)\] An option to pass to Integer, Float, to return nil instead of raise an exception (shyouhei)
+- [[Feature #12732]](https://bugs.ruby-lang.org/issues/12732) An option to pass to Integer, Float, to return nil instead of raise an exception (shyouhei)
 
 - akr: it seems there are needs of other conversion methods than to\_i or Integer
 - nobu: they just want to detect validity, not exceptions.
@@ -273,7 +273,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - Martin: but Upcase?() is a new concept.
 - waiting for matz.
 
-- \[Feature [#12745](https://bugs.ruby-lang.org/issues/12745)\] String#(g)sub(!) should pass a MatchData to the block, not a String (shyouhei)
+- [[Feature #12745]](https://bugs.ruby-lang.org/issues/12745) String#(g)sub(!) should pass a MatchData to the block, not a String (shyouhei)
 
 - akr: naming matters.
 - shyouhei: is that we need a new method name?  What about changing gsub behaviour?
@@ -284,19 +284,19 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - shyouhei: it might be possible to extend the passed string to define method that returns $~.
 - akr: adding a new method is the most clean way if we can find good method name.
 
-- \[Feature [#12747](https://bugs.ruby-lang.org/issues/12747)\] Add TracePoint#callee\_id (shyouhei)
+- [[Feature #12747]](https://bugs.ruby-lang.org/issues/12747) Add TracePoint#callee\_id (shyouhei)
 
 - assign ko1.
 
-- \[Feature [#12755](https://bugs.ruby-lang.org/issues/12755)\] optimize instruction sequence (shyouhei)
+- [[Feature #12755]](https://bugs.ruby-lang.org/issues/12755) optimize instruction sequence (shyouhei)
 
 - waiting matz.
 
-- \[Bug [#12780](https://bugs.ruby-lang.org/issues/12780)\] BigDecimal#round returns different types depending on argument (shyouhei)
+- [[Bug #12780]](https://bugs.ruby-lang.org/issues/12780) BigDecimal#round returns different types depending on argument (shyouhei)
 
 - assign mrkn
 
-- \[Feature [#12790](https://bugs.ruby-lang.org/issues/12790)\] Better inspect for stdlib classes (shyouhei)
+- [[Feature #12790]](https://bugs.ruby-lang.org/issues/12790) Better inspect for stdlib classes (shyouhei)
 
 - akr: I can’t read the output.
 - mrkn: yes.  I’ll fix this.  But it’s not that simple.
@@ -316,7 +316,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 - nobu: lets see RC1’s response.
 
-- \[Bug [#12828](https://bugs.ruby-lang.org/issues/12828)\] Check whether macro RUBY is okay for protecting ruby-specific onigumo extensions (duerst)
+- [[Bug #12828]](https://bugs.ruby-lang.org/issues/12828) Check whether macro RUBY is okay for protecting ruby-specific onigumo extensions (duerst)
 
 - nobu: RUBY is already defined at defines.h
 - naruse: doesn’t anyone want to use vanilla onigumo someday?
@@ -326,7 +326,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 Write your name and your interest (what do you want to ask and to whom?) please.
 
-- \[Feature [#12760](https://bugs.ruby-lang.org/issues/12760)\] Optional block argument for itself (Victor Shepelev)
+- [[Feature #12760]](https://bugs.ruby-lang.org/issues/12760) Optional block argument for itself (Victor Shepelev)
 
 - “itself” doesn’t sound right
 - nobu: if itself takes block it should behave like tap.

--- a/2016/DevMeeting-2016-11-25.md
+++ b/2016/DevMeeting-2016-11-25.md
@@ -149,14 +149,14 @@ RC1? at 12/1
 
 Issues
 
-- \[Bug [#12958](https://bugs.ruby-lang.org/issues/12958)\] Breaking change in how #round works (yui-knk listed on this agenda) Is there any migration path for changing behavior of round? For example only warning on Ruby 2.4 and chnage behavior on Ruby 2.5.
+- [[Bug #12958]](https://bugs.ruby-lang.org/issues/12958) Breaking change in how #round works (yui-knk listed on this agenda) Is there any migration path for changing behavior of round? For example only warning on Ruby 2.4 and chnage behavior on Ruby 2.5.
 
 - mrkn: what problem are there?
 - yui-knk(behind shyouhei): want to know how ruby-core thinks abot the incompatibility.
 - shyouhei: it seems the rails breakage is about ActionView
 - naruse: it’s better for rails to have a dedicated method to round a float.
 
-- \[Feature [#12963](https://bugs.ruby-lang.org/issues/12963)\] ?string longer than one char
+- [[Feature #12963]](https://bugs.ruby-lang.org/issues/12963) ?string longer than one char
 
 - matz: I feel not confident with : :
 - shyouhei: “::” vs “: :” are different in meaning.
@@ -173,19 +173,19 @@ Issues
 - mrkn: x.round(half::"up") -> x.round(half: :"up")
 - nobu: x.round(half:: "up") -> NG
 
-- \[Feature [#12953](https://bugs.ruby-lang.org/issues/12953)\] (Float, Integer, Rational)#round(half: :down)
+- [[Feature #12953]](https://bugs.ruby-lang.org/issues/12953) (Float, Integer, Rational)#round(half: :down)
 
 - mrkn: I think it’s OK
 - matz: seems nobody is against it.
 
-- \[Feature [#12063](https://bugs.ruby-lang.org/issues/12063)\] KeyError#receiver and KeyError#name
+- [[Feature #12063]](https://bugs.ruby-lang.org/issues/12063) KeyError#receiver and KeyError#name
 
 - shyouhei: I’m not sure about the patch but the feature itself seems OK
 - nobu: I see no problem on the patch.
 - ko1: it’s not a child of ArgumentError.
 - matz: Ruby’s exceptions classes are not well considered… Anyway Python used KeyError.
 
-- \[Bug [#11929](https://bugs.ruby-lang.org/issues/11929)\] No programatic way to check ability to dup/clone an object (duerst)
+- [[Bug #11929]](https://bugs.ruby-lang.org/issues/11929) No programatic way to check ability to dup/clone an object (duerst)
 
 - matz: respond\_to? is insufficient to check if it can be dup’ed, because it could raise exceptions.
 - matz: There is no way to change identity of a fixnum.
@@ -193,46 +193,46 @@ Issues
 - duerst: I’d prefer failing silently.
 - matz: I want a separate proposal for that.
 
-- \[Bug [#12831](https://bugs.ruby-lang.org/issues/12831)\] /\\X/ (extended grapheme cluster) can't pass unicode.org's GraphemeBreakTest
+- [[Bug #12831]](https://bugs.ruby-lang.org/issues/12831) /\\X/ (extended grapheme cluster) can't pass unicode.org's GraphemeBreakTest
 
 - duerst: not currently implemented.
 - naruse: I’ll take a look.
 
-- \[Feature [#12695](https://bugs.ruby-lang.org/issues/12695)\] File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set
+- [[Feature #12695]](https://bugs.ruby-lang.org/issues/12695) File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set
 
 - matz: OK
 
-- \[Feature [#4897](https://bugs.ruby-lang.org/issues/4897)\] Define Math::TAU and BigMath.TAU. The "true" circle constant, Tau=2\*Pi. See [http://tauday.com/](http://tauday.com/)
+- [[Feature #4897]](https://bugs.ruby-lang.org/issues/4897) Define Math::TAU and BigMath.TAU. The "true" circle constant, Tau=2\*Pi. See [http://tauday.com/](http://tauday.com/)
 
 - mrkn: last time I suggested TWO\_PI.
 - matz: I don’t think TWO\_PI satisfies TAU fans.
 - matz: I want to leave it rejected.
 
-- \[Feature [#12721](https://bugs.ruby-lang.org/issues/12721)\] public\_module\_function
+- [[Feature #12721]](https://bugs.ruby-lang.org/issues/12721) public\_module\_function
 
 - nurse: わかる
 - matz: I’m not sure what benefits are there.
 
-- \[Feature [#12732](https://bugs.ruby-lang.org/issues/12732)\] An option to pass to Integer, Float, to return nil instead of raise an exception
+- [[Feature #12732]](https://bugs.ruby-lang.org/issues/12732) An option to pass to Integer, Float, to return nil instead of raise an exception
 
-- also: \[Feature [#12968](https://bugs.ruby-lang.org/issues/12968)\] Allow default value via block for Integer(), Float() and Rational()
+- also: [[Feature #12968]](https://bugs.ruby-lang.org/issues/12968) Allow default value via block for Integer(), Float() and Rational()
 
 - naruse: what’s wrong with rescue?
 - shyouhei: raising exception then rescueing is too big compared to what’s needed here; we only need to convert a string to an integer.
 
-- \[Feature [#12745](https://bugs.ruby-lang.org/issues/12745)\] String#(g)sub(!) should pass a MatchData to the block, not a String
+- [[Feature #12745]](https://bugs.ruby-lang.org/issues/12745) String#(g)sub(!) should pass a MatchData to the block, not a String
 
 - matz: 1 is NG. I prefer 4 -> 2 -> 3
 - ko1: I fear there should be considerable amount of overheads in 3.
 - naruse: scan should also be handled. 4 and 2 are  not applicablte.
 
-- \[Feature [#12753](https://bugs.ruby-lang.org/issues/12753)\] Useful operator to check bit-flag is true or false
+- [[Feature #12753]](https://bugs.ruby-lang.org/issues/12753) Useful operator to check bit-flag is true or false
 
 - shyouhei: what is wanted is to check if certain bit is set or not.  &==0 is a bit too operational.
 - matz: name? “and?” seems wrong.
 - naruse: what about “bittest?”
 
-- \[Feature [#12979](https://bugs.ruby-lang.org/issues/12979)\] Avoid exception for #dup on Integer (and similar cases)
+- [[Feature #12979]](https://bugs.ruby-lang.org/issues/12979) Avoid exception for #dup on Integer (and similar cases)
 
 - matz: OK.
 
@@ -240,11 +240,11 @@ Issues
 
 - assign mrkn
 
-- \[Feature [#12754](https://bugs.ruby-lang.org/issues/12754)\] Want to use prepared buffer with Array#pack
+- [[Feature #12754]](https://bugs.ruby-lang.org/issues/12754) Want to use prepared buffer with Array#pack
 
 - matz: sounds reasonable.
 
-- \[Feature [#12752](https://bugs.ruby-lang.org/issues/12752)\] Unpacking a value from a binary requires additional '.first'
+- [[Feature #12752]](https://bugs.ruby-lang.org/issues/12752) Unpacking a value from a binary requires additional '.first'
 
 - matz: I would prefer keyword arguments but index:0 doesn’t much differ from .first
 - naruse: write”(‘C’)\[0\]” and let the interpreter optimize.
@@ -254,44 +254,44 @@ Issues
 - extra argument
 - .first
 
-- \[Feature [#12746](https://bugs.ruby-lang.org/issues/12746)\] class Array: alias .prepend to .unshift ?
+- [[Feature #12746]](https://bugs.ruby-lang.org/issues/12746) class Array: alias .prepend to .unshift ?
 
 - mrkn: is “prepend” a valid english word?
 - shyouhei: they say it’s more natural
 - matz: OK
 
-- \[Feature [#11815](https://bugs.ruby-lang.org/issues/11815)\] Proposal for method Array#difference
+- [[Feature #11815]](https://bugs.ruby-lang.org/issues/11815) Proposal for method Array#difference
 
 - shyouhei: real-world example is shown (poker bot)
 
-- \[Feature [#12978](https://bugs.ruby-lang.org/issues/12978)\] Symbol after keyword
+- [[Feature #12978]](https://bugs.ruby-lang.org/issues/12978) Symbol after keyword
 
 - matz: reject. I can’t but read this being a String, not Symbol.
 
-- \[Feature [#12770](https://bugs.ruby-lang.org/issues/12770)\] Hash#left\_merge
+- [[Feature #12770]](https://bugs.ruby-lang.org/issues/12770) Hash#left\_merge
 
 - akira: Rails has reverse\_merge.
 - naruse: the proposed functionality is not the identical to reverse\_merge.
 - ko1: chechk if hash entry is nil, is something new (not orignal behaviour of merge)
 
-- \[Feature [#12760](https://bugs.ruby-lang.org/issues/12760)\] Optional block argument for itself
+- [[Feature #12760]](https://bugs.ruby-lang.org/issues/12760) Optional block argument for itself
 
 - matz: object.{|x|...} is NG.
 
-- \[Feature [#12775](https://bugs.ruby-lang.org/issues/12775)\] Random subset of array
+- [[Feature #12775]](https://bugs.ruby-lang.org/issues/12775) Random subset of array
 
 - mrkn: random length array does not make sense to me.
 - shyouhei: it seems the OP uses this for test.
 
-- \[Bug [#10290](https://bugs.ruby-lang.org/issues/10290)\] segfault when calling a lambda recursively after rescuing SystemStackError
+- [[Bug #10290]](https://bugs.ruby-lang.org/issues/10290) segfault when calling a lambda recursively after rescuing SystemStackError
 
 - nudge nobu
 
-- \[Bug [#12688](https://bugs.ruby-lang.org/issues/12688)\] Thread unsafety in autoload
+- [[Bug #12688]](https://bugs.ruby-lang.org/issues/12688) Thread unsafety in autoload
 
 - assign ko1
 
-- \[Feature [#12786](https://bugs.ruby-lang.org/issues/12786)\] String#casecmp?
+- [[Feature #12786]](https://bugs.ruby-lang.org/issues/12786) String#casecmp?
 
 - naruse: There could be cases where downcase strings are equal, while upcase strings arent.
 - duerst: This feature might be implemented similarily like //i, or upcase(downcase()) == upcase(downcase()); string.downcase(:fold) is (almost?) completely identical to string.upcase.downcase
@@ -299,38 +299,38 @@ Issues
 - matz: is “casecmp?” OK?
 - shyouhei: to me yes.
 
-- \[Feature [#12612](https://bugs.ruby-lang.org/issues/12612)\] Switch Range#=== to use cover? instead of include?
+- [[Feature #12612]](https://bugs.ruby-lang.org/issues/12612) Switch Range#=== to use cover? instead of include?
 
 - naruse: instead of cover?, we should define dedicated Range#===, with optimization for integer (&co.) cases. It can keep compatibility.
 - ko1: maybe akr is interested in it.
 - shyouhei: introducing incompatibility only because it is inefficient is kind of weak.
 
-- \[Bug [#9244](https://bugs.ruby-lang.org/issues/9244)\] unexpected behaviour of 'require' when $LOAD\_PATH gets changed
+- [[Bug #9244]](https://bugs.ruby-lang.org/issues/9244) unexpected behaviour of 'require' when $LOAD\_PATH gets changed
 
 - matz: I don’t immediately think it’s a bug.
 
-- \[Feature [#12719](https://bugs.ruby-lang.org/issues/12719)\] Struct#merge for partial updates
+- [[Feature #12719]](https://bugs.ruby-lang.org/issues/12719) Struct#merge for partial updates
 
 - matz: “merge” sounds wrong.
 - akira: “assign”?
 - shyouhei: what about the feature itself, apart from the naming thing?
 - matz: use case not clear to me.
 
-- \[Feature [#12715](https://bugs.ruby-lang.org/issues/12715)\] Allow ruby hackers to omit having to specify class or module mandatory, if they know exactly what they want to do
+- [[Feature #12715]](https://bugs.ruby-lang.org/issues/12715) Allow ruby hackers to omit having to specify class or module mandatory, if they know exactly what they want to do
 
 - matz wants feedback from OP.
 
-- \[Feature [#12698](https://bugs.ruby-lang.org/issues/12698)\] Method to delete a substring by regex match
+- [[Feature #12698]](https://bugs.ruby-lang.org/issues/12698) Method to delete a substring by regex match
 
 - duerst: what about allowing String#delete to accept regexps? (this would be instead of gremove)
 - mrkn: the OP does not tell us what is wrong with gsub.
 
-- \[Feature [#12697](https://bugs.ruby-lang.org/issues/12697)\] Why shouldn't Module meta programming methods be public?
+- [[Feature #12697]](https://bugs.ruby-lang.org/issues/12697) Why shouldn't Module meta programming methods be public?
 
-- \[Feature [#12780](https://bugs.ruby-lang.org/issues/12780)\] BigDecimal#round returns different types depending on argument
+- [[Feature #12780]](https://bugs.ruby-lang.org/issues/12780) BigDecimal#round returns different types depending on argument
 
-- \[Feature [#12813](https://bugs.ruby-lang.org/issues/12813)\] Calling chunk\_while, slice\_after, slice\_before, slice\_when with no block
+- [[Feature #12813]](https://bugs.ruby-lang.org/issues/12813) Calling chunk\_while, slice\_after, slice\_before, slice\_when with no block
 
 - matz will think about it.
 
-- \[Feature [#12882](https://bugs.ruby-lang.org/issues/12882)\] Add caller/file/line information to internal Kernel#warn calls
+- [[Feature #12882]](https://bugs.ruby-lang.org/issues/12882) Add caller/file/line information to internal Kernel#warn calls

--- a/2016/DevMeeting-2016-12-21.md
+++ b/2016/DevMeeting-2016-12-21.md
@@ -149,22 +149,22 @@ Issues
 
 ## Blocker for 2.4 release
 
-- \[Feature [#12944](https://bugs.ruby-lang.org/issues/12944)\] Change Kernel#warn to call Warning.warn (shyouhei)
+- [[Feature #12944]](https://bugs.ruby-lang.org/issues/12944) Change Kernel#warn to call Warning.warn (shyouhei)
 
 - nobu: nobody is against to call Warning.warn but there are pitfalls
 - akr: what about stringify given arguments, then pass to Warning.warn?
 - akr: is adding “\\n” to the given argument Kernel#warn’s duty or Warning.warn’s?
 - akr: we want to change spec of Kernel#warn.  In order to do so we should avoid rushing this to 2.4.
 
-- \[Feature [#13017](https://bugs.ruby-lang.org/issues/13017)\] Switch SipHash from SipHash24 to SipHash13(?)
+- [[Feature #13017]](https://bugs.ruby-lang.org/issues/13017) Switch SipHash from SipHash24 to SipHash13(?)
 
 - it should be safe to remain SipHash24.
 
-- \[Bug [#13019](https://bugs.ruby-lang.org/issues/13019)\] related? (shyouhei)
+- [[Bug #13019]](https://bugs.ruby-lang.org/issues/13019) related? (shyouhei)
 
 - nobu: no opinion against it
 
-- \[Feature [#12142](https://bugs.ruby-lang.org/issues/12142)\] Hash tables with open addressing (shyouehi) it seems ruby-core:78558 must be looked at.
+- [[Feature #12142]](https://bugs.ruby-lang.org/issues/12142) Hash tables with open addressing (shyouehi) it seems ruby-core:78558 must be looked at.
 
 - nobu: it is done.
 
@@ -172,114 +172,114 @@ Issues
 
 - Bugs that seems forgotten (shyouhei) assign who?
 
-- \[Bug [#12666](https://bugs.ruby-lang.org/issues/12666)\] Fatal error: glibc detected an invalid stdio handle
+- [[Bug #12666]](https://bugs.ruby-lang.org/issues/12666) Fatal error: glibc detected an invalid stdio handle
 
 - akr: why not use ldd(1)?
 
-- \[Bug [#12945](https://bugs.ruby-lang.org/issues/12945)\] Use-after-free in vm\_trace.c
+- [[Bug #12945]](https://bugs.ruby-lang.org/issues/12945) Use-after-free in vm\_trace.c
 
 - nobu: I think I fixed this
 
-- \[Bug [#12961](https://bugs.ruby-lang.org/issues/12961)\] Bad value for range using infinity for Date or Time
+- [[Bug #12961]](https://bugs.ruby-lang.org/issues/12961) Bad value for range using infinity for Date or Time
 
 - nobu: is this a problem of coerce?
 - matz: the problem is what receiver is this.
 
-- \[Bug [#12809](https://bugs.ruby-lang.org/issues/12809)\] passing a proc to Kernel#lambda does not create a lambda
+- [[Bug #12809]](https://bugs.ruby-lang.org/issues/12809) passing a proc to Kernel#lambda does not create a lambda
 
 - akr: it is by design.
 
-- \[Bug [#12551](https://bugs.ruby-lang.org/issues/12551)\] Exception accessing file with long path on windows
+- [[Bug #12551]](https://bugs.ruby-lang.org/issues/12551) Exception accessing file with long path on windows
 
 - nobu it’s already assigned.
 
-- \[Bug [#12907](https://bugs.ruby-lang.org/issues/12907)\] rb\_respond\_to() return value is incorrect
+- [[Bug #12907]](https://bugs.ruby-lang.org/issues/12907) rb\_respond\_to() return value is incorrect
 
 - matz: this is a bug.
 - assign nagachika
 
-- \[Bug [#13000](https://bugs.ruby-lang.org/issues/13000)\] Implement Set#include? with Hash#include?
+- [[Bug #13000]](https://bugs.ruby-lang.org/issues/13000) Implement Set#include? with Hash#include?
 
 - akr: is this a bug?
 
-- \[Bug [#13018](https://bugs.ruby-lang.org/issues/13018)\] end of file reached (EOFError) from SMTP
+- [[Bug #13018]](https://bugs.ruby-lang.org/issues/13018) end of file reached (EOFError) from SMTP
 
 - assign shugo
 
-- \[Bug [#13030](https://bugs.ruby-lang.org/issues/13030)\] Unexpected T\_IMEMO object when building with VMDEBUG
+- [[Bug #13030]](https://bugs.ruby-lang.org/issues/13030) Unexpected T\_IMEMO object when building with VMDEBUG
 
 - assign ko1
 
-- \[Bug [#13043](https://bugs.ruby-lang.org/issues/13043)\] Exception#cause can become recursive/infinite
+- [[Bug #13043]](https://bugs.ruby-lang.org/issues/13043) Exception#cause can become recursive/infinite
 
 - akira: what is wrong with recusive cause?
 - mrkn: what’s the expected cause in this case?
 
-- \[Feature [#12732](https://bugs.ruby-lang.org/issues/12732)\] An option to pass to Integer, Float, to return nil instead of raise an exception (shyouhei) conclusion?
+- [[Feature #12732]](https://bugs.ruby-lang.org/issues/12732) An option to pass to Integer, Float, to return nil instead of raise an exception (shyouhei) conclusion?
 
 - shyouhei: naruse and tenderlove wrote their opinions.
 
-- \[Feature [#12745](https://bugs.ruby-lang.org/issues/12745)\] String#(g)sub(!) should pass a MatchData to the block, not a String (shyouhei) conclusion?
+- [[Feature #12745]](https://bugs.ruby-lang.org/issues/12745) String#(g)sub(!) should pass a MatchData to the block, not a String (shyouhei) conclusion?
 
 - akr: #sg or #gs, matz’s original proposal should be accepted I think
 - nobu: how about String#sed
 
-- \[Feature [#12753](https://bugs.ruby-lang.org/issues/12753)\] Useful operator to check bit-flag is true or false (shyouhei)
+- [[Feature #12753]](https://bugs.ruby-lang.org/issues/12753) Useful operator to check bit-flag is true or false (shyouhei)
 
 - seems discussion is going on
 
-- \[Feature [#11815](https://bugs.ruby-lang.org/issues/11815)\] Proposal for method Array#difference (shyouhei) Matz is thinking about this.
+- [[Feature #11815]](https://bugs.ruby-lang.org/issues/11815) Proposal for method Array#difference (shyouhei) Matz is thinking about this.
 
 - mrkn: what about Array#delete with multiple arguments?
 
-- \[Feature [#2074](https://bugs.ruby-lang.org/issues/2074)\] json の j や jj は module\_function にするべき？
+- [[Feature #2074]](https://bugs.ruby-lang.org/issues/2074) json の j や jj は module\_function にするべき？
 
 - akr: This is a 3PI
 
-- \[Feature [#9209](https://bugs.ruby-lang.org/issues/9209)\]\[Feature [#11925](https://bugs.ruby-lang.org/issues/11925)\] Struct instances creatable with named args (nobu)
+- [[Feature #9209]](https://bugs.ruby-lang.org/issues/9209)[[Feature #11925]](https://bugs.ruby-lang.org/issues/11925) Struct instances creatable with named args (nobu)
 
 - akr: naming issue.
 
-- \[Feature [#12802](https://bugs.ruby-lang.org/issues/12802)\] Add BLAKE2 support to Digest (nobu)
+- [[Feature #12802]](https://bugs.ruby-lang.org/issues/12802) Add BLAKE2 support to Digest (nobu)
 
 - naruse: do we need this?  no actual use yet.  SHA3 has chance.
 - naruse: just let people use OpenSSL directly.
 - akira: seems Tony does not demand this but saying “if someone has interest …”
 
-- \[Feature [#12861](https://bugs.ruby-lang.org/issues/12861)\] Lexically scoped super (nobu)
+- [[Feature #12861]](https://bugs.ruby-lang.org/issues/12861) Lexically scoped super (nobu)
 
 - nobu: define\_method is the cause of evil
 - matz: I’m not sure if lexically-scoped super would actually get used or not.
 
-- \[Bug [#12812](https://bugs.ruby-lang.org/issues/12812)\] Added Coverage#result= (shyuohei)
+- [[Bug #12812]](https://bugs.ruby-lang.org/issues/12812) Added Coverage#result= (shyuohei)
 
 - mame is assigned, let him handle this
 
-- \[Feature [#12180](https://bugs.ruby-lang.org/issues/12180)\] switch id\_table.c variant (shyouhei) ko1?
+- [[Feature #12180]](https://bugs.ruby-lang.org/issues/12180) switch id\_table.c variant (shyouhei) ko1?
 
 - is it OK?
 
-- \[Feature [#8158](https://bugs.ruby-lang.org/issues/8158)\] lightweight structure for loaded features index (shyouhei)
+- [[Feature #8158]](https://bugs.ruby-lang.org/issues/8158) lightweight structure for loaded features index (shyouhei)
 
 - naruse: not for 2.4 but seems OK for 2.5.
 
-- \[Feature [#12839](https://bugs.ruby-lang.org/issues/12839)\] CSV - Give not nil but empty strings for empty fields (shyouhei) assign who?
+- [[Feature #12839]](https://bugs.ruby-lang.org/issues/12839) CSV - Give not nil but empty strings for empty fields (shyouhei) assign who?
 
 - CSV has no maintenar
 
-- \[Feature [#12854](https://bugs.ruby-lang.org/issues/12854)\] Proc#curry should return an instance of the class, not Proc (shyouhei)
+- [[Feature #12854]](https://bugs.ruby-lang.org/issues/12854) Proc#curry should return an instance of the class, not Proc (shyouhei)
 
 - akr: we are not sure if it is safe, because curry is something very conceptual.
 
-- \[Bug [#12855](https://bugs.ruby-lang.org/issues/12855)\] Inconsistent keys identity in compare\_by\_identity Hash when using literals (shyouhei) bug or...?
+- [[Bug #12855]](https://bugs.ruby-lang.org/issues/12855) Inconsistent keys identity in compare\_by\_identity Hash when using literals (shyouhei) bug or...?
 
 - akr: this is an over-optimization.
 
-- \[Feature [#12882](https://bugs.ruby-lang.org/issues/12882)\] Add caller/file/line information to internal Kernel#warn calls (shyouhei)
+- [[Feature #12882]](https://bugs.ruby-lang.org/issues/12882) Add caller/file/line information to internal Kernel#warn calls (shyouhei)
 
 - matz will respond
 
-- \[Feature [#7360](https://bugs.ruby-lang.org/issues/7360)\] Adding Pathname#glob (shyouhei)
+- [[Feature #7360]](https://bugs.ruby-lang.org/issues/7360) Adding Pathname#glob (shyouhei)
 
 - akr: I understand the needs but the implementation is wrong.
 
@@ -287,21 +287,21 @@ Issues
 2. then implement.
 3. then this ticket should use that.
 
-- \[Feature [#11286](https://bugs.ruby-lang.org/issues/11286)\] \[PATCH\] Add case equality arity to Enumerable's sequence predicates. (shyouhei)
+- [[Feature #11286]](https://bugs.ruby-lang.org/issues/11286) \[PATCH\] Add case equality arity to Enumerable's sequence predicates. (shyouhei)
 
 - shyouhei: seems the OP wants some variant of grep
 - akr: regexp might be straight-forward to read but?
 - matz: positive, but might be better in another name?
 
-- \[Feature [#5446](https://bugs.ruby-lang.org/issues/5446)\] at\_fork callback API (shyouhei)
+- [[Feature #5446]](https://bugs.ruby-lang.org/issues/5446) at\_fork callback API (shyouhei)
 
 - what about make it as a pure-ruby gem?
 
-- \[Feature [#12780](https://bugs.ruby-lang.org/issues/12780)\] BigDecimal#round returns different types depending on argument (shyouhei)
-- \[Feature [#11428](https://bugs.ruby-lang.org/issues/11428)\] system/exec/etc. should to\_s their argument to restore Pathname functionality as it was in 1.8 (shyouhei)
-- \[Feature [#12180](https://bugs.ruby-lang.org/issues/12180)\] switch id\_table.c variant (shyouhei)
+- [[Feature #12780]](https://bugs.ruby-lang.org/issues/12780) BigDecimal#round returns different types depending on argument (shyouhei)
+- [[Feature #11428]](https://bugs.ruby-lang.org/issues/11428) system/exec/etc. should to\_s their argument to restore Pathname functionality as it was in 1.8 (shyouhei)
+- [[Feature #12180]](https://bugs.ruby-lang.org/issues/12180) switch id\_table.c variant (shyouhei)
 
-- \[Feature [#5481](https://bugs.ruby-lang.org/issues/5481)\] [https://bugs.ruby-lang.org/issues/5481](https://bugs.ruby-lang.org/issues/5481)
+- [[Feature #5481]](https://bugs.ruby-lang.org/issues/5481) [https://bugs.ruby-lang.org/issues/5481](https://bugs.ruby-lang.org/issues/5481)
 
 - \[Bug [#12998](https://bugs.ruby-lang.org/issues/12998)[\] paragraph mode inconsistency between](https://bugs.ruby-lang.org/issues/5481) [IO#each\_line](https://bugs.ruby-lang.org/issues/5481) [and](https://bugs.ruby-lang.org/issues/5481) [String#each\_line](https://bugs.ruby-lang.org/issues/5481)[(nobu)](https://bugs.ruby-lang.org/issues/5481)
 

--- a/2017/DevMeeting-2017-01-19.md
+++ b/2017/DevMeeting-2017-01-19.md
@@ -154,7 +154,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 
 ## Carry-over from previous meeting(s)
 
-## \[Feature [#12180](https://bugs.ruby-lang.org/issues/12180)\] switch id\_table.c variant (shyouhei)
+## [[Feature #12180]](https://bugs.ruby-lang.org/issues/12180) switch id\_table.c variant (shyouhei)
 
 
 - ko1: funny-falcon’s open addressing hash is beating mine.
@@ -163,7 +163,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: isn’t it too big for a new comer?
 - ko1: I see. I’ll do.
 
-## \[Feature [#12944](https://bugs.ruby-lang.org/issues/12944)\] Change Kernel#warn to call Warning.warn (shyouhei)
+## [[Feature #12944]](https://bugs.ruby-lang.org/issues/12944) Change Kernel#warn to call Warning.warn (shyouhei)
 
 
 - nobu: what spec?
@@ -171,7 +171,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: compatibility concern?
 - matz: why not just try it.
 
-## \[Feature [#13124](https://bugs.ruby-lang.org/issues/13124)\] Should #puts convert to external encoding? (shyouhei)
+## [[Feature #13124]](https://bugs.ruby-lang.org/issues/13124) Should #puts convert to external encoding? (shyouhei)
 
 
 - shyouhei: what’s this?
@@ -182,7 +182,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: I think it’s OK for particular IO that needs encoding, it’s convenient to have such feature.
 - naruse: OK, I’ll respond.
 
-## \[Feature [#13017](https://bugs.ruby-lang.org/issues/13017)\] Switch SipHash from SipHash24 to SipHash13 (shyouhei)
+## [[Feature #13017]](https://bugs.ruby-lang.org/issues/13017) Switch SipHash from SipHash24 to SipHash13 (shyouhei)
 
 
 - shyouhei: I'm confident it's OK to go to 2.5.
@@ -191,7 +191,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - shyouhei: I will
 - matz: go ahead.
 
-## \[Bug [#12998](https://bugs.ruby-lang.org/issues/12998)\] paragraph mode inconsistency between IO#each\_line and String#each\_line(nobu)
+## [[Bug #12998]](https://bugs.ruby-lang.org/issues/12998) paragraph mode inconsistency between IO#each\_line and String#each\_line(nobu)
 
 
 - ko1: ideal behaviour?
@@ -199,7 +199,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - matz: (nod)
 - nobu: I already merged this.
 
-## \[Feature [#8158](https://bugs.ruby-lang.org/issues/8158)\] lightweight structure for loaded features index (shyouhei)
+## [[Feature #8158]](https://bugs.ruby-lang.org/issues/8158) lightweight structure for loaded features index (shyouhei)
 
 
 - ko1: nobody but nobu can say if it’s OK.
@@ -207,7 +207,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - hsbt: why not let funny-falcon merge this?
 - matz: I take the idea.
 
-## \[Feature [#12854](https://bugs.ruby-lang.org/issues/12854)\] Proc#curry should return an instance of the class, not Proc (shyouhei)
+## [[Feature #12854]](https://bugs.ruby-lang.org/issues/12854) Proc#curry should return an instance of the class, not Proc (shyouhei)
 
 
 - ko1: general idea?
@@ -216,7 +216,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - matz: seems they are different proposals than applications of #curry.
 - matz: I’ll ask for use cases.
 
-## \[Feature [#5481](https://bugs.ruby-lang.org/issues/5481)\] Gemifying Ruby standard library (hsbt)
+## [[Feature #5481]](https://bugs.ruby-lang.org/issues/5481) Gemifying Ruby standard library (hsbt)
 
 
 - hsbt: Waiting approval of Matz
@@ -234,7 +234,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: I see concerns of dependency hell.
 - hsbt: it’s OK we create separate ML threads for each library to discuss.
 
-## \[Feature [#12901](https://bugs.ruby-lang.org/issues/12901)\] Anonymous functions without scope lookup overhead (shyouhei)
+## [[Feature #12901]](https://bugs.ruby-lang.org/issues/12901) Anonymous functions without scope lookup overhead (shyouhei)
 
 
 - ko1: matz said we should automatically optimize procs when possible, not explicitly stating like this.
@@ -250,7 +250,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 
 - matz will respond, ko1 to create a new ticket that refer this one.
 
-## \[Feature [#12906](https://bugs.ruby-lang.org/issues/12906)\] do/end blocks work with ensure/rescue/else (shyouhei)
+## [[Feature #12906]](https://bugs.ruby-lang.org/issues/12906) do/end blocks work with ensure/rescue/else (shyouhei)
 
 
 - shyouhei: OP is wise because he do not talk about { … }
@@ -261,7 +261,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: generally speaking it is good to reduce indent.
 - matz: Let me think about it. -> OK
 
-## \[Feature [#12926](https://bugs.ruby-lang.org/issues/12926)\] -l flag for line end processing should use chomp! instead of chop! (shyouhei)
+## [[Feature #12926]](https://bugs.ruby-lang.org/issues/12926) -l flag for line end processing should use chomp! instead of chop! (shyouhei)
 
 
 - nobu: perl behaves like chomp.
@@ -270,7 +270,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - akr: chomp is ruby1.1+, \-l already exists in ruby 0.95
 - matz: OK.
 
-## \[Feature [#12912](https://bugs.ruby-lang.org/issues/12912)\] An endless range (1..) (shyouhei)
+## [[Feature #12912]](https://bugs.ruby-lang.org/issues/12912) An endless range (1..) (shyouhei)
 
 
 - shyouhei: what about opossite side ...1?
@@ -285,13 +285,13 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - nobu: (1..) seems visually odd.
 - akr: for now, use step and drop.
 
-## \[Feature [#12933](https://bugs.ruby-lang.org/issues/12933)\] Add Some and Optional (shyouhei)
+## [[Feature #12933]](https://bugs.ruby-lang.org/issues/12933) Add Some and Optional (shyouhei)
 
 
 - nobu: start as a gem.
 - matz: agree.
 
-## \[Feature [#12931](https://bugs.ruby-lang.org/issues/12931)\] Add support for Binding#instance\_eval (shyouhei)
+## [[Feature #12931]](https://bugs.ruby-lang.org/issues/12931) Add support for Binding#instance\_eval (shyouhei)
 
 
 - shyouhei: what is needed ultimately is to pass a block to Binding#eval
@@ -299,7 +299,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - nobu: I think it’s not faster, if not impossible.
 - nobu will reject.
 
-## \[Feature [#12929](https://bugs.ruby-lang.org/issues/12929)\] ternary should look ahead w/in a block (and not care about newlines) (shyouhei)
+## [[Feature #12929]](https://bugs.ruby-lang.org/issues/12929) ternary should look ahead w/in a block (and not care about newlines) (shyouhei)
 
 
 - naruse: perl people tends to write it.
@@ -307,14 +307,14 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - shyouhei: Martin says we already look-ahead for periods.
 - matz: Python ignores newlines inside of parens.
 
-## \[Misc [#12935](https://bugs.ruby-lang.org/issues/12935)\] Webrick: Update HTTP Status codes, share them (shyouhei)
+## [[Misc #12935]](https://bugs.ruby-lang.org/issues/12935) Webrick: Update HTTP Status codes, share them (shyouhei)
 
 
 - nobu: is it Webrick?
 - akr: Webrick has this code but no one wants to require the whole.
 - akira: nobody looks at anywhere but Rack.
 
-## \[Feature [#12962](https://bugs.ruby-lang.org/issues/12962)\] Feature Proposal: Extend 'protected' to support module friendship (shyouhei)
+## [[Feature #12962]](https://bugs.ruby-lang.org/issues/12962) Feature Proposal: Extend 'protected' to support module friendship (shyouhei)
 
 
 - akr: use of protected is discouraged.
@@ -323,31 +323,31 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - naruse: I think it’s RuboCop’s duty to warn such thing.
 - akr: it’s a good thing anyway to update rdoc to discourage usages.
 
-## \[Feature [#12957](https://bugs.ruby-lang.org/issues/12957)\] A more OO way to create lambda Procs (shyouhei)
+## [[Feature #12957]](https://bugs.ruby-lang.org/issues/12957) A more OO way to create lambda Procs (shyouhei)
 
 
 - akr: I don’t understand the OP’s intension.
 - shyouhei: I think they want a subclass of lambda.  that’s not possible today.
 - akr: it is possible. complicated though. ->  commented.
 
-## \[Feature [#12966](https://bugs.ruby-lang.org/issues/12966)\] net/ftp to include fxp support? (shyouhei) who's going to handle this?
+## [[Feature #12966]](https://bugs.ruby-lang.org/issues/12966) net/ftp to include fxp support? (shyouhei) who's going to handle this?
 
 
 - shugo is handling.
 
-## \[Feature [#12967](https://bugs.ruby-lang.org/issues/12967)\] Add a default for RUBY\_GC\_HEAP\_GROWTH\_MAX\_SLOTS out-of-the-box (shyouhei)
+## [[Feature #12967]](https://bugs.ruby-lang.org/issues/12967) Add a default for RUBY\_GC\_HEAP\_GROWTH\_MAX\_SLOTS out-of-the-box (shyouhei)
 
 
 - ko1: I’m not sure if this parameter is a sane default.
 - ko1: also, I think there should be a comprehensive approach to parameterize GC, not individually like this.
 
-## \[Feature [#12969](https://bugs.ruby-lang.org/issues/12969)\] Allow optional parameter in String#strip and related (shyouhei)
+## [[Feature #12969]](https://bugs.ruby-lang.org/issues/12969) Allow optional parameter in String#strip and related (shyouhei)
 
 
 - naruse: I think regexp is the best for this purpose.
 - naruse: I don’t like the tr-like argument string.
 
-## \[Feature [#13016](https://bugs.ruby-lang.org/issues/13016)\] String#gsub(hash) (shyouhei)
+## [[Feature #13016]](https://bugs.ruby-lang.org/issues/13016) String#gsub(hash) (shyouhei)
 
 
 - akr: what’s wrong with union?
@@ -357,49 +357,49 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - shyouhei: understand that point.
 - naruse: you have to sort by length before union. Otherwise カ can match before ガ.
 
-## \[Bug [#8241](https://bugs.ruby-lang.org/issues/8241)\] If uri host-part has underscore ( '\_' ), 'URI#parse' raise 'URI::InvalidURIError' (shyouhei)
+## [[Bug #8241]](https://bugs.ruby-lang.org/issues/8241) If uri host-part has underscore ( '\_' ), 'URI#parse' raise 'URI::InvalidURIError' (shyouhei)
 
 
 - naruse: I think this is done.
 
-## \[Bug [#8826](https://bugs.ruby-lang.org/issues/8826)\] BigDecimal#div and #quo different behavior and inconsistencies (shyouhei) status?>mrkn
+## [[Bug #8826]](https://bugs.ruby-lang.org/issues/8826) BigDecimal#div and #quo different behavior and inconsistencies (shyouhei) status?>mrkn
 
 
 - mkrn: I'll start to fix it as soon as possible.
 
-## \[Feature [#13048](https://bugs.ruby-lang.org/issues/13048)\] Better way to do Regexp.new(Regexp.escape("some string")) (shyouhei)
+## [[Feature #13048]](https://bugs.ruby-lang.org/issues/13048) Better way to do Regexp.new(Regexp.escape("some string")) (shyouhei)
 
 
 - naruse: quick look at the github result seems every usage of Regexp.new(Regexp.escape()) are bad.
 - akr: Regexp.exact() ?
 
-## \[Bug [#13111](https://bugs.ruby-lang.org/issues/13111)\] Degraded performance for delegated methods through Forwardable module (shyouhei) assign who?
+## [[Bug #13111]](https://bugs.ruby-lang.org/issues/13111) Degraded performance for delegated methods through Forwardable module (shyouhei) assign who?
 
 
 - nobu: I did this already I think.
 
-## \[Bug [#13098](https://bugs.ruby-lang.org/issues/13098)\] miniruby fails with SEGV on NetBSD/powerpc (shyouhei) look at the backtarce (shyouhei)
+## [[Bug #13098]](https://bugs.ruby-lang.org/issues/13098) miniruby fails with SEGV on NetBSD/powerpc (shyouhei) look at the backtarce (shyouhei)
 
 
 - nobu: will take a look.
 
-## \[Bug [#13125](https://bugs.ruby-lang.org/issues/13125)\] MRI has too much Qtrue : Qfalse; (shyouhei)
+## [[Bug #13125]](https://bugs.ruby-lang.org/issues/13125) MRI has too much Qtrue : Qfalse; (shyouhei)
 
 
 - nobu: nobody is against the needs of macro but the name?
 - shyouhei: will update the ticket.
 
-## \[Bug [#13127](https://bugs.ruby-lang.org/issues/13127)\] DRb \`load': connection closed (DRb::DRbConnError) when client exit's from within a loop iterating over remote objects (shyouhei)
+## [[Bug #13127]](https://bugs.ruby-lang.org/issues/13127) DRb \`load': connection closed (DRb::DRbConnError) when client exit's from within a loop iterating over remote objects (shyouhei)
 
 
 - assign seki
 
-## \[Feature [#13067](https://bugs.ruby-lang.org/issues/13067)\] TrueClass,FalseClass to provide \=== to match truthy/falsy values. (shyouhei)
+## [[Feature #13067]](https://bugs.ruby-lang.org/issues/13067) TrueClass,FalseClass to provide \=== to match truthy/falsy values. (shyouhei)
 
 
 - matz: I give up.
 
-## \[Bug [#13064](https://bugs.ruby-lang.org/issues/13064)\] Inconsistent behavior with next inside begin/end across different implementations. (shyouhei) spec or...?
+## [[Bug #13064]](https://bugs.ruby-lang.org/issues/13064) Inconsistent behavior with next inside begin/end across different implementations. (shyouhei) spec or...?
 
 
 - ko1: it’s 1 to me.
@@ -407,12 +407,12 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - ko1:  it is.  Because you can’t place next here statically.
 - akr: should the JIS/ISO specify as such?
 
-## \[Bug [#13104](https://bugs.ruby-lang.org/issues/13104)\] math.rb affects Rational literals (nobu)
+## [[Bug #13104]](https://bugs.ruby-lang.org/issues/13104) math.rb affects Rational literals (nobu)
 
 
 - matz: it’s ugly, but mathn is ugly by nature.
 
-## \[Bug [#9569](https://bugs.ruby-lang.org/issues/9569)\] SecureRandom should try /dev/urandom first (shyouhei) I now think it's OK
+## [[Bug #9569]](https://bugs.ruby-lang.org/issues/9569) SecureRandom should try /dev/urandom first (shyouhei) I now think it's OK
 
 
 - shyouhei: I will

--- a/2017/DevMeeting-2017-03-13.md
+++ b/2017/DevMeeting-2017-03-13.md
@@ -152,7 +152,7 @@ log: TBD
 
 ## Carry-over from previous meeting(s)
 
-- \[Feature [#13110](https://bugs.ruby-lang.org/issues/13110)\] Byte-based operations for String (shugo)
+- [[Feature #13110]](https://bugs.ruby-lang.org/issues/13110) Byte-based operations for String (shugo)
 
 - matz: OK for byteoffset.
 - akr: destructive modification using bytesplice may cause string rescan because it can break validity of the string.
@@ -160,7 +160,7 @@ log: TBD
 - naruse: that is byteoffset here.
 - akr: byteindex may have problem for inter-codepoint index.
 
-- \[Bug [#13105](https://bugs.ruby-lang.org/issues/13105)\] String#to\_f and String#to\_r don't stop successive underscores (nobu)
+- [[Bug #13105]](https://bugs.ruby-lang.org/issues/13105) String#to\_f and String#to\_r don't stop successive underscores (nobu)
 
 - nobu: is this intentional?
 - ko1: ignore all underscores?
@@ -175,17 +175,17 @@ log: TBD
 
 - matz: OK, lets make it as we do as literals.
 
-- \[Feature [#13109](https://bugs.ruby-lang.org/issues/13109)\] using in refinements is required to be physically placed before the refined method call (shyouhei)
+- [[Feature #13109]](https://bugs.ruby-lang.org/issues/13109) using in refinements is required to be physically placed before the refined method call (shyouhei)
 
 - matz: I don’t think it’s a bug. It’s intentional.  But we may allow this as an extension.
 
-- \[Bug [#12705](https://bugs.ruby-lang.org/issues/12705)\] yielding args to a lambda uses block/proc rather than lambda/method semantics (shyouhei) status?
+- [[Bug #12705]](https://bugs.ruby-lang.org/issues/12705) yielding args to a lambda uses block/proc rather than lambda/method semantics (shyouhei) status?
 
 - ko1: we should fix the interpreter
 - ko1: we introduced ad-hoc change to lambda creation but that turned out to be a mistake, and observed here.
 - ko1: to be fixed in 2.5.
 
-- \[Feature [#13095](https://bugs.ruby-lang.org/issues/13095)\] \[PATCH\] io.c (rb\_f\_syscall): remove deprecation notice (shyouhei)
+- [[Feature #13095]](https://bugs.ruby-lang.org/issues/13095) \[PATCH\] io.c (rb\_f\_syscall): remove deprecation notice (shyouhei)
 
 - shyouhei: do we want to remove system calls?
 - akr: yes.
@@ -195,12 +195,12 @@ log: TBD
 - akr: current situation is too difficult to use properly, too easy to get used.
 - akr: my suggestion is to move it to ext/syscall.
 
-- \[Feature [#13122](https://bugs.ruby-lang.org/issues/13122)\] Special syntax for Hash#default\_proc (shyouhei)
+- [[Feature #13122]](https://bugs.ruby-lang.org/issues/13122) Special syntax for Hash#default\_proc (shyouhei)
 
 - tal: not only default proc, but also there are default values.
 - matz: reject
 
-- \[Feature [#12650](https://bugs.ruby-lang.org/issues/12650)\] Use UTF-8 encoding for ENV on Windows (duerst)
+- [[Feature #12650]](https://bugs.ruby-lang.org/issues/12650) Use UTF-8 encoding for ENV on Windows (duerst)
 
 - nobu: ENV is about inter-process, we cannot change alone.
 - shyouhei: seems they need something like “UTF-8 mode”
@@ -214,7 +214,7 @@ log: TBD
 - duerst: when a PC is used by only one person ENV tends to remain single encoding but when people share a PC, ENV is shared across users. (cp437?)
 - nobu: system-wide.
 
-- \[Feature [#6284](https://bugs.ruby-lang.org/issues/6284)\] Add composition for procs (shyouhei)
+- [[Feature #6284]](https://bugs.ruby-lang.org/issues/6284) Add composition for procs (shyouhei)
 
 - ko1: is it a matter of speed?
 - shyouhei: it seems composition is faster now
@@ -223,36 +223,36 @@ log: TBD
 - matz: I have no strong opinion on it.
 - matz: I’ll respond.
 
-- \[Feature [#13137](https://bugs.ruby-lang.org/issues/13137)\] Hash Shorthand (shyouhei)
+- [[Feature #13137]](https://bugs.ruby-lang.org/issues/13137) Hash Shorthand (shyouhei)
 
 - matz: reject
 
-- \[Feature [#13166](https://bugs.ruby-lang.org/issues/13166)\] Feature Request: Byte Arrays for Ruby 3 (shyouhei)
+- [[Feature #13166]](https://bugs.ruby-lang.org/issues/13166) Feature Request: Byte Arrays for Ruby 3 (shyouhei)
 
 - akr: I’m for this but I don’t think I can persuade matz.
 - matz: exactly.
 - akr: so I proposed setbit/getbit, in order for the OP to create a dedicated class on top of it.
 
-- \[Feature [#9116](https://bugs.ruby-lang.org/issues/9116)\] String#rsplit missing (shyouhei)
+- [[Feature #9116]](https://bugs.ruby-lang.org/issues/9116) String#rsplit missing (shyouhei)
 
 - akr: what’s this?
 - shyouhei: they say python’s
 - naruse: use case?
 - tal: rsplit(...,2) can be generally written using regexp. ohter cases when we cant do this using regexp?
 
-- \[Feature [#4532](https://bugs.ruby-lang.org/issues/4532)\] \[PATCH\] add IO#pread and IO#pwrite methods (shyouhei)
+- [[Feature #4532]](https://bugs.ruby-lang.org/issues/4532) \[PATCH\] add IO#pread and IO#pwrite methods (shyouhei)
 
 - akr: portability concern? This is POSIX but added recently.
 - shyouhei: POSIX issue 5
 - akr: at least 2001 version has this.
 - matz: OK.
 
-- \[Bug [#13146](https://bugs.ruby-lang.org/issues/13146)\] Float::NANs in Hashes are confusing (more than usual). (mrkn)
+- [[Bug #13146]](https://bugs.ruby-lang.org/issues/13146) Float::NANs in Hashes are confusing (more than usual). (mrkn)
 
 - nobu: prohibit inserting NaNs into hashs?
 - naruse: that’s nonsense.
 
-- \[Bug [#13134](https://bugs.ruby-lang.org/issues/13134)\] Rational() inconsistency (nobu)
+- [[Bug #13134]](https://bugs.ruby-lang.org/issues/13134) Rational() inconsistency (nobu)
 
 - matz: OK.
 
@@ -273,39 +273,39 @@ log: TBD
 - naruse: should we backport this?
 - matz: I don’t think so.
 
-- \[Bug [#13181](https://bugs.ruby-lang.org/issues/13181)\] Unexpected line in rescue backtrace (shyouhei) what's this?
+- [[Bug #13181]](https://bugs.ruby-lang.org/issues/13181) Unexpected line in rescue backtrace (shyouhei) what's this?
 - this week's "assign whom?" section (shyouhei)
 
-- \[Bug [#13271](https://bugs.ruby-lang.org/issues/13271)\] Clarifications on refinement spec
-- \[Bug [#13269](https://bugs.ruby-lang.org/issues/13269)\] test/readline/test\_readline.rb and mingw
-- \[Bug [#13298](https://bugs.ruby-lang.org/issues/13298)\] mingw SEGV TestEnumerable#test\_callcc
-- \[Bug [#13280](https://bugs.ruby-lang.org/issues/13280)\] net/ftp: Putbinaryfile (on Windows) requires blocksize equal to file size
-- \[Bug [#13276](https://bugs.ruby-lang.org/issues/13276)\] Dir.glob returns empty array when OS has no more file handles (expected exception)
+- [[Bug #13271]](https://bugs.ruby-lang.org/issues/13271) Clarifications on refinement spec
+- [[Bug #13269]](https://bugs.ruby-lang.org/issues/13269) test/readline/test\_readline.rb and mingw
+- [[Bug #13298]](https://bugs.ruby-lang.org/issues/13298) mingw SEGV TestEnumerable#test\_callcc
+- [[Bug #13280]](https://bugs.ruby-lang.org/issues/13280) net/ftp: Putbinaryfile (on Windows) requires blocksize equal to file size
+- [[Bug #13276]](https://bugs.ruby-lang.org/issues/13276) Dir.glob returns empty array when OS has no more file handles (expected exception)
 
 - nobu: this one predates 1.0. should we backport?
 - matz: I don’t think so.
 
-- \[Bug [#13284](https://bugs.ruby-lang.org/issues/13284)\] IA64 ruby 2.4 miniruby segfault
-- \[Bug [#13286](https://bugs.ruby-lang.org/issues/13286)\] Segfault when using rb\_debug\_inspector\_open / rb\_debug\_inspector\_frame\_binding\_get with Fiddle, but not when directly from C extension
-- \[Bug [#13305](https://bugs.ruby-lang.org/issues/13305)\] Occasional segfaults after defining methods while running coverage
-- \[Bug [#13307](https://bugs.ruby-lang.org/issues/13307)\] Changing scheme from http to https for the URI does not change the port number
+- [[Bug #13284]](https://bugs.ruby-lang.org/issues/13284) IA64 ruby 2.4 miniruby segfault
+- [[Bug #13286]](https://bugs.ruby-lang.org/issues/13286) Segfault when using rb\_debug\_inspector\_open / rb\_debug\_inspector\_frame\_binding\_get with Fiddle, but not when directly from C extension
+- [[Bug #13305]](https://bugs.ruby-lang.org/issues/13305) Occasional segfaults after defining methods while running coverage
+- [[Bug #13307]](https://bugs.ruby-lang.org/issues/13307) Changing scheme from http to https for the URI does not change the port number
 
-- \[Bug [#13282](https://bugs.ruby-lang.org/issues/13282)\] opt\_str\_freeze does not always dedupe (shyouhei)
+- [[Bug #13282]](https://bugs.ruby-lang.org/issues/13282) opt\_str\_freeze does not always dedupe (shyouhei)
 
 - shyouhei: this is about power\_assert
 - akr: what’s wrong with it?
 - shyouhei: seems tracepoint?
 - ko1: don’t know the exact reason.
 
-- \[Feature [#13295](https://bugs.ruby-lang.org/issues/13295)\] \[PATCH\] compile.c: apply opt\_str\_freeze to String#-@ (uminus) (shyohei) seems OK to me as well
+- [[Feature #13295]](https://bugs.ruby-lang.org/issues/13295) \[PATCH\] compile.c: apply opt\_str\_freeze to String#-@ (uminus) (shyohei) seems OK to me as well
 
 - ko1: this is buggy.  Can’t redefine \-@ in this patch.
 
-- \[Feature [#13179](https://bugs.ruby-lang.org/issues/13179)\] Deep Hash Update Method (shyouhei)
+- [[Feature #13179]](https://bugs.ruby-lang.org/issues/13179) Deep Hash Update Method (shyouhei)
 
 - nobu: #bury has already been rejected, no update since then.
 
-- \[Misc [#13283](https://bugs.ruby-lang.org/issues/13283)\] Disable \`&' interpreted as argument prefix warning when passing symbol to Enumerable#map (duerst)
+- [[Misc #13283]](https://bugs.ruby-lang.org/issues/13283) Disable \`&' interpreted as argument prefix warning when passing symbol to Enumerable#map (duerst)
 
 - duerst: the warning is older than Symbol#to\_proc
 - shyouhei: why not suppress the warning for symbol literals, not for variables
@@ -314,18 +314,18 @@ log: TBD
 - matz: mruby won’t warn this case?
 - nobu: it does.
 
-- \[Feature [#13290](https://bugs.ruby-lang.org/issues/13290)\] A method to use a hash like in a case construction (duerst)
+- [[Feature #13290]](https://bugs.ruby-lang.org/issues/13290) A method to use a hash like in a case construction (duerst)
 
 - matz: I don’t understand the usage.  Let me ask the OP.
 
-- \[Feature [#13077](https://bugs.ruby-lang.org/issues/13077)\] \[PATCH\] introduce String#fstring method (ko1) some discussions on twitter they don't like \-'str' notation.
+- [[Feature #13077]](https://bugs.ruby-lang.org/issues/13077) \[PATCH\] introduce String#fstring method (ko1) some discussions on twitter they don't like \-'str' notation.
 
 - shyouhei: we can add other stylish names later. \-@ is “for the time being”.
 - matz: if you have opinions, have a separate issue.
 
 ## From non-attendees
 
-- \[Bug [#13223](https://bugs.ruby-lang.org/issues/13223)\] What should the behavior of File.join be when File::SEPARATOR is set? Can I apply this patch? (tenderlove)
+- [[Bug #13223]](https://bugs.ruby-lang.org/issues/13223) What should the behavior of File.join be when File::SEPARATOR is set? Can I apply this patch? (tenderlove)
 
 - ko1: this is a bug.
 - nobu: this is either we fix the document to allow other separators or not.

--- a/2017/DevMeeting-2017-04-17.md
+++ b/2017/DevMeeting-2017-04-17.md
@@ -157,39 +157,39 @@ log: TBD
 
 ## Carry-over from previous meeting(s)
 
-- \[Bug [#13257](https://bugs.ruby-lang.org/issues/13257)\] Symbol#respond\_to?(:singleton\_class) should be false (naruse)
+- [[Bug #13257]](https://bugs.ruby-lang.org/issues/13257) Symbol#respond\_to?(:singleton\_class) should be false (naruse)
 
 - akr: I feel it’s OK to undef them.
 - matz: I doubt to check behaviours using respond\_to?
 - nalsh: class << obj; creates a singleton class if not.  This is not good.
 - nobu: It seems what OP wants is actually a list of extended modules, which is not currently obtainable.
 
-- \[Misc [#13163](https://bugs.ruby-lang.org/issues/13163)\] Uncaught exceptions may not be reported when Thread#report\_on\_exception=true and Thread#abort\_on\_exception=true (naruse)
+- [[Misc #13163]](https://bugs.ruby-lang.org/issues/13163) Uncaught exceptions may not be reported when Thread#report\_on\_exception=true and Thread#abort\_on\_exception=true (naruse)
 
 - nobu: OK to me.
 
-- \[Bug [#13181](https://bugs.ruby-lang.org/issues/13181)\] Unexpected line in rescue backtrace (shyouhei) what's this?
+- [[Bug #13181]](https://bugs.ruby-lang.org/issues/13181) Unexpected line in rescue backtrace (shyouhei) what's this?
 
 - assign ko1
 
-- \[Feature [#8263](https://bugs.ruby-lang.org/issues/8263)\] Support discovering yield state of individual Fibers (shyouhei)
+- [[Feature #8263]](https://bugs.ruby-lang.org/issues/8263) Support discovering yield state of individual Fibers (shyouhei)
 
 - assign ko1
 
-- \[Feature [#8576](https://bugs.ruby-lang.org/issues/8576)\] Add optimized method type for constant value methods (shyouhei)
+- [[Feature #8576]](https://bugs.ruby-lang.org/issues/8576) Add optimized method type for constant value methods (shyouhei)
 
 - assign ko1
 
-- \[Bug [#13188](https://bugs.ruby-lang.org/issues/13188)\] Reinitialize Ruby VM. (shyouhei) New C API ...?
+- [[Bug #13188]](https://bugs.ruby-lang.org/issues/13188) Reinitialize Ruby VM. (shyouhei) New C API ...?
 
 - assign ko1
 
-- \[Feature [#2740](https://bugs.ruby-lang.org/issues/2740)\] Extend const\_missing to pass in the nesting (shyouhei)
+- [[Feature #2740]](https://bugs.ruby-lang.org/issues/2740) Extend const\_missing to pass in the nesting (shyouhei)
 
 - matz: does this still work?
 - matz: also, I don’t like autoloading in general.
 
-- \[Feature [#13211](https://bugs.ruby-lang.org/issues/13211)\] Hash#delete taking a splat (shyouhei)
+- [[Feature #13211]](https://bugs.ruby-lang.org/issues/13211) Hash#delete taking a splat (shyouhei)
 
 - mrkn: I once wanted this too
 - akr: return value? array for arity >= 2?
@@ -199,87 +199,87 @@ log: TBD
 - mrkn: That’s Hash#extract!
 - akr: seems what is requested is not a good design, compared to what is wanted.
 
-- \[Bug [#11567](https://bugs.ruby-lang.org/issues/11567)\] Segmentation fault CFUNC :gets (shyouhei)
+- [[Bug #11567]](https://bugs.ruby-lang.org/issues/11567) Segmentation fault CFUNC :gets (shyouhei)
 
 - nobu: it seems race between read and close
 - shyouhei: seems fixed.
 
-- \[Feature [#13172](https://bugs.ruby-lang.org/issues/13172)\] Method that yields object to block and returns result (shyouhei) new name candidate
+- [[Feature #13172]](https://bugs.ruby-lang.org/issues/13172) Method that yields object to block and returns result (shyouhei) new name candidate
 
 - shyouhei: #pass is proposed.
 - matz: It doesn’t sound nice.
 
-- \[Feature [#13224](https://bugs.ruby-lang.org/issues/13224)\] Add FrozenError as a subclass of RuntimeError (shyouhei)
+- [[Feature #13224]](https://bugs.ruby-lang.org/issues/13224) Add FrozenError as a subclass of RuntimeError (shyouhei)
 
 - matz: I don’t want to have infinite number of exceptions but this seems OK.
 
-- \[Misc [#13230](https://bugs.ruby-lang.org/issues/13230)\] Better Do ... while structure (shyouhei)
+- [[Misc #13230]](https://bugs.ruby-lang.org/issues/13230) Better Do ... while structure (shyouhei)
 
 - shyouhei: I don’t understand this.
 - matz: reject
 
-- \[Feature [#13245](https://bugs.ruby-lang.org/issues/13245)\] \[PATCH\] reject inter-thread TLS modification (shyouhei)
+- [[Feature #13245]](https://bugs.ruby-lang.org/issues/13245) \[PATCH\] reject inter-thread TLS modification (shyouhei)
 
 - ko1: we would like to forbid this in a future.
 - shyouhei: what about adding warning.
 - akr: is this need?  We have no problem right now.  Is this worth introducing backwards incompatibility?
 
-- \[Feature [#13252](https://bugs.ruby-lang.org/issues/13252)\] C API for creating strings without copying (shyouhei)
+- [[Feature #13252]](https://bugs.ruby-lang.org/issues/13252) C API for creating strings without copying (shyouhei)
 
 - ko1: the proposal is not doable
 - nobu: maybe we need to have separate deallocator
 - assign ko1
 
-- \[Bug [#13249](https://bugs.ruby-lang.org/issues/13249)\] Access modifiers don't have an effect inside class methods in Ruby >= 2.3 (shyouhei) design issue or bug?
+- [[Bug #13249]](https://bugs.ruby-lang.org/issues/13249) Access modifiers don't have an effect inside class methods in Ruby >= 2.3 (shyouhei) design issue or bug?
 
 - naruse: wasn’t this intentional?
 - ko1: no idea.
 - matz: It’s OK to me to deprecate this, if we can warn this.
 
-- \[Feature [#13265](https://bugs.ruby-lang.org/issues/13265)\] TracePoint for basic operation redefinition (shyouhei)
+- [[Feature #13265]](https://bugs.ruby-lang.org/issues/13265) TracePoint for basic operation redefinition (shyouhei)
 
 - assign ko1
 
-- \[Bug [#12834](https://bugs.ruby-lang.org/issues/12834)\] prepend getting prepended even if it already exists in the ancestors chain (shyouhei)
+- [[Bug #12834]](https://bugs.ruby-lang.org/issues/12834) prepend getting prepended even if it already exists in the ancestors chain (shyouhei)
 
 - akr: doesn’t this loop forever?
 - ko1: no. I fixed that loop.
 - matz: I wanted to change include’s behaviour in 1.9 but not successful then.
 - matz: I started thinking prepend shall be applied many times. For include..?
 
-- \[Bug [#7976](https://bugs.ruby-lang.org/issues/7976)\] TracePoint call is at call point, not call site (shyouhei)
+- [[Bug #7976]](https://bugs.ruby-lang.org/issues/7976) TracePoint call is at call point, not call site (shyouhei)
 
 - ko1: わかる
 - assign ko1
 
-- \[Feature [#12901](https://bugs.ruby-lang.org/issues/12901)\] Anonymous functions without scope lookup overhead (shyouhei) status?
+- [[Feature #12901]](https://bugs.ruby-lang.org/issues/12901) Anonymous functions without scope lookup overhead (shyouhei) status?
 
 - pass this time.
 
-- \[Feature [#12573](https://bugs.ruby-lang.org/issues/12573)\] Introduce a straightforward way to discover whether a process is running (shyouhei)
+- [[Feature #12573]](https://bugs.ruby-lang.org/issues/12573) Introduce a straightforward way to discover whether a process is running (shyouhei)
 
 - akr: locked pidfile does not need this method.
 
-- \[Feature [#13263](https://bugs.ruby-lang.org/issues/13263)\] Add companion integer nth-root method to recent Integer#isqrt (shyouhei)
+- [[Feature #13263]](https://bugs.ruby-lang.org/issues/13263) Add companion integer nth-root method to recent Integer#isqrt (shyouhei)
 
 - shyouhei: I have no idea when this is used.
 - akr: same as above.
 - mrkn: what about asking the OP?
 
-- \[Feature [#9453](https://bugs.ruby-lang.org/issues/9453)\] Return symbols of defined methods for attr and friends (shyouhei) look at the last comment
+- [[Feature #9453]](https://bugs.ruby-lang.org/issues/9453) Return symbols of defined methods for attr and friends (shyouhei) look at the last comment
 
 - shyouhei: the last comment says the situation changed.
 - akr: that sounds reasonable…
 - matz: but definition of multiple methods at once is something special here.
 - matz: will respond.
 
-- \[Feature [#13302](https://bugs.ruby-lang.org/issues/13302)\] Provide a (force) --enable-openssl switch for ruby ./configure (or similar) (shyouhei)
+- [[Feature #13302]](https://bugs.ruby-lang.org/issues/13302) Provide a (force) --enable-openssl switch for ruby ./configure (or similar) (shyouhei)
 
 - shyouhei: openssl needs miniruby and doesn’t stop if absent.
 - naruse: --enable-openssl sounds strange, it should be --with-openssl
 - nobu: what about let --with-ext=openssl to abort if absent.
 
-- \[Feature [#13303](https://bugs.ruby-lang.org/issues/13303)\] String#any? as !String#empty? (shyouhei)
+- [[Feature #13303]](https://bugs.ruby-lang.org/issues/13303) String#any? as !String#empty? (shyouhei)
 
 - matz: I don’t like any? because Enumerable#any? cannot be applied to String straight-forward.
 - matz: str.not\_empty? seems inferior than !str.empty?
@@ -293,79 +293,79 @@ log: TBD
 
 ## From attendees
 
-- \[Feature [#13334](https://bugs.ruby-lang.org/issues/13334)\] Removed deprecated mathn extentions. (hsbt)
+- [[Feature #13334]](https://bugs.ruby-lang.org/issues/13334) Removed deprecated mathn extentions. (hsbt)
 
 - matz: OK.
 
 - Assign who? section (shyouhei)
 
-- \[Bug [#13228](https://bugs.ruby-lang.org/issues/13228)\] s\[i\]=c(assigning a character) for String is slower than Array on Linux
+- [[Bug #13228]](https://bugs.ruby-lang.org/issues/13228) s\[i\]=c(assigning a character) for String is slower than Array on Linux
 
 - shyouhei: that search\_nonascii is unavoidable
 - naruse: 5x slower on my machine
 - nobu: no difference on my macine
 - shyouhei: what’s the cause?
 
-- \[Bug [#13264](https://bugs.ruby-lang.org/issues/13264)\] Binding#irb does not work in context of frozen object
-- \[Bug [#12642](https://bugs.ruby-lang.org/issues/12642)\] Net::HTTP populates host header incorrectly when using an IPv6 Address
-- \[Bug [#13196](https://bugs.ruby-lang.org/issues/13196)\] Improve keyword argument errors when non-keyword arguments given
-- \[Bug [#13320](https://bugs.ruby-lang.org/issues/13320)\] rescue blocks get an entry in backtrace locations
-- \[Bug [#13324](https://bugs.ruby-lang.org/issues/13324)\] IRB Segmentation Fault from eval infinite loop
-- \[Bug [#13330](https://bugs.ruby-lang.org/issues/13330)\] Array.include? is slow for symbols
-- \[Bug [#13336](https://bugs.ruby-lang.org/issues/13336)\] Default Parameters don't work
-- \[Bug [#13337](https://bugs.ruby-lang.org/issues/13337)\] Eval and Later Defined Local Variables
-- \[Bug [#13338](https://bugs.ruby-lang.org/issues/13338)\] MinGW SEGV in test/ruby/test\_keyword.rb svn 58034, ok in svn 58021.
-- \[Bug [#13390](https://bugs.ruby-lang.org/issues/13390)\] MinGW build test-all SEGV, issue in test framework or error recovery?
-- \[Bug [#13350](https://bugs.ruby-lang.org/issues/13350)\] File.read :newline option not respected on Linux
-- \[Feature [#13362](https://bugs.ruby-lang.org/issues/13362)\] \[PATCH\] socket: avoid fcntl for read/write\_nonblock on Linux
-- \[Bug [#13351](https://bugs.ruby-lang.org/issues/13351)\] net/http: Net::HTTP.start sets wrong default arg value
+- [[Bug #13264]](https://bugs.ruby-lang.org/issues/13264) Binding#irb does not work in context of frozen object
+- [[Bug #12642]](https://bugs.ruby-lang.org/issues/12642) Net::HTTP populates host header incorrectly when using an IPv6 Address
+- [[Bug #13196]](https://bugs.ruby-lang.org/issues/13196) Improve keyword argument errors when non-keyword arguments given
+- [[Bug #13320]](https://bugs.ruby-lang.org/issues/13320) rescue blocks get an entry in backtrace locations
+- [[Bug #13324]](https://bugs.ruby-lang.org/issues/13324) IRB Segmentation Fault from eval infinite loop
+- [[Bug #13330]](https://bugs.ruby-lang.org/issues/13330) Array.include? is slow for symbols
+- [[Bug #13336]](https://bugs.ruby-lang.org/issues/13336) Default Parameters don't work
+- [[Bug #13337]](https://bugs.ruby-lang.org/issues/13337) Eval and Later Defined Local Variables
+- [[Bug #13338]](https://bugs.ruby-lang.org/issues/13338) MinGW SEGV in test/ruby/test\_keyword.rb svn 58034, ok in svn 58021.
+- [[Bug #13390]](https://bugs.ruby-lang.org/issues/13390) MinGW build test-all SEGV, issue in test framework or error recovery?
+- [[Bug #13350]](https://bugs.ruby-lang.org/issues/13350) File.read :newline option not respected on Linux
+- [[Feature #13362]](https://bugs.ruby-lang.org/issues/13362) \[PATCH\] socket: avoid fcntl for read/write\_nonblock on Linux
+- [[Bug #13351]](https://bugs.ruby-lang.org/issues/13351) net/http: Net::HTTP.start sets wrong default arg value
 - watson's
 
-- \[Bug [#13341](https://bugs.ruby-lang.org/issues/13341)\] Improve performance of implicit type conversion
-- \[Bug [#13342](https://bugs.ruby-lang.org/issues/13342)\] Improve yielding block performance
-- \[Bug [#13354](https://bugs.ruby-lang.org/issues/13354)\] Improve Time#<=> performance
-- \[Bug [#13357](https://bugs.ruby-lang.org/issues/13357)\] Improve Time#+ & Time#- performance
-- \[Bug [#13365](https://bugs.ruby-lang.org/issues/13365)\] Improve performance of rb\_equal() with special constants
-- \[Bug [#13368](https://bugs.ruby-lang.org/issues/13368)\] Improve performance of Array#sum with float elements
-- \[Bug [#13374](https://bugs.ruby-lang.org/issues/13374)\] Fix one of performance regressions in method calling
+- [[Bug #13341]](https://bugs.ruby-lang.org/issues/13341) Improve performance of implicit type conversion
+- [[Bug #13342]](https://bugs.ruby-lang.org/issues/13342) Improve yielding block performance
+- [[Bug #13354]](https://bugs.ruby-lang.org/issues/13354) Improve Time#<=> performance
+- [[Bug #13357]](https://bugs.ruby-lang.org/issues/13357) Improve Time#+ & Time#- performance
+- [[Bug #13365]](https://bugs.ruby-lang.org/issues/13365) Improve performance of rb\_equal() with special constants
+- [[Bug #13368]](https://bugs.ruby-lang.org/issues/13368) Improve performance of Array#sum with float elements
+- [[Bug #13374]](https://bugs.ruby-lang.org/issues/13374) Fix one of performance regressions in method calling
 - nobu: I call him for a volunteer.
 
-- \[Bug [#13373](https://bugs.ruby-lang.org/issues/13373)\] FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
-- \[Bug [#13101](https://bugs.ruby-lang.org/issues/13101)\] Date#rfc2822 and Time#rfc2822 don't return the same format
-- \[Bug [#13312](https://bugs.ruby-lang.org/issues/13312)\] String#casecmp raises TypeError instead of returning nil
-- \[Bug [#12684](https://bugs.ruby-lang.org/issues/12684)\] Delegator#eql? missing
-- \[Feature [#13389](https://bugs.ruby-lang.org/issues/13389)\] \[PATCH\] POP3 support timeout for TLS handshake
-- \[Bug [#13319](https://bugs.ruby-lang.org/issues/13319)\] GC issues seen with GCC7
-- \[Bug [#13404](https://bugs.ruby-lang.org/issues/13404)\] Hash#any? yields arguments to lambdas with proc semantics
-- \[Bug [#13406](https://bugs.ruby-lang.org/issues/13406)\] URI.parse
-- \[Bug [#13413](https://bugs.ruby-lang.org/issues/13413)\] --with-static-linked-ext doesn't install extension files on make install
-- \[Bug [#13420](https://bugs.ruby-lang.org/issues/13420)\] Integer#{round,floor,ceil,truncate} should always return an integer, not a float
-- \[Bug [#13429](https://bugs.ruby-lang.org/issues/13429)\] Net::SMTP has no read timeout when connexion over TLS
+- [[Bug #13373]](https://bugs.ruby-lang.org/issues/13373) FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
+- [[Bug #13101]](https://bugs.ruby-lang.org/issues/13101) Date#rfc2822 and Time#rfc2822 don't return the same format
+- [[Bug #13312]](https://bugs.ruby-lang.org/issues/13312) String#casecmp raises TypeError instead of returning nil
+- [[Bug #12684]](https://bugs.ruby-lang.org/issues/12684) Delegator#eql? missing
+- [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) \[PATCH\] POP3 support timeout for TLS handshake
+- [[Bug #13319]](https://bugs.ruby-lang.org/issues/13319) GC issues seen with GCC7
+- [[Bug #13404]](https://bugs.ruby-lang.org/issues/13404) Hash#any? yields arguments to lambdas with proc semantics
+- [[Bug #13406]](https://bugs.ruby-lang.org/issues/13406) URI.parse
+- [[Bug #13413]](https://bugs.ruby-lang.org/issues/13413) --with-static-linked-ext doesn't install extension files on make install
+- [[Bug #13420]](https://bugs.ruby-lang.org/issues/13420) Integer#{round,floor,ceil,truncate} should always return an integer, not a float
+- [[Bug #13429]](https://bugs.ruby-lang.org/issues/13429) Net::SMTP has no read timeout when connexion over TLS
 
-- \[Feature [#13309](https://bugs.ruby-lang.org/issues/13309)\] Locale paramter for Integer(), Float(), Rational() (shyouhei)
-- \[Feature [#12733](https://bugs.ruby-lang.org/issues/12733)\] Bundle bundler to ruby core (shyouhei) updates?
-- \[Feature [#11302](https://bugs.ruby-lang.org/issues/11302)\] Dir.entries and Dir.foreach without [".", ".."](https://bugs.ruby-lang.org/projects/ruby/wiki/shyouhei)
-- \[Feature [#13332](https://bugs.ruby-lang.org/issues/13332)\] Forwardable#def\_instance\_delegator nil (shyouhei)
-- \[Feature [#13334](https://bugs.ruby-lang.org/issues/13334)\] Removed deprecated mathn extentions. (shyouhei)
-- \[Bug [#12921](https://bugs.ruby-lang.org/issues/12921)\] Retrieve user and password for proxy from env (shyouhei)
+- [[Feature #13309]](https://bugs.ruby-lang.org/issues/13309) Locale paramter for Integer(), Float(), Rational() (shyouhei)
+- [[Feature #12733]](https://bugs.ruby-lang.org/issues/12733) Bundle bundler to ruby core (shyouhei) updates?
+- [[Feature #11302]](https://bugs.ruby-lang.org/issues/11302) Dir.entries and Dir.foreach without [".", ".."](https://bugs.ruby-lang.org/projects/ruby/wiki/shyouhei)
+- [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def\_instance\_delegator nil (shyouhei)
+- [[Feature #13334]](https://bugs.ruby-lang.org/issues/13334) Removed deprecated mathn extentions. (shyouhei)
+- [[Bug #12921]](https://bugs.ruby-lang.org/issues/12921) Retrieve user and password for proxy from env (shyouhei)
 
 - akr: what about whitelisting OSes? modern ones should work.
 
-- \[Feature [#13333](https://bugs.ruby-lang.org/issues/13333)\] block to yield (shyouhei)
-- \[Feature [#13378](https://bugs.ruby-lang.org/issues/13378)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
-- \[Feature [#13381](https://bugs.ruby-lang.org/issues/13381)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
-- \[Bug [#13315](https://bugs.ruby-lang.org/issues/13315)\] Single "%" at the end of printf format string appears in the result (shyouhei)
-- \[Feature [#13385](https://bugs.ruby-lang.org/issues/13385)\] \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
-- \[Feature [#13383](https://bugs.ruby-lang.org/issues/13383)\] \[PATCH\] Module#source\_location (shyouhei)
-- \[Feature [#12063](https://bugs.ruby-lang.org/issues/12063)\] KeyError#receiver and KeyError#name (shyouhei) status?
-- \[Bug [#13397](https://bugs.ruby-lang.org/issues/13397)\] #object\_id should not be signed (shyouhei)
-- \[Feature [#13396](https://bugs.ruby-lang.org/issues/13396)\] Net::HTTP has no write timeout (shyouhei)
-- \[Bug [#13407](https://bugs.ruby-lang.org/issues/13407)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
-- \[Feature [#13395](https://bugs.ruby-lang.org/issues/13395)\] Add a method to check for not nil (shyouhei)
+- [[Feature #13333]](https://bugs.ruby-lang.org/issues/13333) block to yield (shyouhei)
+- [[Feature #13378]](https://bugs.ruby-lang.org/issues/13378) Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+- [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+- [[Bug #13315]](https://bugs.ruby-lang.org/issues/13315) Single "%" at the end of printf format string appears in the result (shyouhei)
+- [[Feature #13385]](https://bugs.ruby-lang.org/issues/13385) \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
+- [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) \[PATCH\] Module#source\_location (shyouhei)
+- [[Feature #12063]](https://bugs.ruby-lang.org/issues/12063) KeyError#receiver and KeyError#name (shyouhei) status?
+- [[Bug #13397]](https://bugs.ruby-lang.org/issues/13397) #object\_id should not be signed (shyouhei)
+- [[Feature #13396]](https://bugs.ruby-lang.org/issues/13396) Net::HTTP has no write timeout (shyouhei)
+- [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+- [[Feature #13395]](https://bugs.ruby-lang.org/issues/13395) Add a method to check for not nil (shyouhei)
 
 ## From non-attendees
 
-- \[Feature [#12886](https://bugs.ruby-lang.org/issues/12886)\] URI#merge doesn't handle paths correctly (hsbt)
+- [[Feature #12886]](https://bugs.ruby-lang.org/issues/12886) URI#merge doesn't handle paths correctly (hsbt)
 
 - hsbt: cf [https://github.com/ruby/ruby/pull/1469](https://github.com/ruby/ruby/pull/1469)
 - hsbt: the fix seems partial. status?

--- a/2017/DevMeeting-2017-05-19.md
+++ b/2017/DevMeeting-2017-05-19.md
@@ -172,190 +172,190 @@ log: TBD
 
 - Previous bugs that were not assigned
 
-- \[Bug [#13196](https://bugs.ruby-lang.org/issues/13196)\] Improve keyword argument errors when non-keyword arguments given
+- [[Bug #13196]](https://bugs.ruby-lang.org/issues/13196) Improve keyword argument errors when non-keyword arguments given
 
 - ko1: isn’t it too long?
 - shyouhei: that depends.
 - matz: it’s a good idea to make errors descriptive.
 
-- \[Bug [#13320](https://bugs.ruby-lang.org/issues/13320)\] rescue blocks get an entry in backtrace locations
+- [[Bug #13320]](https://bugs.ruby-lang.org/issues/13320) rescue blocks get an entry in backtrace locations
 
 - shyouhei: can you look at it? > nobu
 - ko1: there are other corner cases in backtraces where \_unexpected\_-ish backtrace situation.
 - mrkn: does it cause any problems? is it worth deleting?
 - ko1: I tried this and the “bar” line seems indicating the method bar, not raise.
 
-- \[Bug [#13324](https://bugs.ruby-lang.org/issues/13324)\] IRB Segmentation Fault from eval infinite loop
+- [[Bug #13324]](https://bugs.ruby-lang.org/issues/13324) IRB Segmentation Fault from eval infinite loop
 
 - akr: this is a infinite loop.
 - akr: isn’t it possible to extend guard page?
 - ko1: it is technically impossible to rewind stack overflow.
 
-- \[Bug [#13330](https://bugs.ruby-lang.org/issues/13330)\] Array.include? is slow for symbols
+- [[Bug #13330]](https://bugs.ruby-lang.org/issues/13330) Array.include? is slow for symbols
 
 - assign ko1
 
-- \[Bug [#13336](https://bugs.ruby-lang.org/issues/13336)\] Default Parameters don't work
+- [[Bug #13336]](https://bugs.ruby-lang.org/issues/13336) Default Parameters don't work
 
 - ko1: would like to hear from mame.
 
-- \[Bug [#13337](https://bugs.ruby-lang.org/issues/13337)\] Eval and Later Defined Local Variables
+- [[Bug #13337]](https://bugs.ruby-lang.org/issues/13337) Eval and Later Defined Local Variables
 
 - akr: this is by design.
 - shyouhei: doc issue?
 
-- \[Bug [#13390](https://bugs.ruby-lang.org/issues/13390)\] MinGW build test-all SEGV, issue in test framework or error recovery?
+- [[Bug #13390]](https://bugs.ruby-lang.org/issues/13390) MinGW build test-all SEGV, issue in test framework or error recovery?
 
 - nobu: I’m working on it
 - naruse: OK, assign to you.
 
-- \[Bug [#13350](https://bugs.ruby-lang.org/issues/13350)\] File.read :newline option not respected on Linux
+- [[Bug #13350]](https://bugs.ruby-lang.org/issues/13350) File.read :newline option not respected on Linux
 
 - shyouhei: this is a bug.
 - nobu: Windows situation is done by the runtime.
 
-- \[Bug [#13351](https://bugs.ruby-lang.org/issues/13351)\] net/http: Net::HTTP.start sets wrong default arg value
+- [[Bug #13351]](https://bugs.ruby-lang.org/issues/13351) net/http: Net::HTTP.start sets wrong default arg value
 
 - akr: is it possible to simulate old behavior, when we change the default?
 - shyouhei: yes.
 
-- \[Bug [#13373](https://bugs.ruby-lang.org/issues/13373)\] FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
+- [[Bug #13373]](https://bugs.ruby-lang.org/issues/13373) FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
 
 - matz: reproducible code?
 
-- \[Bug [#13101](https://bugs.ruby-lang.org/issues/13101)\] Date#rfc2822 and Time#rfc2822 don't return the same format
+- [[Bug #13101]](https://bugs.ruby-lang.org/issues/13101) Date#rfc2822 and Time#rfc2822 don't return the same format
 
 - akr: technically they are both true.
 - nobu: the patch also includes -0000 change
 - shyouhei: that’s a problem.
 
-- \[Bug [#13312](https://bugs.ruby-lang.org/issues/13312)\] String#casecmp raises TypeError instead of returning nil
+- [[Bug #13312]](https://bugs.ruby-lang.org/issues/13312) String#casecmp raises TypeError instead of returning nil
 
 - nobu: I think it’s OK to fix.
 - hsbt: assign stomer
 
-- \[Bug [#12684](https://bugs.ruby-lang.org/issues/12684)\] Delegator#eql? missing
+- [[Bug #12684]](https://bugs.ruby-lang.org/issues/12684) Delegator#eql? missing
 
 - shyouhei: it ends with “nobu: seems fine”.
 - nobu: will look at it again.
 
-- \[Feature [#13389](https://bugs.ruby-lang.org/issues/13389)\] \[PATCH\] POP3 support timeout for TLS handshake
+- [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) \[PATCH\] POP3 support timeout for TLS handshake
 
 - assign who?
 - seems no one is active.
 - nobu: why not just merge it?
 
-- \[Bug [#13404](https://bugs.ruby-lang.org/issues/13404)\] Hash#any? yields arguments to lambdas with proc semantics
+- [[Bug #13404]](https://bugs.ruby-lang.org/issues/13404) Hash#any? yields arguments to lambdas with proc semantics
 
 - nobu: #13391 is blocking this issue.
 
-- \[Bug [#13413](https://bugs.ruby-lang.org/issues/13413)\] --with-static-linked-ext doesn't install extension files on make install
+- [[Bug #13413]](https://bugs.ruby-lang.org/issues/13413) --with-static-linked-ext doesn't install extension files on make install
 
 - assign nobu
 
-- \[Bug [#13429](https://bugs.ruby-lang.org/issues/13429)\] Net::SMTP has no read timeout when connexion over TLS
+- [[Bug #13429]](https://bugs.ruby-lang.org/issues/13429) Net::SMTP has no read timeout when connexion over TLS
 
 - assign shugo
 
-- \[Feature [#13309](https://bugs.ruby-lang.org/issues/13309)\] Locale paramter for Integer(), Float(), Rational() (shyouhei)
+- [[Feature #13309]](https://bugs.ruby-lang.org/issues/13309) Locale paramter for Integer(), Float(), Rational() (shyouhei)
 
 - nobu: This should start as a gem.
 
-- \[Feature [#12733](https://bugs.ruby-lang.org/issues/12733)\] Bundle bundler to ruby core (shyouhei) updates?
-- \[Feature [#11302](https://bugs.ruby-lang.org/issues/11302)\] Dir.entries and Dir.foreach without [".", ".."](https://bugs.ruby-lang.org/projects/ruby/wiki/shyouhei)
+- [[Feature #12733]](https://bugs.ruby-lang.org/issues/12733) Bundle bundler to ruby core (shyouhei) updates?
+- [[Feature #11302]](https://bugs.ruby-lang.org/issues/11302) Dir.entries and Dir.foreach without [".", ".."](https://bugs.ruby-lang.org/projects/ruby/wiki/shyouhei)
 
 - matz: OK.
 
-- \[Feature [#13332](https://bugs.ruby-lang.org/issues/13332)\] Forwardable#def\_instance\_delegator nil (shyouhei)
-- \[Feature [#13333](https://bugs.ruby-lang.org/issues/13333)\] block to yield (shyouhei)
+- [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def\_instance\_delegator nil (shyouhei)
+- [[Feature #13333]](https://bugs.ruby-lang.org/issues/13333) block to yield (shyouhei)
 
 - nobu: because we can.
 - ko1: I’m afraid there can be places where this breaks something in-core.
 
-- \[Feature [#13378](https://bugs.ruby-lang.org/issues/13378)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
-- \[Feature [#13381](https://bugs.ruby-lang.org/issues/13381)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
-- \[Bug [#13315](https://bugs.ruby-lang.org/issues/13315)\] Single "%" at the end of printf format string appears in the result (shyouhei)
-- \[Feature [#13385](https://bugs.ruby-lang.org/issues/13385)\] \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
-- \[Feature [#13383](https://bugs.ruby-lang.org/issues/13383)\] \[PATCH\] Module#source\_location (shyouhei)
-- \[Feature [#12063](https://bugs.ruby-lang.org/issues/12063)\] KeyError#receiver and KeyError#name (shyouhei) status?
-- \[Bug [#13397](https://bugs.ruby-lang.org/issues/13397)\] #object\_id should not be signed (shyouhei)
-- \[Feature [#13396](https://bugs.ruby-lang.org/issues/13396)\] Net::HTTP has no write timeout (shyouhei)
-- \[Bug [#13407](https://bugs.ruby-lang.org/issues/13407)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
-- \[Feature [#13395](https://bugs.ruby-lang.org/issues/13395)\] Add a method to check for not nil (shyouhei)
+- [[Feature #13378]](https://bugs.ruby-lang.org/issues/13378) Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+- [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+- [[Bug #13315]](https://bugs.ruby-lang.org/issues/13315) Single "%" at the end of printf format string appears in the result (shyouhei)
+- [[Feature #13385]](https://bugs.ruby-lang.org/issues/13385) \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
+- [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) \[PATCH\] Module#source\_location (shyouhei)
+- [[Feature #12063]](https://bugs.ruby-lang.org/issues/12063) KeyError#receiver and KeyError#name (shyouhei) status?
+- [[Bug #13397]](https://bugs.ruby-lang.org/issues/13397) #object\_id should not be signed (shyouhei)
+- [[Feature #13396]](https://bugs.ruby-lang.org/issues/13396) Net::HTTP has no write timeout (shyouhei)
+- [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+- [[Feature #13395]](https://bugs.ruby-lang.org/issues/13395) Add a method to check for not nil (shyouhei)
 
 ## From attendees
 
-- \[Feature [#13483](https://bugs.ruby-lang.org/issues/13483)\] TracePoint#enable with block for thread-local trace (ko1)
+- [[Feature #13483]](https://bugs.ruby-lang.org/issues/13483) TracePoint#enable with block for thread-local trace (ko1)
 
 - ko1: I want to make trace thread local
 - shyouhei: is there a way to emulate old behaviour?
 - ko1: ThracePoint.enable will do.
 
-- \[Bug [#13249](https://bugs.ruby-lang.org/issues/13249)\] Access modifiers don't have an effect inside class methods in Ruby >= 2.3 (ko1, ask the approach)
+- [[Bug #13249]](https://bugs.ruby-lang.org/issues/13249) Access modifiers don't have an effect inside class methods in Ruby >= 2.3 (ko1, ask the approach)
 
 - shyouhei: we want to prohibit private with zero arity inside of a singleton method.
 
 - watson continues to request pulling his ideas
 
-- \[Bug [#13436](https://bugs.ruby-lang.org/issues/13436)\] Improve performance of Array#<=> with Fixnum/Float/String elements
-- \[Bug [#13437](https://bugs.ruby-lang.org/issues/13437)\] Improve performance of Enumerable#{sort\_by,min\_by,max\_by,minmax\_by}
-- \[Bug [#13443](https://bugs.ruby-lang.org/issues/13443)\] Improve performance of Range#{min,max}
-- \[Bug [#13482](https://bugs.ruby-lang.org/issues/13482)\] Improve performance of "set instance variable"
-- \[Bug [#13447](https://bugs.ruby-lang.org/issues/13447)\] Improve performance of rb\_eql()
-- \[Bug [#13503](https://bugs.ruby-lang.org/issues/13503)\] Improve performance of some Time & Rational methods
-- \[Bug [#13506](https://bugs.ruby-lang.org/issues/13506)\] Improve performance of Complex#{+,-,,/,\*,abs2}
-- \[Bug [#13519](https://bugs.ruby-lang.org/issues/13519)\] Improve performance of some Time methods
-- \[Bug [#13507](https://bugs.ruby-lang.org/issues/13507)\] Improve performance of some Complex methods where call Numeric#real? internally
-- \[Bug [#13553](https://bugs.ruby-lang.org/issues/13553)\] Improve performance in where push the element into non shared Array object
+- [[Bug #13436]](https://bugs.ruby-lang.org/issues/13436) Improve performance of Array#<=> with Fixnum/Float/String elements
+- [[Bug #13437]](https://bugs.ruby-lang.org/issues/13437) Improve performance of Enumerable#{sort\_by,min\_by,max\_by,minmax\_by}
+- [[Bug #13443]](https://bugs.ruby-lang.org/issues/13443) Improve performance of Range#{min,max}
+- [[Bug #13482]](https://bugs.ruby-lang.org/issues/13482) Improve performance of "set instance variable"
+- [[Bug #13447]](https://bugs.ruby-lang.org/issues/13447) Improve performance of rb\_eql()
+- [[Bug #13503]](https://bugs.ruby-lang.org/issues/13503) Improve performance of some Time & Rational methods
+- [[Bug #13506]](https://bugs.ruby-lang.org/issues/13506) Improve performance of Complex#{+,-,,/,\*,abs2}
+- [[Bug #13519]](https://bugs.ruby-lang.org/issues/13519) Improve performance of some Time methods
+- [[Bug #13507]](https://bugs.ruby-lang.org/issues/13507) Improve performance of some Complex methods where call Numeric#real? internally
+- [[Bug #13553]](https://bugs.ruby-lang.org/issues/13553) Improve performance in where push the element into non shared Array object
 
 - assign who? corner (shyouhei)
 
-- \[Bug [#13432](https://bugs.ruby-lang.org/issues/13432)\] set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
-- \[Bug [#13446](https://bugs.ruby-lang.org/issues/13446)\] refinements with prepend for module has strange behavior
-- \[Bug [#13492](https://bugs.ruby-lang.org/issues/13492)\] Integer#prime? and Prime.each might produce false positives
+- [[Bug #13432]](https://bugs.ruby-lang.org/issues/13432) set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
+- [[Bug #13446]](https://bugs.ruby-lang.org/issues/13446) refinements with prepend for module has strange behavior
+- [[Bug #13492]](https://bugs.ruby-lang.org/issues/13492) Integer#prime? and Prime.each might produce false positives
 
 - akr: the patch seems ok.
 
-- \[Bug [#13498](https://bugs.ruby-lang.org/issues/13498)\] Weakref, Weakmap and define\_finalizer don't work on frozen objects
-- \[Bug [#13513](https://bugs.ruby-lang.org/issues/13513)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
-- \[Bug [#13501](https://bugs.ruby-lang.org/issues/13501)\] Process.kill behaviour for negative pid is not documented and may be wrong
-- \[Bug [#13515](https://bugs.ruby-lang.org/issues/13515)\] Pathname#join doesn't add separator on UNC paths
-- \[Bug [#13521](https://bugs.ruby-lang.org/issues/13521)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
-- \[Bug [#13537](https://bugs.ruby-lang.org/issues/13537)\] ruby crash in rb\_gc\_mark
-- \[Bug [#13545](https://bugs.ruby-lang.org/issues/13545)\] Ruby built by clang 4.0.0 parses Float literal wrongly
+- [[Bug #13498]](https://bugs.ruby-lang.org/issues/13498) Weakref, Weakmap and define\_finalizer don't work on frozen objects
+- [[Bug #13513]](https://bugs.ruby-lang.org/issues/13513) Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
+- [[Bug #13501]](https://bugs.ruby-lang.org/issues/13501) Process.kill behaviour for negative pid is not documented and may be wrong
+- [[Bug #13515]](https://bugs.ruby-lang.org/issues/13515) Pathname#join doesn't add separator on UNC paths
+- [[Bug #13521]](https://bugs.ruby-lang.org/issues/13521) \[PATCH\] Add fallback for DNS resolver registry key on Wine
+- [[Bug #13537]](https://bugs.ruby-lang.org/issues/13537) ruby crash in rb\_gc\_mark
+- [[Bug #13545]](https://bugs.ruby-lang.org/issues/13545) Ruby built by clang 4.0.0 parses Float literal wrongly
 
 - naruse: OK but I think this is a day-to-day fix.
 
-- \[Bug [#13548](https://bugs.ruby-lang.org/issues/13548)\] miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
-- \[Bug [#13555](https://bugs.ruby-lang.org/issues/13555)\] Disable TestTrace#test\_trace\_stackoverflow
-- \[Bug [#13524](https://bugs.ruby-lang.org/issues/13524)\] miniruby: \[BUG\] Segmentation fault at 0x0055e487e00230 ruby 2.4.1p111 (2017-03-22 revision 58053) \[x86\_64-li
-- \[Bug [#13557](https://bugs.ruby-lang.org/issues/13557)\] there's no way to pass backtrace locations as a massaged backtrace
-- \[Bug [#10290](https://bugs.ruby-lang.org/issues/10290)\] segfault when calling a lambda recursively after rescuing SystemStackError
+- [[Bug #13548]](https://bugs.ruby-lang.org/issues/13548) miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
+- [[Bug #13555]](https://bugs.ruby-lang.org/issues/13555) Disable TestTrace#test\_trace\_stackoverflow
+- [[Bug #13524]](https://bugs.ruby-lang.org/issues/13524) miniruby: \[BUG\] Segmentation fault at 0x0055e487e00230 ruby 2.4.1p111 (2017-03-22 revision 58053) \[x86\_64-li
+- [[Bug #13557]](https://bugs.ruby-lang.org/issues/13557) there's no way to pass backtrace locations as a massaged backtrace
+- [[Bug #10290]](https://bugs.ruby-lang.org/issues/10290) segfault when calling a lambda recursively after rescuing SystemStackError
 
 - Fix confirmed?
 
-- \[Feature [#10674](https://bugs.ruby-lang.org/issues/10674)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
-- \[Bug [#13542](https://bugs.ruby-lang.org/issues/13542)\] MinGW trunk Builds - Summary of Issues
+- [[Feature #10674]](https://bugs.ruby-lang.org/issues/10674) Net::HTTP retries idempotent requests once after a timeout, but its not configurable
+- [[Bug #13542]](https://bugs.ruby-lang.org/issues/13542) MinGW trunk Builds - Summary of Issues
 
-- \[Bug [#13549](https://bugs.ruby-lang.org/issues/13549)\] MinGW / Windows encoding - Two issues
-- \[Bug [#13556](https://bugs.ruby-lang.org/issues/13556)\] MinGW readline Alt / Meta keys
-- \[Bug [#13569](https://bugs.ruby-lang.org/issues/13569)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+- [[Bug #13549]](https://bugs.ruby-lang.org/issues/13549) MinGW / Windows encoding - Two issues
+- [[Bug #13556]](https://bugs.ruby-lang.org/issues/13556) MinGW readline Alt / Meta keys
+- [[Bug #13569]](https://bugs.ruby-lang.org/issues/13569) Windows - TestRubyOptions#test\_search - append to paths instead of replacing
 
-- \[Bug [#13564](https://bugs.ruby-lang.org/issues/13564)\] Exception message management
+- [[Bug #13564]](https://bugs.ruby-lang.org/issues/13564) Exception message management
 
-- \[Feature [#13383](https://bugs.ruby-lang.org/issues/13383)\] \[PATCH\] Module#source\_location (shyouhei)
-- \[Feature [#13434](https://bugs.ruby-lang.org/issues/13434)\] better method definition in C API (shyouhei)
-- \[Feature [#13512](https://bugs.ruby-lang.org/issues/13512)\] System Threads (shyouhei)
-- \[Feature [#13518](https://bugs.ruby-lang.org/issues/13518)\] Indented multiline comments (shyouhei)
-- \[Feature [#13516](https://bugs.ruby-lang.org/issues/13516)\] Improve the text of the circular require warning (shyouhei)
-- \[Feature [#13532](https://bugs.ruby-lang.org/issues/13532)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
+- [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) \[PATCH\] Module#source\_location (shyouhei)
+- [[Feature #13434]](https://bugs.ruby-lang.org/issues/13434) better method definition in C API (shyouhei)
+- [[Feature #13512]](https://bugs.ruby-lang.org/issues/13512) System Threads (shyouhei)
+- [[Feature #13518]](https://bugs.ruby-lang.org/issues/13518) Indented multiline comments (shyouhei)
+- [[Feature #13516]](https://bugs.ruby-lang.org/issues/13516) Improve the text of the circular require warning (shyouhei)
+- [[Feature #13532]](https://bugs.ruby-lang.org/issues/13532) Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
 
 - shyouhei: is this by design or…?
 - akr: it’s ok to add.  Patch please.
 
-- \[Bug [#13535](https://bugs.ruby-lang.org/issues/13535)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
-- \[Feature [#13552](https://bugs.ruby-lang.org/issues/13552)\] \[PATCH 0/2\] reimplement ConditionVariable, Queue, SizedQueue using ccan/list (shyouhei)
-- \[Feature [#13568](https://bugs.ruby-lang.org/issues/13568)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
+- [[Bug #13535]](https://bugs.ruby-lang.org/issues/13535) Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
+- [[Feature #13552]](https://bugs.ruby-lang.org/issues/13552) \[PATCH 0/2\] reimplement ConditionVariable, Queue, SizedQueue using ccan/list (shyouhei)
+- [[Feature #13568]](https://bugs.ruby-lang.org/issues/13568) File#path for O\_TMPFILE fds are unmeaning (sorah)
 
 - sorah: It makes no sense for O\_TMPFILE to have a path
 - nobu: but should it be nil?  There will be no way to obtain underlying filesystem then.
@@ -364,10 +364,10 @@ log: TBD
 - akr: File#path is used as inspectation on logs. therefore it should return informational string
 - naruse: \`ls -al ll /proc/25378/fd/9\` returns “lrwx------ 1 naruse 64 May 19 17:13 9 -> /tmp/#14379824 (deleted)”
 
-- \[Feature [#13563](https://bugs.ruby-lang.org/issues/13563)\] Implement Hash#choice method. (shyouhei)
-- \[Feature [#13562](https://bugs.ruby-lang.org/issues/13562)\] Use a sized enumerator with #yield\_self (shyouhei) needs?
+- [[Feature #13563]](https://bugs.ruby-lang.org/issues/13563) Implement Hash#choice method. (shyouhei)
+- [[Feature #13562]](https://bugs.ruby-lang.org/issues/13562) Use a sized enumerator with #yield\_self (shyouhei) needs?
 
-- \[Feature [#13056](https://bugs.ruby-lang.org/issues/13056)\] base option to Dir.glob (nobu)
+- [[Feature #13056]](https://bugs.ruby-lang.org/issues/13056) base option to Dir.glob (nobu)
 
 - akr: how about it?
 - matz: OK.
@@ -378,7 +378,7 @@ log: TBD
 
 Write your name and your interest (what do you want to ask and to whom?) please.
 
-- \[Feature [#8661](https://bugs.ruby-lang.org/issues/8661)\] Backstrace in reverse order. The OP asked for an option but this is currently always the case for the toplevel exception handler. Is this OK for compatibility? It is surprising for the least (See comment 6). Can we have matz's opinion? (eregon)
+- [[Feature #8661]](https://bugs.ruby-lang.org/issues/8661) Backstrace in reverse order. The OP asked for an option but this is currently always the case for the toplevel exception handler. Is this OK for compatibility? It is surprising for the least (See comment 6). Can we have matz's opinion? (eregon)
 
 - shyouhei: test-unit scrumbles backtrace.
 - hsbt: I want to hear other application developer’s voice

--- a/2017/DevMeeting-2017-06-16.md
+++ b/2017/DevMeeting-2017-06-16.md
@@ -127,7 +127,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-## \[Feature [#12733](https://bugs.ruby-lang.org/issues/12733)\] Bundle bundler to ruby core (shyouhei) updates?
+## [[Feature #12733]](https://bugs.ruby-lang.org/issues/12733) Bundle bundler to ruby core (shyouhei) updates?
 
 
 - hsbt: rubygems/rubygems 2.7 requires bundler.  After it is released, when ruby-core merges that version, we have to take care.
@@ -138,23 +138,23 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: is there any blocker?
 - hsbt: rspec.
 
-## \[Feature [#13332](https://bugs.ruby-lang.org/issues/13332)\] Forwardable#def\_instance\_delegator nil (shyouhei)
+## [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def\_instance\_delegator nil (shyouhei)
 
 
 - assign nobu
 
-## \[Feature [#13333](https://bugs.ruby-lang.org/issues/13333)\] block to yield (shyouhei)
+## [[Feature #13333]](https://bugs.ruby-lang.org/issues/13333) block to yield (shyouhei)
 
 
 - ko1: we need more use cases.
 - martin: nobu: add them to the ticket.
 
-## \[Feature [#13378](https://bugs.ruby-lang.org/issues/13378)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+## [[Feature #13378]](https://bugs.ruby-lang.org/issues/13378) Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
 
 
 - nobu: I don’t want to handle fds this way because we can’t close properly on exceptions. I think we should wrap them using IOs.
 
-## \[Feature [#13381](https://bugs.ruby-lang.org/issues/13381)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
 
 
 - ko1: how about it? I don’t like “f”string naming.
@@ -162,139 +162,139 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: true but we already have rb\_intern().
 - ko1: nobody has idea. so that nobu and ko1 will decide it. nobody against exposing this functionality.
 
-## \[Feature [#13385](https://bugs.ruby-lang.org/issues/13385)\] \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
+## [[Feature #13385]](https://bugs.ruby-lang.org/issues/13385) \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
 
 
 - akr: I can’t say if this is valid until I fully understand the RFC.
 - akira: what about using domain\_name gem?
 - assign akr.
 
-## \[Feature [#13383](https://bugs.ruby-lang.org/issues/13383)\] \[PATCH\] Module#source\_location (shyouhei)
+## [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) \[PATCH\] Module#source\_location (shyouhei)
 
 
 - akira: needs?
 - shyouhei: I think source\_locations makes more sense than source\_location.
 - akira: I started to confuse.  Is it useful?  We can already get Method#source\_location.
 
-## \[Feature [#12063](https://bugs.ruby-lang.org/issues/12063)\] KeyError#receiver and KeyError#name (shyouhei) status?
+## [[Feature #12063]](https://bugs.ruby-lang.org/issues/12063) KeyError#receiver and KeyError#name (shyouhei) status?
 
 
 - matz: I take KeyError#key.
 
-## \[Bug [#13397](https://bugs.ruby-lang.org/issues/13397)\] #object\_id should not be signed (shyouhei)
+## [[Bug #13397]](https://bugs.ruby-lang.org/issues/13397) #object\_id should not be signed (shyouhei)
 
 
 - akr: isn’t it possible to somehow calculate so that we can avoid negative object\_id?  Because pointers are 8 byte aligned, while positive fixnums are of 262 space.
 - nobu: it’s true we can avoid negative numbers on some environment, but not always.
 - reject this specific issue and request for new issue that address the inspect helper.
 
-## \[Feature [#13396](https://bugs.ruby-lang.org/issues/13396)\] Net::HTTP has no write timeout (shyouhei)
+## [[Feature #13396]](https://bugs.ruby-lang.org/issues/13396) Net::HTTP has no write timeout (shyouhei)
 
-## \[Bug [#13407](https://bugs.ruby-lang.org/issues/13407)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+## [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
 
-## \[Feature [#13395](https://bugs.ruby-lang.org/issues/13395)\] Add a method to check for not nil (shyouhei)
+## [[Feature #13395]](https://bugs.ruby-lang.org/issues/13395) Add a method to check for not nil (shyouhei)
 
-## \[Feature [#13434](https://bugs.ruby-lang.org/issues/13434)\] better method definition in C API (shyouhei)
+## [[Feature #13434]](https://bugs.ruby-lang.org/issues/13434) better method definition in C API (shyouhei)
 
 
 - nobu: I think parsing string is not a good idea.
 
-## \[Feature [#13512](https://bugs.ruby-lang.org/issues/13512)\] System Threads (shyouhei)
+## [[Feature #13512]](https://bugs.ruby-lang.org/issues/13512) System Threads (shyouhei)
 
-## \[Feature [#13518](https://bugs.ruby-lang.org/issues/13518)\] Indented multiline comments (shyouhei)
+## [[Feature #13518]](https://bugs.ruby-lang.org/issues/13518) Indented multiline comments (shyouhei)
 
-## \[Feature [#13516](https://bugs.ruby-lang.org/issues/13516)\] Improve the text of the circular require warning (shyouhei)
+## [[Feature #13516]](https://bugs.ruby-lang.org/issues/13516) Improve the text of the circular require warning (shyouhei)
 
-## \[Feature [#13532](https://bugs.ruby-lang.org/issues/13532)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
+## [[Feature #13532]](https://bugs.ruby-lang.org/issues/13532) Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
 
-## \[Bug [#13535](https://bugs.ruby-lang.org/issues/13535)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
+## [[Bug #13535]](https://bugs.ruby-lang.org/issues/13535) Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
 
-## \[Feature [#13568](https://bugs.ruby-lang.org/issues/13568)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
+## [[Feature #13568]](https://bugs.ruby-lang.org/issues/13568) File#path for O\_TMPFILE fds are unmeaning (sorah)
 
-## \[Feature [#13563](https://bugs.ruby-lang.org/issues/13563)\] Implement Hash#choice method. (shyouhei)
+## [[Feature #13563]](https://bugs.ruby-lang.org/issues/13563) Implement Hash#choice method. (shyouhei)
 
 - Previous bugs that were not assigned (shyouhei)
 
 
-## \[Bug [#13196](https://bugs.ruby-lang.org/issues/13196)\] Improve keyword argument errors when non-keyword arguments given
+## [[Bug #13196]](https://bugs.ruby-lang.org/issues/13196) Improve keyword argument errors when non-keyword arguments given
 
-## \[Bug [#13320](https://bugs.ruby-lang.org/issues/13320)\] rescue blocks get an entry in backtrace locations
+## [[Bug #13320]](https://bugs.ruby-lang.org/issues/13320) rescue blocks get an entry in backtrace locations
 
-## \[Bug [#13336](https://bugs.ruby-lang.org/issues/13336)\] Default Parameters don't work
+## [[Bug #13336]](https://bugs.ruby-lang.org/issues/13336) Default Parameters don't work
 
-## \[Bug [#13337](https://bugs.ruby-lang.org/issues/13337)\] Eval and Later Defined Local Variables
+## [[Bug #13337]](https://bugs.ruby-lang.org/issues/13337) Eval and Later Defined Local Variables
 
-## \[Bug [#13350](https://bugs.ruby-lang.org/issues/13350)\] File.read :newline option not respected on Linux
+## [[Bug #13350]](https://bugs.ruby-lang.org/issues/13350) File.read :newline option not respected on Linux
 
-## \[Bug [#13373](https://bugs.ruby-lang.org/issues/13373)\] FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
+## [[Bug #13373]](https://bugs.ruby-lang.org/issues/13373) FileUtils methods for copy, move and remove directories is not providing a decent error trace for letting know if it was success or fail
 
-## \[Bug [#13101](https://bugs.ruby-lang.org/issues/13101)\] Date#rfc2822 and Time#rfc2822 don't return the same format
+## [[Bug #13101]](https://bugs.ruby-lang.org/issues/13101) Date#rfc2822 and Time#rfc2822 don't return the same format
 
-## \[Bug [#12684](https://bugs.ruby-lang.org/issues/12684)\] Delegator#eql? missing
+## [[Bug #12684]](https://bugs.ruby-lang.org/issues/12684) Delegator#eql? missing
 
-## \[Feature [#13389](https://bugs.ruby-lang.org/issues/13389)\] \[PATCH\] POP3 support timeout for TLS handshake
+## [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) \[PATCH\] POP3 support timeout for TLS handshake
 
-## \[Bug [#13404](https://bugs.ruby-lang.org/issues/13404)\] Hash#any? yields arguments to lambdas with proc semantics
+## [[Bug #13404]](https://bugs.ruby-lang.org/issues/13404) Hash#any? yields arguments to lambdas with proc semantics
 
-## \[Bug [#13413](https://bugs.ruby-lang.org/issues/13413)\] --with-static-linked-ext doesn't install extension files on make install
+## [[Bug #13413]](https://bugs.ruby-lang.org/issues/13413) --with-static-linked-ext doesn't install extension files on make install
 
-## \[Bug [#13429](https://bugs.ruby-lang.org/issues/13429)\] Net::SMTP has no read timeout when connexion over TLS
+## [[Bug #13429]](https://bugs.ruby-lang.org/issues/13429) Net::SMTP has no read timeout when connexion over TLS
 
-## \[Bug [#13432](https://bugs.ruby-lang.org/issues/13432)\] set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
+## [[Bug #13432]](https://bugs.ruby-lang.org/issues/13432) set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
 
-## \[Bug [#13446](https://bugs.ruby-lang.org/issues/13446)\] refinements with prepend for module has strange behavior
+## [[Bug #13446]](https://bugs.ruby-lang.org/issues/13446) refinements with prepend for module has strange behavior
 
-## \[Bug [#13498](https://bugs.ruby-lang.org/issues/13498)\] Weakref, Weakmap and define\_finalizer don't work on frozen objects
+## [[Bug #13498]](https://bugs.ruby-lang.org/issues/13498) Weakref, Weakmap and define\_finalizer don't work on frozen objects
 
-## \[Bug [#13513](https://bugs.ruby-lang.org/issues/13513)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
+## [[Bug #13513]](https://bugs.ruby-lang.org/issues/13513) Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
 
-## \[Bug [#13501](https://bugs.ruby-lang.org/issues/13501)\] Process.kill behaviour for negative pid is not documented and may be wrong
+## [[Bug #13501]](https://bugs.ruby-lang.org/issues/13501) Process.kill behaviour for negative pid is not documented and may be wrong
 
-## \[Bug [#13515](https://bugs.ruby-lang.org/issues/13515)\] Pathname#join doesn't add separator on UNC paths
+## [[Bug #13515]](https://bugs.ruby-lang.org/issues/13515) Pathname#join doesn't add separator on UNC paths
 
-## \[Bug [#13521](https://bugs.ruby-lang.org/issues/13521)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
+## [[Bug #13521]](https://bugs.ruby-lang.org/issues/13521) \[PATCH\] Add fallback for DNS resolver registry key on Wine
 
-## \[Bug [#13537](https://bugs.ruby-lang.org/issues/13537)\] ruby crash in rb\_gc\_mark
+## [[Bug #13537]](https://bugs.ruby-lang.org/issues/13537) ruby crash in rb\_gc\_mark
 
-## \[Bug [#13548](https://bugs.ruby-lang.org/issues/13548)\] miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
+## [[Bug #13548]](https://bugs.ruby-lang.org/issues/13548) miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
 
-## \[Bug [#13555](https://bugs.ruby-lang.org/issues/13555)\] Disable TestTrace#test\_trace\_stackoverflow
+## [[Bug #13555]](https://bugs.ruby-lang.org/issues/13555) Disable TestTrace#test\_trace\_stackoverflow
 
-## \[Bug [#13557](https://bugs.ruby-lang.org/issues/13557)\] there's no way to pass backtrace locations as a massaged backtrace
+## [[Bug #13557]](https://bugs.ruby-lang.org/issues/13557) there's no way to pass backtrace locations as a massaged backtrace
 
-## \[Bug [#10290](https://bugs.ruby-lang.org/issues/10290)\] segfault when calling a lambda recursively after rescuing SystemStackError
+## [[Bug #10290]](https://bugs.ruby-lang.org/issues/10290) segfault when calling a lambda recursively after rescuing SystemStackError
 
 
 - Fix confirmed?
 
 - nobu: the variant of setjmp seems to be the root cause.  The proposed workaround works, but may impact performance.  We have to measure before changing the default.
 
-## \[Feature [#10674](https://bugs.ruby-lang.org/issues/10674)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
+## [[Feature #10674]](https://bugs.ruby-lang.org/issues/10674) Net::HTTP retries idempotent requests once after a timeout, but its not configurable
 
-## \[Bug [#13542](https://bugs.ruby-lang.org/issues/13542)\] MinGW trunk Builds - Summary of Issues
-
-
-## \[Bug [#13549](https://bugs.ruby-lang.org/issues/13549)\] MinGW / Windows encoding - Two issues
-
-## \[Bug [#13556](https://bugs.ruby-lang.org/issues/13556)\] MinGW readline Alt / Meta keys
-
-## \[Bug [#13569](https://bugs.ruby-lang.org/issues/13569)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+## [[Bug #13542]](https://bugs.ruby-lang.org/issues/13542) MinGW trunk Builds - Summary of Issues
 
 
-## \[Bug [#13564](https://bugs.ruby-lang.org/issues/13564)\] Exception message management
+## [[Bug #13549]](https://bugs.ruby-lang.org/issues/13549) MinGW / Windows encoding - Two issues
+
+## [[Bug #13556]](https://bugs.ruby-lang.org/issues/13556) MinGW readline Alt / Meta keys
+
+## [[Bug #13569]](https://bugs.ruby-lang.org/issues/13569) Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+
+
+## [[Bug #13564]](https://bugs.ruby-lang.org/issues/13564) Exception message management
 
 
 ## From attendees
 
-## \[Bug [#12159](https://bugs.ruby-lang.org/issues/12159)\] Thread::Backtrace::Location#path returns absolute path for files loaded by require\_relative (ko1)
+## [[Bug #12159]](https://bugs.ruby-lang.org/issues/12159) Thread::Backtrace::Location#path returns absolute path for files loaded by require\_relative (ko1)
 
 
 - ko1: I want to add Thread::Backtrace::Location#realpath to deprecate #absplute\_path instead.
 - matz: no objection.
 
-## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
+## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
 
-- \[Bug [#13576](https://bugs.ruby-lang.org/issues/13576)\] File#to\_path shall be deleted (shyouhei)
+- [[Bug #13576]](https://bugs.ruby-lang.org/issues/13576) File#to\_path shall be deleted (shyouhei)
 
 - akr: did you try deleting this method?
 - shyouhei: no, but I should.
@@ -304,7 +304,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Write your name and your interest (what do you want to ask and to whom?) please.
 
-## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (normalperson)
+## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (normalperson)
 
 
 - ko1: programmers transfer execution of fibers by hand.  Eric proposes to introduce “auto”-Fiber which are OK to transfer each other on blocking situations. His implementation is great. rb\_wait\_for\_single\_fd is the ponit of switching. matz wanted this feature, too.
@@ -321,7 +321,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: is it OK for you to accept Eric’s proposal as-is?
 - matz: I’m positive, but I know your concern so I won’t accept right now.
 
-## \[Feature [#12694](https://bugs.ruby-lang.org/issues/12694)\] Want a String method to remove heading substr.
+## [[Feature #12694]](https://bugs.ruby-lang.org/issues/12694) Want a String method to remove heading substr.
 
 
 - (sonots) I implemented with a name String#remove\_prefix. If the name is ok, I want to merge it. Matz, could you decide? There were other candidates such as lchomp, trim\_prefix. I dropped trim\_prefix because trim is used to remove a list of characters rather than a substring in some languages, so I felt trim\_prefix would raise confusion. I dropped lchomp because I just had never heard.

--- a/2017/DevMeeting-2017-07-14.md
+++ b/2017/DevMeeting-2017-07-14.md
@@ -171,7 +171,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-## \[Feature [#13512](https://bugs.ruby-lang.org/issues/13512)\] System Threads (shyouhei)
+## [[Feature #13512]](https://bugs.ruby-lang.org/issues/13512) System Threads (shyouhei)
 
 
 - ko1: I don’t like this idea.  I don’t want more states over a Thread.
@@ -180,7 +180,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - Previous bugs that were not assigned (shyouhei)
 
 
-## \[Bug [#13350](https://bugs.ruby-lang.org/issues/13350)\] File.read :newline option not respected on Linux
+## [[Bug #13350]](https://bugs.ruby-lang.org/issues/13350) File.read :newline option not respected on Linux
 
 
 - nobu: on Linux we have to explicitly set text mode.
@@ -188,65 +188,65 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - nobu: then we should automatically assume text mode when newline: is specified.
 - matz: make it so,
 
-## \[Feature [#13389](https://bugs.ruby-lang.org/issues/13389)\] \[PATCH\] POP3 support timeout for TLS handshake
+## [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) \[PATCH\] POP3 support timeout for TLS handshake
 
 
 - hsbt: pop3 has no maintainer.
 - naruse: maybe shugo can review the patch?
 
-## \[Bug [#13404](https://bugs.ruby-lang.org/issues/13404)\] Hash#any? yields arguments to lambdas with proc semantics
+## [[Bug #13404]](https://bugs.ruby-lang.org/issues/13404) Hash#any? yields arguments to lambdas with proc semantics
 
 
 - assign ko1
 - cf: #13391
 
-## \[Bug [#13429](https://bugs.ruby-lang.org/issues/13429)\] Net::SMTP has no read timeout when connexion over TLS
+## [[Bug #13429]](https://bugs.ruby-lang.org/issues/13429) Net::SMTP has no read timeout when connexion over TLS
 
 
 - should be closed so that usa can be aware of it.
 
-## \[Bug [#13513](https://bugs.ruby-lang.org/issues/13513)\] Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
+## [[Bug #13513]](https://bugs.ruby-lang.org/issues/13513) Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
 
 
 - assign akr
 
-## \[Bug [#13501](https://bugs.ruby-lang.org/issues/13501)\] Process.kill behaviour for negative pid is not documented and may be wrong
+## [[Bug #13501]](https://bugs.ruby-lang.org/issues/13501) Process.kill behaviour for negative pid is not documented and may be wrong
 
 
 - shyouhei: doc issue?
 - akr: we take negative signal or negative pids.  signal.c:rb\_f\_kill() has special codes for negative signals but not for negative pids.
 - akr: what happens both signal and pid are negative?
 
-## \[Bug [#13521](https://bugs.ruby-lang.org/issues/13521)\] \[PATCH\] Add fallback for DNS resolver registry key on Wine
+## [[Bug #13521]](https://bugs.ruby-lang.org/issues/13521) \[PATCH\] Add fallback for DNS resolver registry key on Wine
 
 
 - nobu: 3rd party issue?
 
-## \[Bug [#13557](https://bugs.ruby-lang.org/issues/13557)\] there's no way to pass backtrace locations as a massaged backtrace
+## [[Bug #13557]](https://bugs.ruby-lang.org/issues/13557) there's no way to pass backtrace locations as a massaged backtrace
 
 
 - nobu: I have to discuss this with ko1.
 
-## \[Feature [#10674](https://bugs.ruby-lang.org/issues/10674)\] Net::HTTP retries idempotent requests once after a timeout, but its not configurable
+## [[Feature #10674]](https://bugs.ruby-lang.org/issues/10674) Net::HTTP retries idempotent requests once after a timeout, but its not configurable
 
 
 - assign naruse
 
-## \[Bug [#13542](https://bugs.ruby-lang.org/issues/13542)\] MinGW trunk Builds - Summary of Issues
+## [[Bug #13542]](https://bugs.ruby-lang.org/issues/13542) MinGW trunk Builds - Summary of Issues
 
 
-## \[Bug [#13549](https://bugs.ruby-lang.org/issues/13549)\] MinGW / Windows encoding - Two issues
+## [[Bug #13549]](https://bugs.ruby-lang.org/issues/13549) MinGW / Windows encoding - Two issues
 
-## \[Bug [#13556](https://bugs.ruby-lang.org/issues/13556)\] MinGW readline Alt / Meta keys
+## [[Bug #13556]](https://bugs.ruby-lang.org/issues/13556) MinGW readline Alt / Meta keys
 
-## \[Bug [#13569](https://bugs.ruby-lang.org/issues/13569)\] Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+## [[Bug #13569]](https://bugs.ruby-lang.org/issues/13569) Windows - TestRubyOptions#test\_search - append to paths instead of replacing
 
 ---
 - nobu: I cannot reproduce these problems.
 - shyouhei: It seems the reporter is not eligible to fix them.
 - hsbt: I made an environment so I’ll see if they reproduce.
 
-## \[Bug [#13564](https://bugs.ruby-lang.org/issues/13564)\] Exception message management
+## [[Bug #13564]](https://bugs.ruby-lang.org/issues/13564) Exception message management
 
 
 - matz I understand that it breaks encapsulation \_by theory\_, but in practice is it worth, for instance, duplicate every time?
@@ -259,17 +259,17 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - should what happen for tainted string?
 - ko1: it seems there is string.c:fstring\_cmp.  Can’t we change this function?
 
-## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
 
 
 - akr: Socket to DB would normally be pooled / shared among threads in normal web applications.  There shall be some locking mechanism to do so.
 
-## \[Feature [#13583](https://bugs.ruby-lang.org/issues/13583)\] Adding Hash#transform\_keys method (shyouhei)
+## [[Feature #13583]](https://bugs.ruby-lang.org/issues/13583) Adding Hash#transform\_keys method (shyouhei)
 
 
 - matz: seems OK.
 
-## \[Feature [#12589](https://bugs.ruby-lang.org/issues/12589)\] VM performance improvement proposal (shyouhei)
+## [[Feature #12589]](https://bugs.ruby-lang.org/issues/12589) VM performance improvement proposal (shyouhei)
 
 
 - akr: is it OK for people to have C compilers in their production environment?
@@ -277,7 +277,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: I think scheme compilers tends to transpile into C.
 - matz: I like this idea itself.
 
-## \[Feature [#13676](https://bugs.ruby-lang.org/issues/13676)\] to\_s method is not overriden for Set (shyouhei)
+## [[Feature #13676]](https://bugs.ruby-lang.org/issues/13676) to\_s method is not overriden for Set (shyouhei)
 
 
 - assign knu
@@ -286,12 +286,12 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - knu: is it OK to call inspect?
 - matz: OK.
 
-## \[Feature [#10771](https://bugs.ruby-lang.org/issues/10771)\] An easy way to get the source location of a constant (shyouhei)
+## [[Feature #10771]](https://bugs.ruby-lang.org/issues/10771) An easy way to get the source location of a constant (shyouhei)
 
 
 - nobu: we already maintain constant source locations for redefinition warnings.
 
-## \[Feature [#13434](https://bugs.ruby-lang.org/issues/13434)\] better method definition in C API (shyouhei)
+## [[Feature #13434]](https://bugs.ruby-lang.org/issues/13434) better method definition in C API (shyouhei)
 
 
 - ko1: is it convenient for you to show backtrace of C methods?
@@ -301,60 +301,60 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - bugs that are not assigned (shyouhei)
 
 
-## \[Bug [#13586](https://bugs.ruby-lang.org/issues/13586)\] Ruby hangs when accessing array which is modified in instance\_eval after Coverage.start
+## [[Bug #13586]](https://bugs.ruby-lang.org/issues/13586) Ruby hangs when accessing array which is modified in instance\_eval after Coverage.start
 
 
 - assign nobu
 - nobu: seems 2.5 is not affected.
 
-## \[Bug [#13574](https://bugs.ruby-lang.org/issues/13574)\] Method redefinition warning
+## [[Bug #13574]](https://bugs.ruby-lang.org/issues/13574) Method redefinition warning
 
 
 - akira: is it OK that we say this is the right way to suppress warning?
 - matz: reject.
 
-## \[Bug [#13616](https://bugs.ruby-lang.org/issues/13616)\] Zlib::GzipReader#pos underflows after calling #ungetbyte or #ungetc at start of file
+## [[Bug #13616]](https://bugs.ruby-lang.org/issues/13616) Zlib::GzipReader#pos underflows after calling #ungetbyte or #ungetc at start of file
 
 
 - naruse: I’ll merge this.
 
-## \[Bug [#13593](https://bugs.ruby-lang.org/issues/13593)\] Addrinfo#== behaves oddly
+## [[Bug #13593]](https://bugs.ruby-lang.org/issues/13593) Addrinfo#== behaves oddly
 
 
 - akr: it’s difficult by theory.
 
-## \[Bug [#13631](https://bugs.ruby-lang.org/issues/13631)\] Cannot disable site and vendor directories
+## [[Bug #13631]](https://bugs.ruby-lang.org/issues/13631) Cannot disable site and vendor directories
 
 
 - assign nobu
 
-## \[Bug [#13647](https://bugs.ruby-lang.org/issues/13647)\] Some weird behaviour with keyword arguments
+## [[Bug #13647]](https://bugs.ruby-lang.org/issues/13647) Some weird behaviour with keyword arguments
 
 
 - nobu: we can explain this behaviour.
 
-## \[Bug [#13649](https://bugs.ruby-lang.org/issues/13649)\] Net::IMAP doesn't support response from a Microsoft Exchange server (which is not compliant with RFC standards)
+## [[Bug #13649]](https://bugs.ruby-lang.org/issues/13649) Net::IMAP doesn't support response from a Microsoft Exchange server (which is not compliant with RFC standards)
 
 
 - assign shugo
 
-## \[Bug [#13654](https://bugs.ruby-lang.org/issues/13654)\] irb save-history extension is not concurrency-safe
+## [[Bug #13654]](https://bugs.ruby-lang.org/issues/13654) irb save-history extension is not concurrency-safe
 
 
 - akr: it’s same as shells.
 - assign keiju
 
-## \[Bug [#13655](https://bugs.ruby-lang.org/issues/13655)\] external encoding named "-" (doc issue or…?)
+## [[Bug #13655]](https://bugs.ruby-lang.org/issues/13655) external encoding named "-" (doc issue or…?)
 
 
 - naruse: doc issue.
 
-## \[Bug [#13660](https://bugs.ruby-lang.org/issues/13660)\] rb\_str\_hash\_m discards bits from the hash
+## [[Bug #13660]](https://bugs.ruby-lang.org/issues/13660) rb\_str\_hash\_m discards bits from the hash
 
 
 - akr: it’s intentional.
 
-## \[Bug [#13671](https://bugs.ruby-lang.org/issues/13671)\] Regexp with lookbehind and case-insensitivity raises RegexpError only on strings with certain characters
+## [[Bug #13671]](https://bugs.ruby-lang.org/issues/13671) Regexp with lookbehind and case-insensitivity raises RegexpError only on strings with certain characters
 
 
 - naruse: /(?<!ass)/iu is suffient to reproduce
@@ -366,7 +366,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - \=> nil
 - But I don't know the expected behavior.
 
-## \[Bug [#13735](https://bugs.ruby-lang.org/issues/13735)\] Initialization-error of sortedset
+## [[Bug #13735]](https://bugs.ruby-lang.org/issues/13735) Initialization-error of sortedset
 
 
 - assign knu
@@ -375,19 +375,19 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Write your name and your interest (what do you want to ask and to whom?) please.
 
-## \[Feature [#13666](https://bugs.ruby-lang.org/issues/13666)\] Allow to write specs instead of tests (nobody wants to write test code twice). (eregon)
+## [[Feature #13666]](https://bugs.ruby-lang.org/issues/13666) Allow to write specs instead of tests (nobody wants to write test code twice). (eregon)
 
 
 - Martin: Okay to me.
 - nobu: nobody disallows to write specs at the first place, do they?
 
-## \[Feature [#13665](https://bugs.ruby-lang.org/issues/13665)\] Before I added String#delete\_prefix. For symmetry, is it okay to commit String#delete\_suffix? (sonots)
+## [[Feature #13665]](https://bugs.ruby-lang.org/issues/13665) Before I added String#delete\_prefix. For symmetry, is it okay to commit String#delete\_suffix? (sonots)
 
 
 - shyouhei: should we add it?
 - matz: no objection.
 
-## \[Feature [#13743](https://bugs.ruby-lang.org/issues/13743)\] Support linking of files opened with O\_TMPFILE (mmasaki)
+## [[Feature #13743]](https://bugs.ruby-lang.org/issues/13743) Support linking of files opened with O\_TMPFILE (mmasaki)
 
 
 - nobu: File.link or File#link?

--- a/2017/DevMeeting-2017-08-31.md
+++ b/2017/DevMeeting-2017-08-31.md
@@ -190,137 +190,137 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-## \[Feature [#13396](https://bugs.ruby-lang.org/issues/13396)\] Net::HTTP has no write timeout (shyouhei)
+## [[Feature #13396]](https://bugs.ruby-lang.org/issues/13396) Net::HTTP has no write timeout (shyouhei)
 
-## \[Bug [#13407](https://bugs.ruby-lang.org/issues/13407)\] We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+## [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
 
-## \[Feature [#13395](https://bugs.ruby-lang.org/issues/13395)\] Add a method to check for not nil (shyouhei)
+## [[Feature #13395]](https://bugs.ruby-lang.org/issues/13395) Add a method to check for not nil (shyouhei)
 
-## \[Feature [#13516](https://bugs.ruby-lang.org/issues/13516)\] Improve the text of the circular require warning (shyouhei)
+## [[Feature #13516]](https://bugs.ruby-lang.org/issues/13516) Improve the text of the circular require warning (shyouhei)
 
-## \[Feature [#13532](https://bugs.ruby-lang.org/issues/13532)\] Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
+## [[Feature #13532]](https://bugs.ruby-lang.org/issues/13532) Enable :encoding key or open-uri (open()) similar as to how File.read() and File.readlines() already allow for (shyouhei)
 
-## \[Bug [#13535](https://bugs.ruby-lang.org/issues/13535)\] Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
+## [[Bug #13535]](https://bugs.ruby-lang.org/issues/13535) Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
 
-## \[Feature [#13568](https://bugs.ruby-lang.org/issues/13568)\] File#path for O\_TMPFILE fds are unmeaning (sorah)
+## [[Feature #13568]](https://bugs.ruby-lang.org/issues/13568) File#path for O\_TMPFILE fds are unmeaning (sorah)
 
 
 - raising exception
 
-## \[Feature [#13563](https://bugs.ruby-lang.org/issues/13563)\] Implement Hash#choice method. (shyouhei)
+## [[Feature #13563]](https://bugs.ruby-lang.org/issues/13563) Implement Hash#choice method. (shyouhei)
 
 
 - naming issue.
 
-## \[Feature [#13581](https://bugs.ruby-lang.org/issues/13581)\] Syntax sugar for method reference (shyouhei)
+## [[Feature #13581]](https://bugs.ruby-lang.org/issues/13581) Syntax sugar for method reference (shyouhei)
 
 
 - naming issue.
 
-## \[Bug [#13438](https://bugs.ruby-lang.org/issues/13438)\] Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei)
+## [[Bug #13438]](https://bugs.ruby-lang.org/issues/13438) Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei)
 
-## \[Misc [#12529](https://bugs.ruby-lang.org/issues/12529)\] LEGAL file covering all the license information within Ruby (shyouhei)
+## [[Misc #12529]](https://bugs.ruby-lang.org/issues/12529) LEGAL file covering all the license information within Ruby (shyouhei)
 
-## \[Feature [#13600](https://bugs.ruby-lang.org/issues/13600)\] yield\_self should be chainable/composable (shyouhei)
+## [[Feature #13600]](https://bugs.ruby-lang.org/issues/13600) yield\_self should be chainable/composable (shyouhei)
 
-## \[Misc [#13597](https://bugs.ruby-lang.org/issues/13597)\] Does read\_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
+## [[Misc #13597]](https://bugs.ruby-lang.org/issues/13597) Does read\_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
 
-## \[Feature [#13606](https://bugs.ruby-lang.org/issues/13606)\] Enumerator equality and comparison (shyouhei)
+## [[Feature #13606]](https://bugs.ruby-lang.org/issues/13606) Enumerator equality and comparison (shyouhei)
 
-## \[Feature [#13604](https://bugs.ruby-lang.org/issues/13604)\] Exposing alternative interface of readline (shyouhei)
+## [[Feature #13604]](https://bugs.ruby-lang.org/issues/13604) Exposing alternative interface of readline (shyouhei)
 
 ---
-## \[Feature [#13608](https://bugs.ruby-lang.org/issues/13608)\] Add TracePoint#thread (shyouhei)
+## [[Feature #13608]](https://bugs.ruby-lang.org/issues/13608) Add TracePoint#thread (shyouhei)
 
-## \[Feature [#13602](https://bugs.ruby-lang.org/issues/13602)\] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
+## [[Feature #13602]](https://bugs.ruby-lang.org/issues/13602) Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
 
-## \[Feature [#13613](https://bugs.ruby-lang.org/issues/13613)\] Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
+## [[Feature #13613]](https://bugs.ruby-lang.org/issues/13613) Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
 
-## \[Feature [#13620](https://bugs.ruby-lang.org/issues/13620)\] Simplifying MRI's build system: always install (shyouhei)
+## [[Feature #13620]](https://bugs.ruby-lang.org/issues/13620) Simplifying MRI's build system: always install (shyouhei)
 
-## \[Feature [#13630](https://bugs.ruby-lang.org/issues/13630)\] :\[\] method should accept block in nice syntax (shyouhei)
+## [[Feature #13630]](https://bugs.ruby-lang.org/issues/13630) :\[\] method should accept block in nice syntax (shyouhei)
 
-## \[Feature [#13639](https://bugs.ruby-lang.org/issues/13639)\] Add "RTMIN" and "RTMAX" to Signal.list (shyouhei)
+## [[Feature #13639]](https://bugs.ruby-lang.org/issues/13639) Add "RTMIN" and "RTMAX" to Signal.list (shyouhei)
 
-## \[Feature [#11484](https://bugs.ruby-lang.org/issues/11484)\] add output offset for readpartial/read\_nonblock/etc (shyouhei)
+## [[Feature #11484]](https://bugs.ruby-lang.org/issues/11484) add output offset for readpartial/read\_nonblock/etc (shyouhei)
 
-## \[Feature [#9001](https://bugs.ruby-lang.org/issues/9001)\] Please package better standard library (shyouhei)
+## [[Feature #9001]](https://bugs.ruby-lang.org/issues/9001) Please package better standard library (shyouhei)
 
-## \[Feature [#13563](https://bugs.ruby-lang.org/issues/13563)\] Implement Hash#choice method. (shyouhei)
+## [[Feature #13563]](https://bugs.ruby-lang.org/issues/13563) Implement Hash#choice method. (shyouhei)
 
-## \[Feature [#12533](https://bugs.ruby-lang.org/issues/12533)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
+## [[Feature #12533]](https://bugs.ruby-lang.org/issues/12533) Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
 
-## \[Feature [#13653](https://bugs.ruby-lang.org/issues/13653)\] Bundled zlib helper (shyouhei)
+## [[Feature #13653]](https://bugs.ruby-lang.org/issues/13653) Bundled zlib helper (shyouhei)
 
-## \[Feature [#13626](https://bugs.ruby-lang.org/issues/13626)\] Add String#byteslice! (shyouhei)
+## [[Feature #13626]](https://bugs.ruby-lang.org/issues/13626) Add String#byteslice! (shyouhei)
 
-## \[Feature [#13551](https://bugs.ruby-lang.org/issues/13551)\] Add a method to alias class methods (shyouhei)
+## [[Feature #13551]](https://bugs.ruby-lang.org/issues/13551) Add a method to alias class methods (shyouhei)
 
-## \[Feature [#13332](https://bugs.ruby-lang.org/issues/13332)\] Forwardable#def\_instance\_delegator nil (shyouhei)
+## [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def\_instance\_delegator nil (shyouhei)
 
-## \[Feature [#13378](https://bugs.ruby-lang.org/issues/13378)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+## [[Feature #13378]](https://bugs.ruby-lang.org/issues/13378) Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
 
-## \[Feature [#13381](https://bugs.ruby-lang.org/issues/13381)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
 
-## \[Feature [#13677](https://bugs.ruby-lang.org/issues/13677)\] Add more details to error "Name or service not known (SocketError)" (shyouhei)
+## [[Feature #13677]](https://bugs.ruby-lang.org/issues/13677) Add more details to error "Name or service not known (SocketError)" (shyouhei)
 
-## \[Feature [#9323](https://bugs.ruby-lang.org/issues/9323)\] IO#writev (shyouhei)
+## [[Feature #9323]](https://bugs.ruby-lang.org/issues/9323) IO#writev (shyouhei)
 
-## \[Feature [#13686](https://bugs.ruby-lang.org/issues/13686)\] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (shyouhei)
+## [[Feature #13686]](https://bugs.ruby-lang.org/issues/13686) Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (shyouhei)
 
-## \[Feature [#13693](https://bugs.ruby-lang.org/issues/13693)\] Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
+## [[Feature #13693]](https://bugs.ruby-lang.org/issues/13693) Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
 
-## \[Feature [#13434](https://bugs.ruby-lang.org/issues/13434)\] better method definition in C API (shyouhei)
+## [[Feature #13434]](https://bugs.ruby-lang.org/issues/13434) better method definition in C API (shyouhei)
 
-## \[Feature [#13696](https://bugs.ruby-lang.org/issues/13696)\] Add exchange and noreplace options to File.rename (shyouhei)
+## [[Feature #13696]](https://bugs.ruby-lang.org/issues/13696) Add exchange and noreplace options to File.rename (shyouhei)
 
-## \[Feature [#13683](https://bugs.ruby-lang.org/issues/13683)\] Add strict Enumerable#single (shyouhei)
+## [[Feature #13683]](https://bugs.ruby-lang.org/issues/13683) Add strict Enumerable#single (shyouhei)
 
-## \[Misc [#13704](https://bugs.ruby-lang.org/issues/13704)\] Exclude Changelog files from documentation. (shyouhei)
+## [[Misc #13704]](https://bugs.ruby-lang.org/issues/13704) Exclude Changelog files from documentation. (shyouhei)
 
-## \[Feature [#13713](https://bugs.ruby-lang.org/issues/13713)\] socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
+## [[Feature #13713]](https://bugs.ruby-lang.org/issues/13713) socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
 
-## \[Feature [#13715](https://bugs.ruby-lang.org/issues/13715)\] \[PATCH\] avoid garbage from Symbol#to\_s in interpolation (shyouhei)
+## [[Feature #13715]](https://bugs.ruby-lang.org/issues/13715) \[PATCH\] avoid garbage from Symbol#to\_s in interpolation (shyouhei)
 
-## \[Feature [#13719](https://bugs.ruby-lang.org/issues/13719)\] \[PATCH\] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
+## [[Feature #13719]](https://bugs.ruby-lang.org/issues/13719) \[PATCH\] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
 
-## \[Feature [#13732](https://bugs.ruby-lang.org/issues/13732)\] Precise Time.now on Windows (shyouhei)
+## [[Feature #13732]](https://bugs.ruby-lang.org/issues/13732) Precise Time.now on Windows (shyouhei)
 
-## \[Feature [#13733](https://bugs.ruby-lang.org/issues/13733)\] Dump the delegator instead of the delegated object (shyouhei)
+## [[Feature #13733]](https://bugs.ruby-lang.org/issues/13733) Dump the delegator instead of the delegated object (shyouhei)
 
-## \[Feature [#13625](https://bugs.ruby-lang.org/issues/13625)\] BigDecimal short form / shorthand (shyouhei)
+## [[Feature #13625]](https://bugs.ruby-lang.org/issues/13625) BigDecimal short form / shorthand (shyouhei)
 
-## \[Feature [#13712](https://bugs.ruby-lang.org/issues/13712)\] String#start\_with? with regexp (shyouhei)
+## [[Feature #13712]](https://bugs.ruby-lang.org/issues/13712) String#start\_with? with regexp (shyouhei)
 
 - bugs that are not assigned (shyouhei)
 
 
-## \[Bug [#13674](https://bugs.ruby-lang.org/issues/13674)\] BigDecimal comparison with Float::INFINITY is erroneous in 2.2.x and 2.3.x
+## [[Bug #13674]](https://bugs.ruby-lang.org/issues/13674) BigDecimal comparison with Float::INFINITY is erroneous in 2.2.x and 2.3.x
 
-## \[Bug [#13675](https://bugs.ruby-lang.org/issues/13675)\] Should Zlib::GzipReader#ungetc accept nil?
+## [[Bug #13675]](https://bugs.ruby-lang.org/issues/13675) Should Zlib::GzipReader#ungetc accept nil?
 
-## \[Bug [#13700](https://bugs.ruby-lang.org/issues/13700)\] Enumerable#sum may not work for Ranges subclasses due to optimization (mrkn)
+## [[Bug #13700]](https://bugs.ruby-lang.org/issues/13700) Enumerable#sum may not work for Ranges subclasses due to optimization (mrkn)
 
-## \[Bug [#13705](https://bugs.ruby-lang.org/issues/13705)\] \[PATCH\] \`cfp consistency error' occurs when raising exception in bmethod call event
+## [[Bug #13705]](https://bugs.ruby-lang.org/issues/13705) \[PATCH\] \`cfp consistency error' occurs when raising exception in bmethod call event
 
-## \[Bug [#13716](https://bugs.ruby-lang.org/issues/13716)\] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+## [[Bug #13716]](https://bugs.ruby-lang.org/issues/13716) Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
 
-## \[Bug [#13670](https://bugs.ruby-lang.org/issues/13670)\] \[BUG\] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
+## [[Bug #13670]](https://bugs.ruby-lang.org/issues/13670) \[BUG\] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
 
 
 ## From attendees
 
-## \[Feature [#13780](https://bugs.ruby-lang.org/issues/13780)\] String#each\_grapheme (naruse)
+## [[Feature #13780]](https://bugs.ruby-lang.org/issues/13780) String#each\_grapheme (naruse)
 
 
 - matz: the unit is grapheme cluster. so the name should be each\_grapheme\_cluster.
 
 
-## \[Misc [#13704](https://bugs.ruby-lang.org/issues/13704)\] \[PATCH\] Exclude Changelog files from documentation. (hsbt)
+## [[Misc #13704]](https://bugs.ruby-lang.org/issues/13704) \[PATCH\] Exclude Changelog files from documentation. (hsbt)
 
-## \[Feature [#12733](https://bugs.ruby-lang.org/issues/12733)\] Bundle bundler to ruby core (hsbt)
+## [[Feature #12733]](https://bugs.ruby-lang.org/issues/12733) Bundle bundler to ruby core (hsbt)
 
-## \[Feature [#13847](https://bugs.ruby-lang.org/issues/13847)\] Gem activated problem for default gems (hsbt)
+## [[Feature #13847]](https://bugs.ruby-lang.org/issues/13847) Gem activated problem for default gems (hsbt)
 
 
 ## [https://gist.github.com/hsbt/968fcbb7acfa9405d82040a3c219f43a](https://gist.github.com/hsbt/968fcbb7acfa9405d82040a3c219f43a) (ja)
@@ -328,107 +328,107 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - Related with [https://bugs.ruby-lang.org/issues/10320](https://bugs.ruby-lang.org/issues/10320)
 
 
-## \[Misc [#13747](https://bugs.ruby-lang.org/issues/13747)\] MinGW trunk build available on Appveyor (shyouhei)
+## [[Misc #13747]](https://bugs.ruby-lang.org/issues/13747) MinGW trunk build available on Appveyor (shyouhei)
 
-## \[Feature [#13751](https://bugs.ruby-lang.org/issues/13751)\] Suppert SSHFP resource records in rubysl-resolv (shyouhei)
+## [[Feature #13751]](https://bugs.ruby-lang.org/issues/13751) Suppert SSHFP resource records in rubysl-resolv (shyouhei)
 
-## \[Bug [#13752](https://bugs.ruby-lang.org/issues/13752)\] Can't observe sibling refinements (shyouhei)
+## [[Bug #13752]](https://bugs.ruby-lang.org/issues/13752) Can't observe sibling refinements (shyouhei)
 
-## \[Feature [#13683](https://bugs.ruby-lang.org/issues/13683)\] Add strict Enumerable#single (shyouhei)
+## [[Feature #13683]](https://bugs.ruby-lang.org/issues/13683) Add strict Enumerable#single (shyouhei)
 
-## \[Feature [#13763](https://bugs.ruby-lang.org/issues/13763)\] Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
+## [[Feature #13763]](https://bugs.ruby-lang.org/issues/13763) Trigger "unused variable warning" for unused variables in parameter lists (shyouhei)
 
-## \[Feature [#13765](https://bugs.ruby-lang.org/issues/13765)\] Add Proc#bind (shyouhei)
+## [[Feature #13765]](https://bugs.ruby-lang.org/issues/13765) Add Proc#bind (shyouhei)
 
-## \[Feature [#13767](https://bugs.ruby-lang.org/issues/13767)\] add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
+## [[Feature #13767]](https://bugs.ruby-lang.org/issues/13767) add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
 
-## \[Feature [#13777](https://bugs.ruby-lang.org/issues/13777)\] Array#delete\_all (shyouhei)
+## [[Feature #13777]](https://bugs.ruby-lang.org/issues/13777) Array#delete\_all (shyouhei)
 
-## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
 
-## \[Feature [#13784](https://bugs.ruby-lang.org/issues/13784)\] Add Enumerable#filter as an alias of Enumerable#select (shyouhei)
+## [[Feature #13784]](https://bugs.ruby-lang.org/issues/13784) Add Enumerable#filter as an alias of Enumerable#select (shyouhei)
 
-## \[Misc [#13804](https://bugs.ruby-lang.org/issues/13804)\] Protected methods cannot be overridden (shyouhei)
+## [[Misc #13804]](https://bugs.ruby-lang.org/issues/13804) Protected methods cannot be overridden (shyouhei)
 
-## \[Feature [#13803](https://bugs.ruby-lang.org/issues/13803)\] Add Socket::Ifaddr.vhid on supported platforms (shyouhei)
+## [[Feature #13803]](https://bugs.ruby-lang.org/issues/13803) Add Socket::Ifaddr.vhid on supported platforms (shyouhei)
 
-## \[Feature [#13807](https://bugs.ruby-lang.org/issues/13807)\] A method to filter the receiver against some condition (shyouhei)
+## [[Feature #13807]](https://bugs.ruby-lang.org/issues/13807) A method to filter the receiver against some condition (shyouhei)
 
-## \[Feature [#13805](https://bugs.ruby-lang.org/issues/13805)\] Make refinement scoping to be like that of constants (shyouhei)
+## [[Feature #13805]](https://bugs.ruby-lang.org/issues/13805) Make refinement scoping to be like that of constants (shyouhei)
 
-## \[Feature [#13789](https://bugs.ruby-lang.org/issues/13789)\] Dir - methods (shyouhei)
+## [[Feature #13789]](https://bugs.ruby-lang.org/issues/13789) Dir - methods (shyouhei)
 
-## \[Misc [#13810](https://bugs.ruby-lang.org/issues/13810)\] Inconsistency between Date and Time.strftime("%v") (shyouhei)
+## [[Misc #13810]](https://bugs.ruby-lang.org/issues/13810) Inconsistency between Date and Time.strftime("%v") (shyouhei)
 
-## \[Feature [#12282](https://bugs.ruby-lang.org/issues/12282)\] Hash#dig! for repeated applications of Hash#fetch (shyouhei)
+## [[Feature #12282]](https://bugs.ruby-lang.org/issues/12282) Hash#dig! for repeated applications of Hash#fetch (shyouhei)
 
-## \[Feature [#13821](https://bugs.ruby-lang.org/issues/13821)\] Allow fibers to be resumed across threads (shyouhei)
+## [[Feature #13821]](https://bugs.ruby-lang.org/issues/13821) Allow fibers to be resumed across threads (shyouhei)
 
-## \[Feature [#9450](https://bugs.ruby-lang.org/issues/9450)\] Allow overriding SSLContext options in Net::HTTP (shyouhei)
+## [[Feature #9450]](https://bugs.ruby-lang.org/issues/9450) Allow overriding SSLContext options in Net::HTTP (shyouhei)
 
-## \[Feature [#13820](https://bugs.ruby-lang.org/issues/13820)\] Add a nill coalescing operator (shyouhei)
+## [[Feature #13820]](https://bugs.ruby-lang.org/issues/13820) Add a nill coalescing operator (shyouhei)
 
-## \[Feature [#13770](https://bugs.ruby-lang.org/issues/13770)\] Can't create valid Cyrillic-named class/module (shyouhei, duerst)
+## [[Feature #13770]](https://bugs.ruby-lang.org/issues/13770) Can't create valid Cyrillic-named class/module (shyouhei, duerst)
 
-## \[Feature [#13839](https://bugs.ruby-lang.org/issues/13839)\] String Interpolation Statements (shyouhei)
+## [[Feature #13839]](https://bugs.ruby-lang.org/issues/13839) String Interpolation Statements (shyouhei)
 
-## \[Misc [#13840](https://bugs.ruby-lang.org/issues/13840)\] Collection methods - stability (shyouhei, duerst (propose to reject))
+## [[Misc #13840]](https://bugs.ruby-lang.org/issues/13840) Collection methods - stability (shyouhei, duerst (propose to reject))
 
-- \[Feature [#13801](https://bugs.ruby-lang.org/issues/13801)\] Implement case equality test for Set#=== (duerst)
+- [[Feature #13801]](https://bugs.ruby-lang.org/issues/13801) Implement case equality test for Set#=== (duerst)
 - bugs that are not assigned (shyouhei)
 
 
-## \[Bug [#13549](https://bugs.ruby-lang.org/issues/13549)\] MinGW / Windows encoding - Two issues
+## [[Bug #13549]](https://bugs.ruby-lang.org/issues/13549) MinGW / Windows encoding - Two issues
 
-## \[Bug [#13754](https://bugs.ruby-lang.org/issues/13754)\] bigdecimal with lower precision that Float
+## [[Bug #13754]](https://bugs.ruby-lang.org/issues/13754) bigdecimal with lower precision that Float
 
-## \[Bug [#13746](https://bugs.ruby-lang.org/issues/13746)\] windows-pr gemのRuby 2.4 32bit版でのSEGV
+## [[Bug #13746]](https://bugs.ruby-lang.org/issues/13746) windows-pr gemのRuby 2.4 32bit版でのSEGV
 
-## \[Bug [#13758](https://bugs.ruby-lang.org/issues/13758)\] TestRubyOptions#test\_segv\_setproctitle segfaults on AARCH64
+## [[Bug #13758]](https://bugs.ruby-lang.org/issues/13758) TestRubyOptions#test\_segv\_setproctitle segfaults on AARCH64
 
-## \[Bug [#13716](https://bugs.ruby-lang.org/issues/13716)\] Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
+## [[Bug #13716]](https://bugs.ruby-lang.org/issues/13716) Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
 
-## \[Bug [#13691](https://bugs.ruby-lang.org/issues/13691)\] Word- and symbol array literals not valid where regular array is
+## [[Bug #13691]](https://bugs.ruby-lang.org/issues/13691) Word- and symbol array literals not valid where regular array is
 
-## \[Bug [#13769](https://bugs.ruby-lang.org/issues/13769)\] IPAddr#ipv4\_compat incorrect behavior
+## [[Bug #13769]](https://bugs.ruby-lang.org/issues/13769) IPAddr#ipv4\_compat incorrect behavior
 
-## \[Bug [#13768](https://bugs.ruby-lang.org/issues/13768)\] SIGCHLD and Thread dead-lock problem
+## [[Bug #13768]](https://bugs.ruby-lang.org/issues/13768) SIGCHLD and Thread dead-lock problem
 
-## \[Bug [#13773](https://bugs.ruby-lang.org/issues/13773)\] Improve String#prepend performance if only one argument is given
+## [[Bug #13773]](https://bugs.ruby-lang.org/issues/13773) Improve String#prepend performance if only one argument is given
 
-## \[Bug [#13774](https://bugs.ruby-lang.org/issues/13774)\] for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
+## [[Bug #13774]](https://bugs.ruby-lang.org/issues/13774) for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
 
-## \[Bug [#13748](https://bugs.ruby-lang.org/issues/13748)\] \[PATCH\] Fix mul overflow detection for LLP64 arch.
+## [[Bug #13748]](https://bugs.ruby-lang.org/issues/13748) \[PATCH\] Fix mul overflow detection for LLP64 arch.
 
-## \[Bug [#13781](https://bugs.ruby-lang.org/issues/13781)\] Should the safe navigation operator invoke nil?
+## [[Bug #13781]](https://bugs.ruby-lang.org/issues/13781) Should the safe navigation operator invoke nil?
 
-## \[Bug [#13795](https://bugs.ruby-lang.org/issues/13795)\] Hash#select return type does not match Hash#find\_all
+## [[Bug #13795]](https://bugs.ruby-lang.org/issues/13795) Hash#select return type does not match Hash#find\_all
 
-## \[Bug [#13811](https://bugs.ruby-lang.org/issues/13811)\] Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
+## [[Bug #13811]](https://bugs.ruby-lang.org/issues/13811) Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
 
 
 We couldn’t investigate it because there is not enough reproduction instruction..
 
-## \[Bug [#13818](https://bugs.ruby-lang.org/issues/13818)\] Licence issue with use of Onigmo rather than Oniguruma library files
+## [[Bug #13818]](https://bugs.ruby-lang.org/issues/13818) Licence issue with use of Onigmo rather than Oniguruma library files
 
-## \[Bug [#13827](https://bugs.ruby-lang.org/issues/13827)\] Improve performance of Base64.urlsafe\_encode64
+## [[Bug #13827]](https://bugs.ruby-lang.org/issues/13827) Improve performance of Base64.urlsafe\_encode64
 
-## \[Bug [#13829](https://bugs.ruby-lang.org/issues/13829)\] NUL char in $0
+## [[Bug #13829]](https://bugs.ruby-lang.org/issues/13829) NUL char in $0
 
-## \[Bug [#13833](https://bugs.ruby-lang.org/issues/13833)\] String#scanf("%a") incorrectly requires a sign on the (binary) exponent
+## [[Bug #13833]](https://bugs.ruby-lang.org/issues/13833) String#scanf("%a") incorrectly requires a sign on the (binary) exponent
 
-## \[Bug [#13835](https://bugs.ruby-lang.org/issues/13835)\] Using 'open-uri' with 'tempfile' causes an exception
+## [[Bug #13835]](https://bugs.ruby-lang.org/issues/13835) Using 'open-uri' with 'tempfile' causes an exception
 
-## \[Bug [#13757](https://bugs.ruby-lang.org/issues/13757)\] TestBacktrace#test\_caller\_lev segaults on PPC
+## [[Bug #13757]](https://bugs.ruby-lang.org/issues/13757) TestBacktrace#test\_caller\_lev segaults on PPC
 
-## \[Bug [#13167](https://bugs.ruby-lang.org/issues/13167)\] Dir.glob is 25x slower since Ruby 2.2
+## [[Bug #13167]](https://bugs.ruby-lang.org/issues/13167) Dir.glob is 25x slower since Ruby 2.2
 
-## \[Bug [#13844](https://bugs.ruby-lang.org/issues/13844)\] Toplevel returns should fire ensures
+## [[Bug #13844]](https://bugs.ruby-lang.org/issues/13844) Toplevel returns should fire ensures
 
 
 ## From non-attendees
 
-## \[Feature [#13686](https://bugs.ruby-lang.org/issues/13686)\] Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (aycabta)
+## [[Feature #13686]](https://bugs.ruby-lang.org/issues/13686) Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (aycabta)
 
 
 ## Write your name and your interest (what do you want to ask and to whom?) please.

--- a/2017/DevMeeting-2017-09-25.md
+++ b/2017/DevMeeting-2017-09-25.md
@@ -191,12 +191,12 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Carry-over from previous meeting(s)
 
-## \[Feature [#13396](https://bugs.ruby-lang.org/issues/13396)\] Net::HTTP has no write timeout (shyouhei) Sorry, what was the conclusion of it?
+## [[Feature #13396]](https://bugs.ruby-lang.org/issues/13396) Net::HTTP has no write timeout (shyouhei) Sorry, what was the conclusion of it?
 
 
 - naruse: I’ll implement this.
 
-## \[Bug [#13438](https://bugs.ruby-lang.org/issues/13438)\] Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei) Sorry, what was the conclusion of it?
+## [[Bug #13438]](https://bugs.ruby-lang.org/issues/13438) Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei) Sorry, what was the conclusion of it?
 
 
 - mrkn: I remember we should not support old OpenBSD.
@@ -204,39 +204,39 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - shyouhei: then should we accept this?
 - nobu: yes.
 
-## \[Feature [#13608](https://bugs.ruby-lang.org/issues/13608)\] Add TracePoint#thread (shyouhei)
+## [[Feature #13608]](https://bugs.ruby-lang.org/issues/13608) Add TracePoint#thread (shyouhei)
 
 
 - ko1: I think we don’t need this.
 - naruse: I wanted this when I created a tracer.
 - ko1: the tracer shall run on the thread. Thread.current should suffice
 
-## \[Feature [#13602](https://bugs.ruby-lang.org/issues/13602)\] Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
+## [[Feature #13602]](https://bugs.ruby-lang.org/issues/13602) Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
 
 
 - ko1: is it worth for a 5-6% speedup?
 - mame: this should affect optcarrot...
 
-## \[Feature [#13613](https://bugs.ruby-lang.org/issues/13613)\] Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
+## [[Feature #13613]](https://bugs.ruby-lang.org/issues/13613) Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
 
 
 - akr: we should define errors that are “fatal” and those aren’t.  For instance, ENOENT is not fatal but EPERM is.
 - shyouhei: it sounds reasonable for someone want to know when there \_are\_ some nasty files.
 - mame: should we raise exceptions for errors other than ENOENT? or to warn only?
 
-## \[Feature [#13620](https://bugs.ruby-lang.org/issues/13620)\] Simplifying MRI's build system: always install (shyouhei)
+## [[Feature #13620]](https://bugs.ruby-lang.org/issues/13620) Simplifying MRI's build system: always install (shyouhei)
 
 
 - the thread is going on.
 
-## \[Feature [#13630](https://bugs.ruby-lang.org/issues/13630)\] :\[\] method should accept block in nice syntax (shyouhei) OK to close?
+## [[Feature #13630]](https://bugs.ruby-lang.org/issues/13630) :\[\] method should accept block in nice syntax (shyouhei) OK to close?
 
 
 - matz: I think it should be accepted.
 - nobu: mruby doesn’t work this way, BTW.
 - shyouhei: OK, lets close.
 
-- \[Feature [#11484](https://bugs.ruby-lang.org/issues/11484)\] add output offset for readpartial/read\_nonblock/etc (shyouhei)
+- [[Feature #11484]](https://bugs.ruby-lang.org/issues/11484) add output offset for readpartial/read\_nonblock/etc (shyouhei)
 
 - akr: sounds OK to me.
 - shyouhei: seems nobody is against the feature itself but the API?
@@ -245,14 +245,14 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - nobu: what about buffer\_offset?
 - knu: seems IO.write has optional 3rd argument, offset, which is used to seek the file.
 
-## \[Feature [#9001](https://bugs.ruby-lang.org/issues/9001)\] Please package better standard library (shyouhe)
+## [[Feature #9001]](https://bugs.ruby-lang.org/issues/9001) Please package better standard library (shyouhe)
 
 
 - duerst: This particular ticket seems no feature but for long term, what should we do for standard libraries?
 - mrkn: I think current goal is to bundle things that are only needed for installing rubygems
 - akira: close this and let people individually name replacemets.
 
-## \[Feature [#12533](https://bugs.ruby-lang.org/issues/12533)\] Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
+## [[Feature #12533]](https://bugs.ruby-lang.org/issues/12533) Refinements: allow modules inclusion, in which the module can call internal methods which it defines. (shyouhei)
 
 
 - matz: this sounds like a bug instead of local rebinding?
@@ -289,24 +289,24 @@ end
 
 puts "tomatoe".vegetables
 
-## \[Feature [#13653](https://bugs.ruby-lang.org/issues/13653)\] Bundled zlib helper (shyouhei)
+## [[Feature #13653]](https://bugs.ruby-lang.org/issues/13653) Bundled zlib helper (shyouhei)
 
 
 - shyouhei: postpone because hsbt is absent.
 
-## \[Feature [#13626](https://bugs.ruby-lang.org/issues/13626)\] Add String#byteslice! (shyouhei)
+## [[Feature #13626]](https://bugs.ruby-lang.org/issues/13626) Add String#byteslice! (shyouhei)
 
 
 - mame: sounds reasonable because we have both slice and slice!
 - matz: agreed.
 
-## \[Feature [#13551](https://bugs.ruby-lang.org/issues/13551)\] Add a method to alias class methods (shyouhei)
+## [[Feature #13551]](https://bugs.ruby-lang.org/issues/13551) Add a method to alias class methods (shyouhei)
 
 
 - shyouhei: ah, I want this feature.
 - matz: I prefer opening singleton class.
 
-## \[Feature [#13332](https://bugs.ruby-lang.org/issues/13332)\] Forwardable#def\_instance\_delegator nil (shyouhei)
+## [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def\_instance\_delegator nil (shyouhei)
 
 
 - nobu: I don’t think this is much meaningful.
@@ -314,30 +314,30 @@ puts "tomatoe".vegetables
 - knu: ActiveSupport::Delegate also doesn’t support this comples feature (but only allow\_nil)
 - matz: I’d like to hear use cases.
 
-## \[Feature [#13378](https://bugs.ruby-lang.org/issues/13378)\] Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
+## [[Feature #13378]](https://bugs.ruby-lang.org/issues/13378) Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
 
 
 - nobu: I’m handlig this. WIP.
 
-## \[Feature [#13381](https://bugs.ruby-lang.org/issues/13381)\] \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
 
 
 - matz: postpone because ko1 is absent.
 
-## \[Feature [#13677](https://bugs.ruby-lang.org/issues/13677)\] Add more details to error "Name or service not known (SocketError)" (shyouhei)
+## [[Feature #13677]](https://bugs.ruby-lang.org/issues/13677) Add more details to error "Name or service not known (SocketError)" (shyouhei)
 
 
 - akr: we currenly only show the return value of gai\_strerror(). Seems OK to extend though.
 - akr: patch is welcomed.
 
-## \[Feature [#9323](https://bugs.ruby-lang.org/issues/9323)\] IO#writev (shyouhei)
+## [[Feature #9323]](https://bugs.ruby-lang.org/issues/9323) IO#writev (shyouhei)
 
 
 - akr: do we call syscalls many times, or should we buffer?
 - mame: I want to know how this speeds things up.
 - knu: maybe atomic write is the point.
 
-## \[Feature [#13693](https://bugs.ruby-lang.org/issues/13693)\] Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
+## [[Feature #13693]](https://bugs.ruby-lang.org/issues/13693) Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
 
 
 - mame: haha
@@ -349,18 +349,18 @@ puts "tomatoe".vegetables
 - mrkn: yes.
 - mrkn: it seems the behaviour of #to\_i comes with atoi().
 
-## \[Feature [#13434](https://bugs.ruby-lang.org/issues/13434)\] better method definition in C API (shyouhei)
+## [[Feature #13434]](https://bugs.ruby-lang.org/issues/13434) better method definition in C API (shyouhei)
 
 
 - shyouhei: postpone because ko1 is absent now.
 
-## \[Feature [#13696](https://bugs.ruby-lang.org/issues/13696)\] Add exchange and noreplace options to File.rename (shyouhei)
+## [[Feature #13696]](https://bugs.ruby-lang.org/issues/13696) Add exchange and noreplace options to File.rename (shyouhei)
 
 
 - akr: This should definitely not be an extension to #rename.
 - nobu: It’s hard to introduce in-core.
 
-## \[Feature [#13683](https://bugs.ruby-lang.org/issues/13683)\] Add strict Enumerable#single (shyouhei)
+## [[Feature #13683]](https://bugs.ruby-lang.org/issues/13683) Add strict Enumerable#single (shyouhei)
 
 
 - shyouhei: わかる
@@ -371,7 +371,7 @@ puts "tomatoe".vegetables
 - mame: what about the feature itself?
 - matz: think we need more use case.
 
-## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
 
 
 - matz: async { File.read }
@@ -380,12 +380,12 @@ puts "tomatoe".vegetables
 - ko1: what if a library author did this, its user can never be aware of this async call.
 - ko1: If a Fiber body is small, it may have no problem.  However when someone write a framework that wraps existing external library, that should result in a problematic situation.
 
-## \[Feature [#13821](https://bugs.ruby-lang.org/issues/13821)\] Allow fibers to be resumed across threads (shyouhei)
+## [[Feature #13821]](https://bugs.ruby-lang.org/issues/13821) Allow fibers to be resumed across threads (shyouhei)
 
 
 - ko1: it’s technically impossible.
 
-## \[Bug [#13931](https://bugs.ruby-lang.org/issues/13931)\] correct install\_name of libruby on macOS (libruby.2.5.0.dylib -> libruby.2.5.dylib) (naruse)
+## [[Bug #13931]](https://bugs.ruby-lang.org/issues/13931) correct install\_name of libruby on macOS (libruby.2.5.0.dylib -> libruby.2.5.dylib) (naruse)
 
 
 - nobu: compatibility version shall be, and is, “2.4.0” ATM.  But we had bugs before.  I don’t want to change the AS-IS behaviour.
@@ -393,24 +393,24 @@ puts "tomatoe".vegetables
 - naruse: compatibility version shall be “2.4.0” or “2.4”, and linked libray should be libruby.2.4.dylib
 
 
-- \[Bug [#13917](https://bugs.ruby-lang.org/issues/13917)\] Comparable#clamp is slower than using Array#min,max. (naruse)
+- [[Bug #13917]](https://bugs.ruby-lang.org/issues/13917) Comparable#clamp is slower than using Array#min,max. (naruse)
 
 - nobu: the prposed patch seems roughly okay
 - mame: we don’t optimize Comparable#clamp for literals, because no practical usage can be thought for such thing. NEWS shall be consulted.
 - naruse: I’ll respond as such. nobu will merge the pull request.
 
-## \[Feature [#13893](https://bugs.ruby-lang.org/issues/13893)\] Add Fiber#\[\] and Fiber#\[\]= and restore Thread#\[\] and Thread#\[\]= to their original behavior (shyouhei)
+## [[Feature #13893]](https://bugs.ruby-lang.org/issues/13893) Add Fiber#\[\] and Fiber#\[\]= and restore Thread#\[\] and Thread#\[\]= to their original behavior (shyouhei)
 
 
 - akr: This is clear, but too late.
 
-## \[Feature [#10344](https://bugs.ruby-lang.org/issues/10344)\] \[PATCH\] Implement Fiber#raise (shyouhei)
+## [[Feature #10344]](https://bugs.ruby-lang.org/issues/10344) \[PATCH\] Implement Fiber#raise (shyouhei)
 
 
 - ko1: if we allow Fiber#raise, auto fiber shall introduce weired behaviour.
 - akr: I don’t think auto fiber should transfar exceptions.
 
-## \[Feature [#13923](https://bugs.ruby-lang.org/issues/13923)\] Idiom to release resources safely, with less indentations (shyouhei)
+## [[Feature #13923]](https://bugs.ruby-lang.org/issues/13923) Idiom to release resources safely, with less indentations (shyouhei)
 
 
 - shyouhei: This is what C++ resolves using RAII
@@ -441,7 +441,7 @@ puts "tomatoe".vegetables
 - matz: returning to the issue, let’s hear what the OP thinks about the nobu’s library.
 
 
-## \[Feature [#13919](https://bugs.ruby-lang.org/issues/13919)\] Add a new method to create Time instances from unix time and nsec (shyouhei)
+## [[Feature #13919]](https://bugs.ruby-lang.org/issues/13919) Add a new method to create Time instances from unix time and nsec (shyouhei)
 
 
 - naruse: I want it.
@@ -459,7 +459,7 @@ puts "tomatoe".vegetables
 - naruse: I think no practical usage are there for specifying both msec and nsec.
 - matz: OK, accepted.  But specifying nil shall raise exceptions.
 
-## \[Bug [#13887](https://bugs.ruby-lang.org/issues/13887)\] test/ruby/test\_io.rb may get stuck with FIBER\_USE\_NATIVE=0 on Linux
+## [[Bug #13887]](https://bugs.ruby-lang.org/issues/13887) test/ruby/test\_io.rb may get stuck with FIBER\_USE\_NATIVE=0 on Linux
 
 
 - ko1: this is a bug that should be fixed. I’ll do.

--- a/2018/DevMeeting-2018-01-24.md
+++ b/2018/DevMeeting-2018-01-24.md
@@ -162,12 +162,12 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 
 ## From attendees
 
-## \[Feature [#14223](https://bugs.ruby-lang.org/issues/14223)\] Enable #to\_proc by Refinements at &hoge (nobu)
+## [[Feature #14223]](https://bugs.ruby-lang.org/issues/14223) Enable #to\_proc by Refinements at &hoge (nobu)
 
 
 - Matz: LGTM.
 
-## \[Feature [#14371](https://bugs.ruby-lang.org/issues/14371)\] New option "recursive: true" for Hash#transform\_keys! (nobu)
+## [[Feature #14371]](https://bugs.ruby-lang.org/issues/14371) New option "recursive: true" for Hash#transform\_keys! (nobu)
 
 
 - Mrkn: This is deep\_stringify\_keys!
@@ -184,14 +184,14 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Mrkn: we can fix it by preserving entries that conflict.
 - Matz: I have strong opinion on this.  Isn’t the current behaviour acceptable in sake of space efficiency?
 
-## \[Bug [#14374](https://bugs.ruby-lang.org/issues/14374)\] for does not splat elements (nobu)
+## [[Bug #14374]](https://bugs.ruby-lang.org/issues/14374) for does not splat elements (nobu)
 
 
 - Ko1: is it me?
 - Nobu: because it’s since 1.9
 - Matz: please fix.
 
-## \[Feature [#14313](https://bugs.ruby-lang.org/issues/14313)\] Support creating KeyError with receiver and key from Ruby (mrkn/kou)
+## [[Feature #14313]](https://bugs.ruby-lang.org/issues/14313) Support creating KeyError with receiver and key from Ruby (mrkn/kou)
 
 
 - Mrkn: I was asked to bring this.
@@ -205,15 +205,15 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Mrkn: But he doesn’t have the repo access bit, nor gem release right.
 - Mame: He’s active on twitter etc.  You should ask his current status.
 
-## \[Feature [#4831](https://bugs.ruby-lang.org/issues/4831)\] Integer#prime\_factors (mrkn)
+## [[Feature #4831]](https://bugs.ruby-lang.org/issues/4831) Integer#prime\_factors (mrkn)
 
 
 - Mrkn: name?
 - Shyouhei: yugui is on the ticket.
 
-## \[Feature [#14235](https://bugs.ruby-lang.org/issues/14235)\] Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
+## [[Feature #14235]](https://bugs.ruby-lang.org/issues/14235) Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
 
-## \[Feature [#14386](https://bugs.ruby-lang.org/issues/14386)\] Add option to let Kernel.#system raise error instead of returning false (k0kubun)
+## [[Feature #14386]](https://bugs.ruby-lang.org/issues/14386) Add option to let Kernel.#system raise error instead of returning false (k0kubun)
 
 
 - Nobu: is this request to raise error when spawn fails, or when the spawned process fails?
@@ -222,7 +222,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Mrkn: I see similarity for discussion on Integer(). \[ruby-core:77171\] \[Feature#12732\]
 - Akr: There are \`exception: true\`
 
-## \[Bug [#14353](https://bugs.ruby-lang.org/issues/14353)\] $SAFE should stay at least thread-local for compatibility (ko1)
+## [[Bug #14353]](https://bugs.ruby-lang.org/issues/14353) $SAFE should stay at least thread-local for compatibility (ko1)
 
 
 - Matz: This feature is something to extinct in future.
@@ -248,7 +248,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 
 ## From non-attendees
 
-## \[Feature [#14382](https://bugs.ruby-lang.org/issues/14382)\] Make public access of a private constant call const\_missing (jeremyevans0)
+## [[Feature #14382]](https://bugs.ruby-lang.org/issues/14382) Make public access of a private constant call const\_missing (jeremyevans0)
 
 
 - Nobu: sounds like a bug to me
@@ -256,7 +256,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Matz: Let’s try.
 - Nobu: I’d like to review the patch.
 
-## \[Feature [#14385](https://bugs.ruby-lang.org/issues/14385)\] Deprecate back-tick for Ruby 3 (hsbt)
+## [[Feature #14385]](https://bugs.ruby-lang.org/issues/14385) Deprecate back-tick for Ruby 3 (hsbt)
 
 
 - Matz: I see several objections are there.
@@ -268,7 +268,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Mame: should we also deprecate def \`; end; self.\` ? If so, warning on parsing is dangerous.
 - Matz: I think we don’t necessarily warn this as soon as 2.6.
 
-## \[Feature [#13969](https://bugs.ruby-lang.org/issues/13969)\] Dir#each\_child (znz)
+## [[Feature #13969]](https://bugs.ruby-lang.org/issues/13969) Dir#each\_child (znz)
 
 
 - Matz: OK.

--- a/2018/DevMeeting-2018-02-20.md
+++ b/2018/DevMeeting-2018-02-20.md
@@ -163,12 +163,12 @@ Next Developper Meetings
 
 ## From attendees
 
-## \[Feature [#14223](https://bugs.ruby-lang.org/issues/14223)\] Enable #to\_proc by Refinements at &hoge (nobu)
+## [[Feature #14223]](https://bugs.ruby-lang.org/issues/14223) Enable #to\_proc by Refinements at &hoge (nobu)
 
 
 - Matz: LGTM.
 
-## \[Feature [#14371](https://bugs.ruby-lang.org/issues/14371)\] New option "recursive: true" for Hash#transform\_keys! (nobu)
+## [[Feature #14371]](https://bugs.ruby-lang.org/issues/14371) New option "recursive: true" for Hash#transform\_keys! (nobu)
 
 
 - Mrkn: This is deep\_stringify\_keys!
@@ -185,14 +185,14 @@ Next Developper Meetings
 - Mrkn: we can fix it by preserving entries that conflict.
 - Matz: I have strong opinion on this.  Isn’t the current behaviour acceptable in sake of space efficiency?
 
-## \[Bug [#14374](https://bugs.ruby-lang.org/issues/14374)\] for does not splat elements (nobu)
+## [[Bug #14374]](https://bugs.ruby-lang.org/issues/14374) for does not splat elements (nobu)
 
 
 - Ko1: is it me?
 - Nobu: because it’s since 1.9
 - Matz: please fix.
 
-## \[Feature [#14313](https://bugs.ruby-lang.org/issues/14313)\] Support creating KeyError with receiver and key from Ruby (mrkn/kou)
+## [[Feature #14313]](https://bugs.ruby-lang.org/issues/14313) Support creating KeyError with receiver and key from Ruby (mrkn/kou)
 
 
 - Mrkn: I was asked to bring this.
@@ -206,15 +206,15 @@ Next Developper Meetings
 - Mrkn: But he doesn’t have the repo access bit, nor gem release right.
 - Mame: He’s active on twitter etc.  You should ask his current status.
 
-## \[Feature [#4831](https://bugs.ruby-lang.org/issues/4831)\] Integer#prime\_factors (mrkn)
+## [[Feature #4831]](https://bugs.ruby-lang.org/issues/4831) Integer#prime\_factors (mrkn)
 
 
 - Mrkn: name?
 - Shyouhei: yugui is on the ticket.
 
-## \[Feature [#14235](https://bugs.ruby-lang.org/issues/14235)\] Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
+## [[Feature #14235]](https://bugs.ruby-lang.org/issues/14235) Merge MJIT infrastructure with conservative JIT compiler (k0kubun)
 
-## \[Feature [#14386](https://bugs.ruby-lang.org/issues/14386)\] Add option to let Kernel.#system raise error instead of returning false (k0kubun)
+## [[Feature #14386]](https://bugs.ruby-lang.org/issues/14386) Add option to let Kernel.#system raise error instead of returning false (k0kubun)
 
 
 - Nobu: is this request to raise error when spawn fails, or when the spawned process fails?
@@ -223,7 +223,7 @@ Next Developper Meetings
 - Mrkn: I see similarity for discussion on Integer(). \[ruby-core:77171\] \[Feature#12732\]
 - Akr: There are \`exception: true\`
 
-## \[Bug [#14353](https://bugs.ruby-lang.org/issues/14353)\] $SAFE should stay at least thread-local for compatibility (ko1)
+## [[Bug #14353]](https://bugs.ruby-lang.org/issues/14353) $SAFE should stay at least thread-local for compatibility (ko1)
 
 
 - Matz: This feature is something to extinct in future.
@@ -249,7 +249,7 @@ Next Developper Meetings
 
 ## From non-attendees
 
-## \[Feature [#14382](https://bugs.ruby-lang.org/issues/14382)\] Make public access of a private constant call const\_missing (jeremyevans0)
+## [[Feature #14382]](https://bugs.ruby-lang.org/issues/14382) Make public access of a private constant call const\_missing (jeremyevans0)
 
 
 - Nobu: sounds like a bug to me
@@ -257,7 +257,7 @@ Next Developper Meetings
 - Matz: Let’s try.
 - Nobu: I’d like to review the patch.
 
-## \[Feature [#14385](https://bugs.ruby-lang.org/issues/14385)\] Deprecate back-tick for Ruby 3 (hsbt)
+## [[Feature #14385]](https://bugs.ruby-lang.org/issues/14385) Deprecate back-tick for Ruby 3 (hsbt)
 
 
 - Matz: I see several objections are there.
@@ -269,7 +269,7 @@ Next Developper Meetings
 - Mame: should we also deprecate def \`; end; self.\` ? If so, warning on parsing is dangerous.
 - Matz: I think we don’t necessarily warn this as soon as 2.6.
 
-## \[Feature [#13969](https://bugs.ruby-lang.org/issues/13969)\] Dir#each\_child (znz)
+## [[Feature #13969]](https://bugs.ruby-lang.org/issues/13969) Dir#each\_child (znz)
 
 
 - Matz: OK.

--- a/2018/DevMeeting-2018-03-15.md
+++ b/2018/DevMeeting-2018-03-15.md
@@ -133,12 +133,12 @@ Maintainers starting Apr 2018:
 
 ### From attendees
 
-- \[Feature [#12732](https://bugs.ruby-lang.org/issues/12732)\] An option to pass to Integer, Float, to return nil instead of raise an exception (mrkn)
+- [[Feature #12732]](https://bugs.ruby-lang.org/issues/12732) An option to pass to Integer, Float, to return nil instead of raise an exception (mrkn)
 
 - Resolved
 - Mrkn will file the conclusion.
 
-- \[Feature [#14476](https://bugs.ruby-lang.org/issues/14476)\] Adding same\_all? for checking whether all items in an Array are same (mrkn)
+- [[Feature #14476]](https://bugs.ruby-lang.org/issues/14476) Adding same\_all? for checking whether all items in an Array are same (mrkn)
 
 - Definition of “same”? -> \`\==\`, for mrkn’s case
 - Empty array? -> true, \[\].all?{} #=> true
@@ -158,12 +158,12 @@ Maintainers starting Apr 2018:
 - ary.uniform\_values?
 - ary.uniform\_values?{|e| e.foo}
 
-- \[Feature [#14362](https://bugs.ruby-lang.org/issues/14362)\] use BigDecimal instead of Float by default (mrkn)
+- [[Feature #14362]](https://bugs.ruby-lang.org/issues/14362) use BigDecimal instead of Float by default (mrkn)
 
 - Reject; Unacceptable performance & too incompatible
 - Matz will respond.
 
-- \[Feature [#14044](https://bugs.ruby-lang.org/issues/14044)\] Introduce a new attribute step in Range (mrkn)
+- [[Feature #14044]](https://bugs.ruby-lang.org/issues/14044) Introduce a new attribute step in Range (mrkn)
 
 \# current
 
@@ -205,36 +205,36 @@ p 1.step(by: 2)         #=> (1.step(by:2))
 - Will be SyntaxError in 2.6-preview2
 - All of begin/do/def (experimental)
 
-- \[Feature [#14594](https://bugs.ruby-lang.org/issues/14594)\] Rethink yield\_self's name
+- [[Feature #14594]](https://bugs.ruby-lang.org/issues/14594) Rethink yield\_self's name
 
 - “then”?
 - (1) Possible to use this method name by other libraries (like promise)
 - (2) No built-in methods like this …
 - Comitters objected the suggestion but matz accepted it
 
-- \[Feature [#14324](https://bugs.ruby-lang.org/issues/14324)\] Should Exception#full\_message include escape sequences?
+- [[Feature #14324]](https://bugs.ruby-lang.org/issues/14324) Should Exception#full\_message include escape sequences?
 
 - Keyword arguments
 
 - order: :top/:bottom
 - highlight: true/false
 
-- \[Feature [#12745](https://bugs.ruby-lang.org/issues/12745)\] String#(g)sub(!) should pass a MatchData to the block, not a String
+- [[Feature #12745]](https://bugs.ruby-lang.org/issues/12745) String#(g)sub(!) should pass a MatchData to the block, not a String
 
 - akr: how about gsubm, \`m\` means MatchData
 
 ### From non-attendees
 
-- \[Feature [#14245](https://bugs.ruby-lang.org/issues/14245)\] Add File.read etc. (shugo)
+- [[Feature #14245]](https://bugs.ruby-lang.org/issues/14245) Add File.read etc. (shugo)
 
 - Accepted
 - FYI: On 2.5, deprecation warning is added for this feature. We’ll remove this feature on 2.6.
 
-- \[Feature [#14579](https://bugs.ruby-lang.org/issues/14579)\] Hash value omission (shugo)
+- [[Feature #14579]](https://bugs.ruby-lang.org/issues/14579) Hash value omission (shugo)
 
 - Reject because matz doesn’t like it.
 
-- \[Bug [#14541](https://bugs.ruby-lang.org/issues/14541)\] Class variables have broken semantics, let's fix them (eregon). I'd like more opinions and thoughts on whether we can change them.
+- [[Bug #14541]](https://bugs.ruby-lang.org/issues/14541) Class variables have broken semantics, let's fix them (eregon). I'd like more opinions and thoughts on whether we can change them.
 
 - usa: I use class variables in a correct way when I love class variables
 - ideas:
@@ -294,4 +294,4 @@ B.show
 
 - It’s considered bug. amatsuda says ActiveSupport will follow Ruby 2.6.
 
-- \[Feature [#11473](https://bugs.ruby-lang.org/issues/11473)\] Immutable String literal in Ruby 3 (hsbt): Do you really want to change it at Ruby 3? If It's yes, We should add a warning with destructive action on Ruby 2.6.
+- [[Feature #11473]](https://bugs.ruby-lang.org/issues/11473) Immutable String literal in Ruby 3 (hsbt): Do you really want to change it at Ruby 3? If It's yes, We should add a warning with destructive action on Ruby 2.6.

--- a/2018/DevMeeting-2018-04-19.md
+++ b/2018/DevMeeting-2018-04-19.md
@@ -85,18 +85,18 @@ wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Ja
 
 ### From attendees
 
-\[Bug [#14345](https://bugs.ruby-lang.org/issues/14345)\] http\_proxy setting should respect both parent domain and subdomain (hsbt)
+[[Bug #14345]](https://bugs.ruby-lang.org/issues/14345) http\_proxy setting should respect both parent domain and subdomain (hsbt)
 
-\[Feature [#14559](https://bugs.ruby-lang.org/issues/14559)\] ENV.slice (hsbt)
+[[Feature #14559]](https://bugs.ruby-lang.org/issues/14559) ENV.slice (hsbt)
 
 - Matz: OK.
 
-\[Feature [#14643](https://bugs.ruby-lang.org/issues/14643)\] Remove problematic separator '\\0' of Dir.glob and Dir.\[\] (usa)
+[[Feature #14643]](https://bugs.ruby-lang.org/issues/14643) Remove problematic separator '\\0' of Dir.glob and Dir.\[\] (usa)
 
 - Usa: we can pass arrays to the pattern.  No need to use \\0.
 - Matz: makes sense.
 
-\[Feature [#14111](https://bugs.ruby-lang.org/issues/14111)\] ArgumentErrorが発生した時メソッドのプロトタイプをメッセージに含む (nobu)
+[[Feature #14111]](https://bugs.ruby-lang.org/issues/14111) ArgumentErrorが発生した時メソッドのプロトタイプをメッセージに含む (nobu)
 
 - nobu : seems OK to me.
 - Mame: is the “prototype” the actual string in the source code, or reconstructed?
@@ -110,30 +110,30 @@ wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Ja
 - Nobu: would like to review the patch again.
 - Ko1: what to show for singleton methods? Might be difficult.
 
-\[Bug [#14688](https://bugs.ruby-lang.org/issues/14688)\] Net::HTTPResponse#value raises "Net::HTTPServerException" in 4xx response (usa)
+[[Bug #14688]](https://bugs.ruby-lang.org/issues/14688) Net::HTTPResponse#value raises "Net::HTTPServerException" in 4xx response (usa)
 
-\[Feature [#14683](https://bugs.ruby-lang.org/issues/14683)\] IRB with Ripper (aycabta)
+[[Feature #14683]](https://bugs.ruby-lang.org/issues/14683) IRB with Ripper (aycabta)
 
 - Ask keiju to look at it.
 - Akr: do the OP want to maintain this?  Or make it a gem to delete from the repo?
 
-\[Feature [#14694](https://bugs.ruby-lang.org/issues/14694)\] TracePoint#parameters (mame)
+[[Feature #14694]](https://bugs.ruby-lang.org/issues/14694) TracePoint#parameters (mame)
 
 - Matz: I see no problem?
 - Ko1: TracePoint#parameters sounds like it expects the parameter values, not the names.
 
-\[Feature [#14624](https://bugs.ruby-lang.org/issues/14624)\] #{nil} allocates a fresh empty string each time (nobu)
+[[Feature #14624]](https://bugs.ruby-lang.org/issues/14624) #{nil} allocates a fresh empty string each time (nobu)
 
 - Matz: sounds like an implementation detail.
 - Ko1: it’s too large a patch to implement this as a new VM instruction.
 - Naruse: when I tested opt\_to\_s with @k0kubun the speedup was marginal/not that much.
 
-\[Feature [#6670](https://bugs.ruby-lang.org/issues/6670)\] str.chars.last should be possible (mame)
+[[Feature #6670]](https://bugs.ruby-lang.org/issues/6670) str.chars.last should be possible (mame)
 
 - Mame: I’d like to give up deprecation of this block-giving behaviour.
 - Matz: OK.
 
-\[Feature [#12912](https://bugs.ruby-lang.org/issues/12912)\] An endless range (1..) (mame)
+[[Feature #12912]](https://bugs.ruby-lang.org/issues/12912) An endless range (1..) (mame)
 
 - Mame: I’d like to consult matz.
 - Matz: I honestly feel there should be a fluent way to do 0..Float::INFINITY.
@@ -142,7 +142,7 @@ wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Ja
 - Akr: when this is done, needs of step should reduce very much.
 - Matz: accepted.
 
-\[Feature [#14352](https://bugs.ruby-lang.org/issues/14352)\] Array#pack("M") Quoted-printable (matz)
+[[Feature #14352]](https://bugs.ruby-lang.org/issues/14352) Array#pack("M") Quoted-printable (matz)
 
 - Naruse: I’ll take care.  Let me make this a doc issue.
 
@@ -150,7 +150,7 @@ wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Ja
 
 - Matz: I can live with #then.
 
-\[Feature [#14697](https://bugs.ruby-lang.org/issues/14697)\] Introducing Range#% as an alias to Range#step (mrkn)
+[[Feature #14697]](https://bugs.ruby-lang.org/issues/14697) Introducing Range#% as an alias to Range#step (mrkn)
 
 - Matz: I have no objection.
 - Mrkn: Numo’s Range#% is here [https://github.com/ruby-numo/numo-narray/blob/master/ext/numo/narray/step.c#L464](https://github.com/ruby-numo/numo-narray/blob/master/ext/numo/narray/step.c#L464)

--- a/2018/DevMeeting-2018-05-17.md
+++ b/2018/DevMeeting-2018-05-17.md
@@ -110,7 +110,7 @@ logs
 
 ## From Attendees
 
-- \[Bug [#14699](https://bugs.ruby-lang.org/issues/14699)\] Subtle behaviors with endless range (mame)
+- [[Bug #14699]](https://bugs.ruby-lang.org/issues/14699) Subtle behaviors with endless range (mame)
 
 - Mame: what to do with #max for endless ones?
 - Usa:
@@ -123,7 +123,7 @@ logs
 - Mrkn: I like nil. (by text chat)
 - Ko1: let’s discuss this issue with mrkn.
 
-- \[Feature [#14724](https://bugs.ruby-lang.org/issues/14724)\] chains of inequalities (Martin)
+- [[Feature #14724]](https://bugs.ruby-lang.org/issues/14724) chains of inequalities (Martin)
 
 - Proposal by gotoken (Kentaro Goto) to allow 0 <= a < 10 as a shortcut of 0<=a && a<10, and so on; patch by Nobu avaliable
 - Ko1: what do you think matz?
@@ -139,13 +139,13 @@ logs
 
 ## From non-attendees
 
-- \[Feature [#14697](https://bugs.ruby-lang.org/issues/14697)\] Introducing Range#% as an alias to Range#step (mrkn)
+- [[Feature #14697]](https://bugs.ruby-lang.org/issues/14697) Introducing Range#% as an alias to Range#step (mrkn)
 
 - Matz already commented LGTM. Please judge whether this is acceptable.
 - Akr: I think this should go.
 - (nobody at the meeting had any objections)
 
-- \[Feature [#14724](https://bugs.ruby-lang.org/issues/14724)\] chains of inequations (mrkn)
+- [[Feature #14724]](https://bugs.ruby-lang.org/issues/14724) chains of inequations (mrkn)
 
 - This new syntax can also reduce the duplicated evaluations of common terms, such as timeval.tv\_sec in the descriptiohn of the proposal.
 - Same issue as above. See above.
@@ -168,7 +168,7 @@ logs
 
 Functional programming: (zverok)
 
-- \[Feature [#6284](https://bugs.ruby-lang.org/issues/6284)\] Add composition for procs
+- [[Feature #6284]](https://bugs.ruby-lang.org/issues/6284) Add composition for procs
 
 - 6-year-old proposal. Matz: "Positive about adding function composition. But we need method name consensus before adding it? Is #\* OK for everyone?"
 - (ko1 is describing the Ruby Hack Challenge results)
@@ -180,7 +180,7 @@ Functional programming: (zverok)
 - Matz: shouldn’t we start with Proc…
 - Matz: and I think we need both OOP-ish / FP-ish way.
 
-- \[Feature [#13581](https://bugs.ruby-lang.org/issues/13581)\] Syntax sugar for method reference
+- [[Feature #13581]](https://bugs.ruby-lang.org/issues/13581) Syntax sugar for method reference
 
 - 1-year-old proposal. Matz: "I am for adding syntax sugar for method reference. But I don't like proposed syntax (e.g. \->). Any other idea?"
 - (reviewed comment #21)
@@ -188,17 +188,17 @@ Functional programming: (zverok)
 - Matz: \`.:\` is better than \`->\`
 - Mame: there is a patch cf #12125 [https://bugs.ruby-lang.org/issues/12125](https://bugs.ruby-lang.org/issues/12125)
 
-- \[Feature [#11161](https://bugs.ruby-lang.org/issues/11161)\] Proc/Method#rcurry working like curry but in reverse order
+- [[Feature #11161]](https://bugs.ruby-lang.org/issues/11161) Proc/Method#rcurry working like curry but in reverse order
 
 - 3-year-old proposal with absolutely no reaction. I've added real-life examples there several months ago.
 - Mame: I don’t think reverse currying works for variadic methods
 - Akr: the “real-life” example is adding keyword arguments, which is not what currying is talking about
 
-- \[Feature [#14390](https://bugs.ruby-lang.org/issues/14390)\] UnboundMethod#to\_proc
+- [[Feature #14390]](https://bugs.ruby-lang.org/issues/14390) UnboundMethod#to\_proc
 
 - What is the expected behaviour here?
 
-- \[Feature [#14423](https://bugs.ruby-lang.org/issues/14423)\] Enumerator from single object (Object#enumerate)
+- [[Feature #14423]](https://bugs.ruby-lang.org/issues/14423) Enumerator from single object (Object#enumerate)
 
 - Naruse: interesting proposal
 - Akr: adding method to Object sounds too radical to me.
@@ -207,7 +207,7 @@ Functional programming: (zverok)
 
 Misc:
 
-- \[Bug [#14575](https://bugs.ruby-lang.org/issues/14575)\] Switch Range#=== to use cover? instead of include? (zverok)
+- [[Bug #14575]](https://bugs.ruby-lang.org/issues/14575) Switch Range#=== to use cover? instead of include? (zverok)
 
 - Seems there is a compatibility issue.
 - Usa: does it matter? No one actually expects Range#=== to behave as #cover?
@@ -222,14 +222,14 @@ Docs (probably not to discuss on development meeting, but I am not sure where I 
 
 - Naruse: This meeting is not for documents. Just assign to docs member group.
 
-- \[Feature [#14473](https://bugs.ruby-lang.org/issues/14473)\] Add Range#subrange? ( greggzst )
+- [[Feature #14473]](https://bugs.ruby-lang.org/issues/14473) Add Range#subrange? ( greggzst )
 
 - Shyouhei: what to do with String this case?
 - Akr: the simplest is to only concern the both ends.
 - Usa: Hash has \`>\` and \`<\`
 - Mame: use case not clear.
 
-- \[Feature [#14097](https://bugs.ruby-lang.org/issues/14097)\] Add union and difference to Array ( ana06)
+- [[Feature #14097]](https://bugs.ruby-lang.org/issues/14097) Add union and difference to Array ( ana06)
 
 - Matz: create #union and #union!, or create mutating #union ?
 - Matz: I want to add mutating method but #union does not sound mutating.
@@ -237,10 +237,10 @@ Docs (probably not to discuss on development meeting, but I am not sure where I 
 - Akr: to me it seems mutating or not is not the key point of this proposal.
     The key point is provide a (readable) name addition to an operator, I guess.
 
-- \[Feature [#14105](https://bugs.ruby-lang.org/issues/14105)\] Introduce xor as alias for Set#^ ( ana06)
+- [[Feature #14105]](https://bugs.ruby-lang.org/issues/14105) Introduce xor as alias for Set#^ ( ana06)
 
 - Assign to knu
 
-- \[Misc [#14760](https://bugs.ruby-lang.org/issues/14760)\] cross-thread IO#close semantics (normal)
+- [[Misc #14760]](https://bugs.ruby-lang.org/issues/14760) cross-thread IO#close semantics (normal)
 
 - Ko1: I made it theoretically possible to unblock IO#select. However there is a difficult problem for  IO#copy\_stream.

--- a/2018/DevMeeting-2018-07-18.md
+++ b/2018/DevMeeting-2018-07-18.md
@@ -104,19 +104,19 @@ Place: MoneyForward HQ (Tokyo, Japan)
 
 ## Carry-over from previous meeting(s)
 
-- \[Feature [#14784](https://bugs.ruby-lang.org/issues/14784)\] One-sided Comparable#clamp (with endless/startless ranges) (zverok)
+- [[Feature #14784]](https://bugs.ruby-lang.org/issues/14784) One-sided Comparable#clamp (with endless/startless ranges) (zverok)
 
 - more reasonable version of Object#enumerate proposed for the previous meeting.
 - isn’t it enough with accepting nil ? (e.g. .clamp(from, nil) )
 
-- \[Feature [#14859](https://bugs.ruby-lang.org/issues/14859)\] Timeout in VM (normalperson)
+- [[Feature #14859]](https://bugs.ruby-lang.org/issues/14859) Timeout in VM (normalperson)
 
 - Still needs some work, mainly wondering if the idea of moving this part of stdlib into core VM is acceptable or not. No semantic changes except speed improvement.
 - Ko1 will check the patch and will comment in Aug.
 
 ## From Attendees
 
-- \[Feature [#14473](https://bugs.ruby-lang.org/issues/14473)\] Add Range#subrange? (tarui)
+- [[Feature #14473]](https://bugs.ruby-lang.org/issues/14473) Add Range#subrange? (tarui)
 
 - subrange?
 -  is ambiguous
@@ -127,7 +127,7 @@ Place: MoneyForward HQ (Tokyo, Japan)
 - include? is already used as it’s an element or not
 - cover? is acceptable, let it go (matz)
 
-- \[Feature [#14912](https://bugs.ruby-lang.org/issues/14912)\] Introduce pattern matching syntax (mame)
+- [[Feature #14912]](https://bugs.ruby-lang.org/issues/14912) Introduce pattern matching syntax (mame)
 
 - pattern matching
 - Matz: positive for the proposal itself, though we need to discuss many details
@@ -175,33 +175,33 @@ End
 
 ## From non-attendees
 
-- \[Feature [#14111](https://bugs.ruby-lang.org/issues/14111)\] ArgumentErrorが発生した時メソッドのプロトタイプをメッセージに含む (esjee)
+- [[Feature #14111]](https://bugs.ruby-lang.org/issues/14111) ArgumentErrorが発生した時メソッドのプロトタイプをメッセージに含む (esjee)
 
 - Suggestion: include method parameters when generating an ArgumentError message. Nobu's patch in the issue provides functionality to make writing a ruby gem to provide this functionality possible.
 - \`method\_name\` is true method name, not \`callee\`.
 - current implementation by nobu returns callee, so, change the implement to return true name.  after then, discuss about the necessity of callee.
 
-- \[Bug [#14878](https://bugs.ruby-lang.org/issues/14878)\] Add command line argument to deactivate JIT (k0kubun)
+- [[Bug #14878]](https://bugs.ruby-lang.org/issues/14878) Add command line argument to deactivate JIT (k0kubun)
 
 - Please discuss the necessity of the flag and its name in the proposal.
 - Use \--disable-jit and \--disable=jit, because we can already use \--disable=gems and \--disable-gems
 
-- \[Feature [#12306](https://bugs.ruby-lang.org/issues/12306)\] Implement String #blank? #present? and improve #strip and family to handle unicode (sam.saffron)
+- [[Feature #12306]](https://bugs.ruby-lang.org/issues/12306) Implement String #blank? #present? and improve #strip and family to handle unicode (sam.saffron)
 
 - blank? Is not the best name, but acceptable (space\_only? or something might be better)
 - present? Is not acceptable at all
 - matz will accept the feature itself of blank?, but hope another good name
 - TBW
 
-- \[Feature [#14913](https://bugs.ruby-lang.org/issues/14913)\] Extend case to match several values at once (zverok)
+- [[Feature #14913]](https://bugs.ruby-lang.org/issues/14913) Extend case to match several values at once (zverok)
 
 - some steps towards better pattern matching
 
-- \[Feature [#14914](https://bugs.ruby-lang.org/issues/14914)\] Add BasicObject#instance\_exec\_with\_block (jeremyevans0)
+- [[Feature #14914]](https://bugs.ruby-lang.org/issues/14914) Add BasicObject#instance\_exec\_with\_block (jeremyevans0)
 
 - Real use case, please
 
-- \[Feature [#14915](https://bugs.ruby-lang.org/issues/14915)\] Deprecate String#crypt, move implementation to string/crypt (jeremyevans0)
+- [[Feature #14915]](https://bugs.ruby-lang.org/issues/14915) Deprecate String#crypt, move implementation to string/crypt (jeremyevans0)
 
 - To remove String#crypt, we first need to remove the dependency to String#crypt of WEBrick.  We first listen Eric Wong (WEBrick maintainer)’s opinion.
 - If Eric agrees with the removal in future, we then ask Jeremy to release compatibility-layer gem by 2.6.  If the release is succeeded, we can deprecate the core method.
@@ -211,12 +211,12 @@ End
 
 Carry over:
 
-- \[Bug [#14887](https://bugs.ruby-lang.org/issues/14887)\] Array#delete\_if does not use #delete (shyouhei)
+- [[Bug #14887]](https://bugs.ruby-lang.org/issues/14887) Array#delete\_if does not use #delete (shyouhei)
 
 - Is it by design, or a bug?
 
-- \[Feature [#13050](https://bugs.ruby-lang.org/issues/13050)\] Readline: expose rl\_completion\_quote\_character variable (nobu)
-- \[Feature [#14850](https://bugs.ruby-lang.org/issues/14850)\] Add official API for setting timezone on Time (nobu)
-- \[Feature [#14869](https://bugs.ruby-lang.org/issues/14869)\] Proposal to add Hash#=== (nobu)
-- \[Feature [#14877](https://bugs.ruby-lang.org/issues/14877)\] Calculate age in Date class (nobu)
-- \[Bug [#14908](https://bugs.ruby-lang.org/issues/14908)\] Enumerator::Lazy creates unnecessary Array objects. (nobu)
+- [[Feature #13050]](https://bugs.ruby-lang.org/issues/13050) Readline: expose rl\_completion\_quote\_character variable (nobu)
+- [[Feature #14850]](https://bugs.ruby-lang.org/issues/14850) Add official API for setting timezone on Time (nobu)
+- [[Feature #14869]](https://bugs.ruby-lang.org/issues/14869) Proposal to add Hash#=== (nobu)
+- [[Feature #14877]](https://bugs.ruby-lang.org/issues/14877) Calculate age in Date class (nobu)
+- [[Bug #14908]](https://bugs.ruby-lang.org/issues/14908) Enumerator::Lazy creates unnecessary Array objects. (nobu)

--- a/2018/DevMeeting-2018-08-09.md
+++ b/2018/DevMeeting-2018-08-09.md
@@ -101,34 +101,34 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 ## Carry-over from previous meeting(s)
 
-- \[Bug [#14887](https://bugs.ruby-lang.org/issues/14887)\] Array#delete\_if does not use #delete (shyouhei)
+- [[Bug #14887]](https://bugs.ruby-lang.org/issues/14887) Array#delete\_if does not use #delete (shyouhei)
 
 - Is it by design, or a bug?
 - Matz: delete is memory inefficient.
 - Mame: if you can override #delete, why not also #delete\_if.
 
-- \[Feature [#13050](https://bugs.ruby-lang.org/issues/13050)\] Readline: expose rl\_completion\_quote\_character variable (nobu)
+- [[Feature #13050]](https://bugs.ruby-lang.org/issues/13050) Readline: expose rl\_completion\_quote\_character variable (nobu)
 
 - Go!!!
 
 ## From Attendees
 
-- \[Feature [#5446](https://bugs.ruby-lang.org/issues/5446)\] at\_fork callback API (eregon) Can we get approval for introducing this? It is solving a real-world issue, in a more reliable way than the various hacks in most Ruby servers.
+- [[Feature #5446]](https://bugs.ruby-lang.org/issues/5446) at\_fork callback API (eregon) Can we get approval for introducing this? It is solving a real-world issue, in a more reliable way than the various hacks in most Ruby servers.
 
 - Mrkn: I wanted to use this in pycall to call PyOS\_AfterFork\_Child, and so on from C-layer, but I noticed that I can use pthread\_atfork directly.
 - Naruse: Ruby’s fork is unsafe operation. Application programmers should understand the fact and carefully handle related operations (for example freeing resources).
 - Akr: I guess at\_fork hook would be problematic with multi-thread and/or multi-guild.  But making it Ruby’s standard feature impress this feature usable universally including multi-thread/guild. So, I’m negative for this proposal.
 - usa: Furthermore, I consider that fork must be destroyed.
 
-- \[Feature [#11258](https://bugs.ruby-lang.org/issues/11258)\] add 'x' mode character for O\_EXCL (kazu)
+- [[Feature #11258]](https://bugs.ruby-lang.org/issues/11258) add 'x' mode character for O\_EXCL (kazu)
 
 - Matz accepted already.
 
-- \[Misc [#14907](https://bugs.ruby-lang.org/issues/14907)\] io.c: do not close inherited FDs by default (akr)
+- [[Misc #14907]](https://bugs.ruby-lang.org/issues/14907) io.c: do not close inherited FDs by default (akr)
 
 - Nobody is against changing defaults
 
-- \[Feature [#14850](https://bugs.ruby-lang.org/issues/14850)\] Add official API for setting timezone on Time (nobu)
+- [[Feature #14850]](https://bugs.ruby-lang.org/issues/14850) Add official API for setting timezone on Time (nobu)
 
 - Akr: localtime/timelocal analogous variant methods should suffice
 
@@ -137,19 +137,19 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 - Matz: is there any reason we need this?
 - Matz: What is actual API?
 
-- \[Feature [#14869](https://bugs.ruby-lang.org/issues/14869)\] Proposal to add Hash#=== (nobu)
+- [[Feature #14869]](https://bugs.ruby-lang.org/issues/14869) Proposal to add Hash#=== (nobu)
 
 - After \[Feature #14912\]
 
-- \[Feature [#14877](https://bugs.ruby-lang.org/issues/14877)\] Calculate age in Date class (nobu)
+- [[Feature #14877]](https://bugs.ruby-lang.org/issues/14877) Calculate age in Date class (nobu)
 
 - Matz: I don’t like the idea to implicitly use today.
 
-- \[Feature [#14973](https://bugs.ruby-lang.org/issues/14973)\] Proposal of percent literal to expand Hash (aycabta)
+- [[Feature #14973]](https://bugs.ruby-lang.org/issues/14973) Proposal of percent literal to expand Hash (aycabta)
 
 - Matz: percent literal...
 
-- \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
+- [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
 
 - Naming.
 
@@ -170,11 +170,11 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 ## From non-attendees
 
-- \[Feature [#14717](https://bugs.ruby-lang.org/issues/14717)\] thread: allow disabling preempt (normalperson)
+- [[Feature #14717]](https://bugs.ruby-lang.org/issues/14717) thread: allow disabling preempt (normalperson)
 
 - Closed already
 
-- \[Feature [#11076](https://bugs.ruby-lang.org/issues/11076)\] Enumerable method count\_by (baweaver)
+- [[Feature #11076]](https://bugs.ruby-lang.org/issues/11076) Enumerable method count\_by (baweaver)
     As mentioned in the discussion, Nobu was kind enough to update this to work with current master for Ruby: [https://github.com/ruby/ruby/compare/trunk...nobu:feature/11076-Enumerable%23count\_by](https://github.com/ruby/ruby/compare/trunk...nobu:feature/11076-Enumerable%23count_by)
     As the code is already written I believe it would be an ideal target for 2.6 as a quick win on an often requested feature.
 
@@ -184,7 +184,7 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 - Matz: I’m not against the feature itself.  Also, do we need a block-less counterpart?
 - Naruse: It looks similar to [Presto’s histogram function](https://prestodb.io/docs/current/functions/aggregate.html#histogram)
 
-- \[Feature [#14954](https://bugs.ruby-lang.org/issues/14954)\] Add :wait option to RubyVM::MJIT.pause (k0kubun)
+- [[Feature #14954]](https://bugs.ruby-lang.org/issues/14954) Add :wait option to RubyVM::MJIT.pause (k0kubun)
 
 - Since it's not released even in preview2 yet, is it okay to change the behavior?
 - Is there any objection for having the option or the option name?
@@ -195,21 +195,21 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 - (baweaver)
 
-- \[Feature [#14869](https://bugs.ruby-lang.org/issues/14869)\] Proposal to add Hash#=== (nobu)
-- \[Feature [#14916](https://bugs.ruby-lang.org/issues/14916)\] Proposal to add Array#=== (aycabta)
-- \[Feature [#14912](https://bugs.ruby-lang.org/issues/14912)\] Introduce pattern matching syntax
-    I believe that these three items are related, and personally I could do a lot of very interesting things with Array#=== and Hash#=== that would get us exceptionally close to features discussed in \[Feature [#14709](https://bugs.ruby-lang.org/issues/14709)\]
+- [[Feature #14869]](https://bugs.ruby-lang.org/issues/14869) Proposal to add Hash#=== (nobu)
+- [[Feature #14916]](https://bugs.ruby-lang.org/issues/14916) Proposal to add Array#=== (aycabta)
+- [[Feature #14912]](https://bugs.ruby-lang.org/issues/14912) Introduce pattern matching syntax
+    I believe that these three items are related, and personally I could do a lot of very interesting things with Array#=== and Hash#=== that would get us exceptionally close to features discussed in [[Feature #14709]](https://bugs.ruby-lang.org/issues/14709)
     This to say I would second the inclusion of the first two items as they relate to the third and fourth. It would give Ruby an exceptional amount of power.
 - Matz: we should discuss these after pattern match is introduced.
 
-- \[Feature [#14759](https://bugs.ruby-lang.org/issues/14759)\] \[PATCH\] set M\_ARENA\_MAX for glibc malloc (sam.saffron)
+- [[Feature #14759]](https://bugs.ruby-lang.org/issues/14759) \[PATCH\] set M\_ARENA\_MAX for glibc malloc (sam.saffron)
     I would also very much like to see it backported 2.4 and 2.5. It is of enormous value to the ecosystem
 
 - Usa: The decision should be made by Linux port maintainer
 - Naruse: up to kosaki.
 - Mame: Once kosaki said “If we merge this, we should decide when we remove this”.
 
-- \[Feature [#14944](https://bugs.ruby-lang.org/issues/14944)\] Support optional inherit argument for Module#method\_defined? (jeremyevans0)
+- [[Feature #14944]](https://bugs.ruby-lang.org/issues/14944) Support optional inherit argument for Module#method\_defined? (jeremyevans0)
 
 - Usa: I want this too.
 - Mame: why?
@@ -224,11 +224,11 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 Carry over:
 
-- \[Bug [#14908](https://bugs.ruby-lang.org/issues/14908)\] Enumerator::Lazy creates unnecessary Array objects. (nobu)
-- \[Feature [#14736](https://bugs.ruby-lang.org/issues/14736)\] Thread selector for flexible cooperative fiber based concurrency (ioquatix)
-- \[Feature [#14739](https://bugs.ruby-lang.org/issues/14739)\] Improve fiber yield/resume performance (ioquatix)
+- [[Bug #14908]](https://bugs.ruby-lang.org/issues/14908) Enumerator::Lazy creates unnecessary Array objects. (nobu)
+- [[Feature #14736]](https://bugs.ruby-lang.org/issues/14736) Thread selector for flexible cooperative fiber based concurrency (ioquatix)
+- [[Feature #14739]](https://bugs.ruby-lang.org/issues/14739) Improve fiber yield/resume performance (ioquatix)
 
 - Ko1: will discuss them in person
 
-- \[Bug [#14968](https://bugs.ruby-lang.org/issues/14968)\] io.c: make all pipes nonblocking by default (normalperson)
-- \[Misc [#14937](https://bugs.ruby-lang.org/issues/14937)\] timer-thread elimination depends on [Bug #14968](https://bugs.ruby-lang.org/issues/normalperson)
+- [[Bug #14968]](https://bugs.ruby-lang.org/issues/14968) io.c: make all pipes nonblocking by default (normalperson)
+- [[Misc #14937]](https://bugs.ruby-lang.org/issues/14937) timer-thread elimination depends on [Bug #14968](https://bugs.ruby-lang.org/issues/normalperson)

--- a/2018/DevMeeting-2018-09-13.md
+++ b/2018/DevMeeting-2018-09-13.md
@@ -84,19 +84,19 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From Attendees
 
-- \[Feature [#15022](https://bugs.ruby-lang.org/issues/15022)\] Oneshot coverage
+- [[Feature #15022]](https://bugs.ruby-lang.org/issues/15022) Oneshot coverage
 
 - I'd like to introduce a new kind of coverage to record whether each line is executed or not. It provides less but still useful information compared to the traditional line coverage, and the measurement is quite faster.
 - shyouhei: clear is not atomic, isn’t it?
 - mame: oh, yes.  maybe I should add clear: true option to peek\_result.
 - all: let’s go
 
-- \[Feature [#8661](https://bugs.ruby-lang.org/issues/8661)\] Add option to print backtrace in reverse order(stack frames first & error last)
+- [[Feature #8661]](https://bugs.ruby-lang.org/issues/8661) Add option to print backtrace in reverse order(stack frames first & error last)
 
 - The current backtrace order is really annoying, and I'm not still used; is there any chance to revert?
 - ???: How about using pager?
 
-- \[Feature [#14609](https://bugs.ruby-lang.org/issues/14609)\] \`Kernel#p\` without args shows the receiver (ko1)
+- [[Feature #14609]](https://bugs.ruby-lang.org/issues/14609) \`Kernel#p\` without args shows the receiver (ko1)
 
 - I feel this feature is very useful and some people say :+1: so let discuss about this feature.
 - everyone except mame/ko1: not good
@@ -104,55 +104,55 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - nobu: how about Kernel#P ?
 - knu: There’s a gem: [https://github.com/esminc/tapp](https://github.com/esminc/tapp)
 
-- \[Misc [#14956](https://bugs.ruby-lang.org/issues/14956)\] Remove stale branches in svn repository (hsbt)
+- [[Misc #14956]](https://bugs.ruby-lang.org/issues/14956) Remove stale branches in svn repository (hsbt)
 
 - go ahead.  not remove, but mv to tag
 
-- \[Feature [#6823](https://bugs.ruby-lang.org/issues/6823)\] Where/how should ruby-mode issues be reported? (kazu)
+- [[Feature #6823]](https://bugs.ruby-lang.org/issues/6823) Where/how should ruby-mode issues be reported? (kazu)
 
 - Remove ruby-mode.el from trunk, use emacs’s instead.
 - Other \*.el’s upstream moves to github.
 
-- \[Feature [#14183](https://bugs.ruby-lang.org/issues/14183)\] "Real" keyword argument
+- [[Feature #14183]](https://bugs.ruby-lang.org/issues/14183) "Real" keyword argument
 
 - I'd like to hear matz's current opinion and other committers' ones.
 
-- \[Feature [#14850](https://bugs.ruby-lang.org/issues/14850)\] Add official API for setting timezone on Time (nobu)
+- [[Feature #14850]](https://bugs.ruby-lang.org/issues/14850) Add official API for setting timezone on Time (nobu)
 
 - nobu: a patch posted.
 - akr: it’s not good to use Time object as a container.  But, we can define the official interface as a Struct which has :year, :month, … members.  then, Time objects suit the interface accidentally :)
 
 ## From non-attendees
 
-- \[Feature [#14975](https://bugs.ruby-lang.org/issues/14975)\] String#append without changing receiver's encoding (ioquatix)
+- [[Feature #14975]](https://bugs.ruby-lang.org/issues/14975) String#append without changing receiver's encoding (ioquatix)
 
 - Can we review this PR? We need to decide functionality (i.e. not changing receivers encoding, rejecting encoding if it's not same, unless receiver is binary).
 - Longer term, we should consider if << and concat should be modified. Changing receiver's encoding seems like a mistake.
 
-- \[Feature [#14739](https://bugs.ruby-lang.org/issues/14739)\] Improve fiber yield/resume performance (ioquatix)
+- [[Feature #14739]](https://bugs.ruby-lang.org/issues/14739) Improve fiber yield/resume performance (ioquatix)
 
 - Can I get commit access and can we agree to merge this change?
 
-- \[Feature [#14888](https://bugs.ruby-lang.org/issues/14888)\] Add trace point for eval (and related functions) (ioquatix)
+- [[Feature #14888]](https://bugs.ruby-lang.org/issues/14888) Add trace point for eval (and related functions) (ioquatix)
 
 - Can we decide if this is acceptable so I can make PR?
 
-- \[Feature [#14097](https://bugs.ruby-lang.org/issues/14097)\] Add union and difference methods to Array ([ana06 (Ana Maria Martinez Gomez)](https://bugs.ruby-lang.org/users/13437))
+- [[Feature #14097]](https://bugs.ruby-lang.org/issues/14097) Add union and difference methods to Array ([ana06 (Ana Maria Martinez Gomez)](https://bugs.ruby-lang.org/users/13437))
 
 - Addition of two new methods in aim of readability, ease of use, efficiency and consistency. There are already PR for both methods.
 - [matz (Yukihiro Matsumoto)](https://bugs.ruby-lang.org/users/13) told me to add this here ;) After my talk in EuRuKo and the feedback from the standing voting I hope it is clearer and easy to decide if this is wanted
 
-- \[Bug [#14908](https://bugs.ruby-lang.org/issues/14908)\] Enumerator::Lazy creates unnecessary Array objects
+- [[Bug #14908]](https://bugs.ruby-lang.org/issues/14908) Enumerator::Lazy creates unnecessary Array objects
 
 - Proposed solution is to change arity of Enumerator::Yielder#<< to 1 from -1 and use it internally for lazy enum instead of Enumerator::Yielder#yield. Generally, method << is used with only one parameter changing arity to 1 also makes it consistent with other classes (String, Array)
 - Since, proposed solution involves spec changes (Enumerator::Yielder#<<'s arity) a discussion is requested before the provided patch can proceed.
 
-- \[Feature [#13167](https://bugs.ruby-lang.org/issues/13167)\] Dir.glob is 25x slower since Ruby 2.2 (ahorek)
+- [[Feature #13167]](https://bugs.ruby-lang.org/issues/13167) Dir.glob is 25x slower since Ruby 2.2 (ahorek)
 
 - improves performance of a glob pattern with braces, especially on windows but also on other platforms
 - the idea was already approved by [matz (Yukihiro Matsumoto)](https://bugs.ruby-lang.org/users/13) [#13873](https://bugs.ruby-lang.org/issues/13873) but later revered (incompatibility of the order)
 - attached patch don't have the same problem
 
-- \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] auto-fiber name, is "Thread::Coro" OK? How should Mutex work between coroutines? Queue/SizedQueue works, now (not sure about signal handler).
+- [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) auto-fiber name, is "Thread::Coro" OK? How should Mutex work between coroutines? Queue/SizedQueue works, now (not sure about signal handler).
 
-\[Feature [#5825](https://bugs.ruby-lang.org/issues/5825)\] Sweet instance var assignment in the object initializer
+[[Feature #5825]](https://bugs.ruby-lang.org/issues/5825) Sweet instance var assignment in the object initializer

--- a/2018/DevMeeting-2018-10-10.md
+++ b/2018/DevMeeting-2018-10-10.md
@@ -104,7 +104,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From Attendees
 
-## \[Feature [#14839](https://bugs.ruby-lang.org/issues/14839)\] How to deal with capitalizing Georgian in Unicode 11.0.0 (duerst)
+## [[Feature #14839]](https://bugs.ruby-lang.org/issues/14839) How to deal with capitalizing Georgian in Unicode 11.0.0 (duerst)
 
 
 - I need feedback on this to be able to implement in in time for the Ruby 2.6 release.
@@ -112,7 +112,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - usa: What about keep things as is, to make Georgian people aware of the issue
 - duerst: Georgian characters can be detectable so theoretically it’s possible to have complete mapping of characters.
 
-## \[Feature [#15195](https://bugs.ruby-lang.org/issues/15195)\] How to deal with new Japanese era (duerst)
+## [[Feature #15195]](https://bugs.ruby-lang.org/issues/15195) How to deal with new Japanese era (duerst)
 
 
 - We should prepare early (even if it's just to check that we need to do nothing)
@@ -132,7 +132,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - hsbt: Efforts ongoing.
 - (details omitted from the log)
 
-- \[Misc [#14632](https://bugs.ruby-lang.org/issues/14632)\] \[ANN\] git.ruby-lang.org (hsbt)
+- [[Misc #14632]](https://bugs.ruby-lang.org/issues/14632) \[ANN\] git.ruby-lang.org (hsbt)
 
 - hsbt: I want to switch to git in 20 Oct.
 - usa: what happens?
@@ -141,7 +141,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - mame: Any restriction on git?
 - hsbt: push --force shall be forbidden.
 
-- \[Feature [#14609](https://bugs.ruby-lang.org/issues/14609)\] \`Kernel#p\` without args shows the receiver (ko1)
+- [[Feature #14609]](https://bugs.ruby-lang.org/issues/14609) \`Kernel#p\` without args shows the receiver (ko1)
 
 - It will be useful.
 
@@ -175,7 +175,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From non-attendees
 
-## \[Feature [#15123](https://bugs.ruby-lang.org/issues/15123)\] Enumerable#compact proposal (greggzst)
+## [[Feature #15123]](https://bugs.ruby-lang.org/issues/15123) Enumerable#compact proposal (greggzst)
 
 
 - It simplifies working with large and small collections so one doesn't have to remember that can't use #compact when enumerator is returned and have to fall back to #reject(:nil?).
@@ -184,7 +184,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - mrkn: Returns another enumerator.
 - matz: Use case not very clear to me.
 
-## \[Feature [#15112](https://bugs.ruby-lang.org/issues/15112)\] Introduce the new singleton method STDERR.p (shevegen)
+## [[Feature #15112]](https://bugs.ruby-lang.org/issues/15112) Introduce the new singleton method STDERR.p (shevegen)
 
 
 - I am mostly curious what the ruby core team thinks about Kenta Murata's proposal; it probably will not take too much time away discussing it briefly, since the scope is small.
@@ -204,7 +204,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - akr: I think STDERR.p is acceptable but IO#p is too short.
 - mame: same feeling.
 
-## \[Feature [#11505](https://bugs.ruby-lang.org/issues/11505)\] Module#=== should call #kind\_of? on the object rather than rb\_obj\_is\_kind\_of which only searches the ancestor hierarchy (rafaelfranca)
+## [[Feature #11505]](https://bugs.ruby-lang.org/issues/11505) Module#=== should call #kind\_of? on the object rather than rb\_obj\_is\_kind\_of which only searches the ancestor hierarchy (rafaelfranca)
 
 
 - This would allow patterns as Decorator and Proxy to work with case statements.
@@ -250,7 +250,7 @@ when Array
 
 end
 
-## \[Feature [#14912](https://bugs.ruby-lang.org/issues/14912)\] Introduce pattern matching syntax (greggzst)
+## [[Feature #14912]](https://bugs.ruby-lang.org/issues/14912) Introduce pattern matching syntax (greggzst)
 
 
 - Many modern languages have introduced pattern matching. I used it in scala and found it very easy to utilize and understand especially in recursion. It makes extracting data easier as well.
@@ -258,7 +258,7 @@ end
 - shyouhei: Any updates?
 - mame: We should ask the status for @k-tsj
 
-## \[Feature [#15144](https://bugs.ruby-lang.org/issues/15144)\] Enumerator#chain (zverok)
+## [[Feature #15144]](https://bugs.ruby-lang.org/issues/15144) Enumerator#chain (zverok)
 
 
 - knu: Understand the needs. Name?
@@ -278,7 +278,7 @@ end
 
 ## I am not sure if it is appropriate, but I'd also be very glad to hear about some "stale" discussions. They were typically reacted on developer meetings as "in general, good proposal (but not sure when it would be implemented/not sure about the name)", or something like that, and I'd like to know maybe we should do something to push them further? List of tickets:
 
-## \[Feature [#14799](https://bugs.ruby-lang.org/issues/14799)\] Startless range: usefulness discussed, patch provided by mame (Yusuke Endoh), waits for Matz's decision (?)
+## [[Feature #14799]](https://bugs.ruby-lang.org/issues/14799) Startless range: usefulness discussed, patch provided by mame (Yusuke Endoh), waits for Matz's decision (?)
 
 
 - mame: I can have 2.5 without it.
@@ -286,18 +286,18 @@ end
 - mame: What about right after when?
 - matz: Mmm…. That’s difficult.
 
-## \[Feature [#14784](https://bugs.ruby-lang.org/issues/14784)\] Comparable#clamp accepting range: comment for akr (Akira Tanaka) about "needlessly big" proposal, I answered it, is it makes the proposal more likely to be accepted?
+## [[Feature #14784]](https://bugs.ruby-lang.org/issues/14784) Comparable#clamp accepting range: comment for akr (Akira Tanaka) about "needlessly big" proposal, I answered it, is it makes the proposal more likely to be accepted?
 
 
 - Nobody is against #clamp accepting ranges.  The issue did not seem requesting that, rather it was for one-sided clamp.
 
-## \[Feature [#6284](https://bugs.ruby-lang.org/issues/6284)\] Composition for procs: the last thing Matz has said is the operators are chosen (<< and \>>), and "We need more discussion if we would add combination methods to the Symbol class." Is there a chance proc composition would make it way in the 2.6?
+## [[Feature #6284]](https://bugs.ruby-lang.org/issues/6284) Composition for procs: the last thing Matz has said is the operators are chosen (<< and \>>), and "We need more discussion if we would add combination methods to the Symbol class." Is there a chance proc composition would make it way in the 2.6?
 
 
 - usa: This has been accepted. (at [https://bugs.ruby-lang.org/issues/6284#note-55](https://bugs.ruby-lang.org/issues/6284#note-55))
 - ko1: @nobu is assigned.  Waiting for him to implement.
 
-## \[Feature [#13581](https://bugs.ruby-lang.org/issues/13581)\] Syntax sugar for method reference. The last thing Matz have said is: ".: looks best to me (followed by :::). Let me consider it for a while." Are there any choices made? Could we expect this for 2.6?
+## [[Feature #13581]](https://bugs.ruby-lang.org/issues/13581) Syntax sugar for method reference. The last thing Matz have said is: ".: looks best to me (followed by :::). Let me consider it for a while." Are there any choices made? Could we expect this for 2.6?
 
 
 - matz: Honestly I still don’t find the right name.
@@ -308,14 +308,14 @@ end
 - ko1: It might matter you, but not for the OP.
 - shyouhei: Maybe.
 
-## \[Feature [#14781](https://bugs.ruby-lang.org/issues/14781)\] Enumerator#generate It seems like people feel cautious enthusiasm about it, but not sure about the name. What should be done here? Voting on the name? Providing the patch with some name, and then voting for the name?
+## [[Feature #14781]](https://bugs.ruby-lang.org/issues/14781) Enumerator#generate It seems like people feel cautious enthusiasm about it, but not sure about the name. What should be done here? Voting on the name? Providing the patch with some name, and then voting for the name?
 
 
 - Everybody is against #generate.
 - duerst: We don’t vote. Or in other words, we have only one person who votes. That’s Matz. Everybody else is very welcome to provide ideas, opinions,...
 - knu: There are many kinds of use cases mixed in one proposal, which need to be sorted out.  How many previous elements to look back, how to define an end of a sequence, etc.          I’ll come up with an alternative concrete API proposal.
 
-- \[Feature [#12490](https://bugs.ruby-lang.org/issues/12490)\] Remove warning on shadowing block params
+- [[Feature #12490]](https://bugs.ruby-lang.org/issues/12490) Remove warning on shadowing block params
 
 - mame: It was introduced when backward incompatibility was involved, but it is no longer a problem, so why not remove it?
 - knu: It’s painful when you have to change this just to silence the warning: user = users.find { |user| … }

--- a/2018/DevMeeting-2018-11-22.md
+++ b/2018/DevMeeting-2018-11-22.md
@@ -125,7 +125,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 - OK but 12/12 is 13:30-.
 
-## \[Feature [#15144](https://bugs.ruby-lang.org/issues/15144)\] Enumerator#chain (zverok)
+## [[Feature #15144]](https://bugs.ruby-lang.org/issues/15144) Enumerator#chain (zverok)
 
 
 - A.k.a. Enumerator#+
@@ -147,7 +147,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Knu: We need a concrete specification first as to when a BOM is written.
 - Ko1: file a new ticket for this.
 
-## \[Feature [#15230](https://bugs.ruby-lang.org/issues/15230)\] RubyVM.resolve\_feature\_path (mame)
+## [[Feature #15230]](https://bugs.ruby-lang.org/issues/15230) RubyVM.resolve\_feature\_path (mame)
 
 
 - I'd like this feature to investigate what will be loaded by require(feature).
@@ -159,7 +159,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Usa: I think it’s a good feature in general; the proposal seems like a rough cut though.
 - Matz: I have no strong objection.
 
-## \[Feature [#15231](https://bugs.ruby-lang.org/issues/15231)\] Remove Object#=~ (mame)
+## [[Feature #15231]](https://bugs.ruby-lang.org/issues/15231) Remove Object#=~ (mame)
 
 
 - The method looks useless, and made a trouble at least for me. I'd like to hear opinions from other committers.
@@ -172,14 +172,14 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Knu: people might have their own =~, so deleting !~ affect them.
 - Akira: it seems sequel defines =~ and not for !~
 
-## \[Feature [#11689](https://bugs.ruby-lang.org/issues/11689)\] Add methods allow us to get visibility from Method and UnboundMethod object. (yui-knk)
+## [[Feature #11689]](https://bugs.ruby-lang.org/issues/11689) Add methods allow us to get visibility from Method and UnboundMethod object. (yui-knk)
 
 
 - I want to introduce this feature to help meta programming. I'd like to hear opinions from other committers.
 
 - Matz: the concept is not if a method is “visible” or not, but if a method is “callable” or not.  So I feel a bit NG to call it visibility.
 
-## \[Feature [#15286](https://bugs.ruby-lang.org/issues/15286)\] Proposal: Add Kernel.#expand(\*args) (aycabta)
+## [[Feature #15286]](https://bugs.ruby-lang.org/issues/15286) Proposal: Add Kernel.#expand(\*args) (aycabta)
 
 
 - Matz: I don’t like the name.
@@ -190,19 +190,19 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Mrkn: { a: a } is much shorter than binding.expand(a) …
 - Naruse: tell us a more realistic use-case.
 
-## \[Bug [#15285](https://bugs.ruby-lang.org/issues/15285)\] lambda return behavior regression from [#14639](https://bugs.ruby-lang.org/issues/14639) (nobu)
+## [[Bug #15285]](https://bugs.ruby-lang.org/issues/15285) lambda return behavior regression from [#14639](https://bugs.ruby-lang.org/issues/14639) (nobu)
 
-## \[Feature [#15289](https://bugs.ruby-lang.org/issues/15289)\] Accept "target" keyword on TracePoint#enable (ko1)
+## [[Feature #15289]](https://bugs.ruby-lang.org/issues/15289) Accept "target" keyword on TracePoint#enable (ko1)
 
 
 - Matz: OK, do it yourself.
 
-## \[Feature [#15287](https://bugs.ruby-lang.org/issues/15287)\] New TracePoint events to support loading features (ko1)
+## [[Feature #15287]](https://bugs.ruby-lang.org/issues/15287) New TracePoint events to support loading features (ko1)
 
 
 - Matz: Ok except naming “loaded”. Koichi should name good name.
 
-## \[Bug [#6087](https://bugs.ruby-lang.org/issues/6087)\] How should inherited methods deal with return values of their own subclass? (mame)
+## [[Bug #6087]](https://bugs.ruby-lang.org/issues/6087) How should inherited methods deal with return values of their own subclass? (mame)
 
 
 - 6 years ago, matz decided that class A < Array; end; A.new.flatten.class #=> A in 2.X, Array in 3.0. Just confirm: has the decision been still unchanged?
@@ -212,7 +212,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Nobu: Methods defined by Enumerable all return an array.
 - Knu: Making all Array methods return an Array object would make it harder to define your own array-like container by subclassing Array.
 
-## \[Feature [#15317](https://bugs.ruby-lang.org/issues/15317)\] How to deal with obsolete property values in Unicode 11.0.0 (duerst)
+## [[Feature #15317]](https://bugs.ruby-lang.org/issues/15317) How to deal with obsolete property values in Unicode 11.0.0 (duerst)
 
 
 - A clear idea on this is needed to upgrade to Unicode 11.0.0.
@@ -221,30 +221,30 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Naruse: program error is preferred here because we can be aware of such breakage before actually deploying the code.
 - Mame: what about issuing a warning instead?
 
-## \[Feature [#13890](https://bugs.ruby-lang.org/issues/13890)\] Allow a regexp as an argument to 'count', to count more interesting things than single characters (duerst)
+## [[Feature #13890]](https://bugs.ruby-lang.org/issues/13890) Allow a regexp as an argument to 'count', to count more interesting things than single characters (duerst)
 
 
 - I find this missing regularly, and writing it by hand in Ruby is clumsy, so addition would be valuable.
 
 
-## \[Feature [#12698](https://bugs.ruby-lang.org/issues/12698)\] Method to delete a substring by regex match (duerst)
+## [[Feature #12698]](https://bugs.ruby-lang.org/issues/12698) Method to delete a substring by regex match (duerst)
 
 
 ## From non-attendees
 
-## \[Feature [#15220](https://bugs.ruby-lang.org/issues/15220)\] Adding OpenSSL 1.1.1 on Travis CI gcc-8 case (jaruga)
+## [[Feature #15220]](https://bugs.ruby-lang.org/issues/15220) Adding OpenSSL 1.1.1 on Travis CI gcc-8 case (jaruga)
 
 
 - To detect an issue for the latest OpenSSL early and guarantee a Ruby version supporting a OpenSSL version.
 
 - Shyouhei: I had already added one.
 
-## \[Feature [#15301](https://bugs.ruby-lang.org/issues/15301)\] Symbol#call, returning method bound with arguments (zverok)
+## [[Feature #15301]](https://bugs.ruby-lang.org/issues/15301) Symbol#call, returning method bound with arguments (zverok)
 
 
 - Matz: I’m very faintly against it.
 
-## \[Feature [#15302](https://bugs.ruby-lang.org/issues/15302)\] Proc#with and Proc#by, for partial function application and currying (Ritchie Buitre)
+## [[Feature #15302]](https://bugs.ruby-lang.org/issues/15302) Proc#with and Proc#by, for partial function application and currying (Ritchie Buitre)
 
 
 - Convenient methods for functional programming.
@@ -254,7 +254,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Ko1: Is the naming only concern?
 - Matz: Not against the feature but I feel the notation is not right.
 
-## \[Bug [#14968](https://bugs.ruby-lang.org/issues/14968)\] make all pipes and sockets non-blocking by default (normalperson)
+## [[Bug #14968]](https://bugs.ruby-lang.org/issues/14968) make all pipes and sockets non-blocking by default (normalperson)
 
 
 - Shyouhei: AFAIK there is a problem on Windows.
@@ -269,12 +269,12 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Matz: maybe we should try it and fix or back out as necessary?
 - Naruse: so Eric should commit it today.
 
-## \[Feature [#13618](https://bugs.ruby-lang.org/issues/13618)\] Thread::Light for 2.6 [ruby-core:89900](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/89900)
+## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) Thread::Light for 2.6 [ruby-core:89900](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/89900)
 
 
 - Matz: will respond.
 
-## \[Feature [#10548](https://bugs.ruby-lang.org/issues/10548)\] remove callcc (Callcc is now going obsolete. Please use Fiber.) (ioquatix)
+## [[Feature #10548]](https://bugs.ruby-lang.org/issues/10548) remove callcc (Callcc is now going obsolete. Please use Fiber.) (ioquatix)
 
 
 - It's unofficially deprecated, unsupported in most implementations of Ruby, and not used very much. Do you think it's a good idea to drop support by 3.0?
@@ -285,7 +285,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Usa: for 3x3?
 - Matz: may not make it 3x faster.
 
-## \[Feature [#15327](https://bugs.ruby-lang.org/issues/15327)\] Proposal: Enable refinements to #respond\_to? (osyo)
+## [[Feature #15327]](https://bugs.ruby-lang.org/issues/15327) Proposal: Enable refinements to #respond\_to? (osyo)
 
 
 - Matz: Mmm.
@@ -300,12 +300,12 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - (everybody started thinking...)
 - Ko1: OK, let’s not think about it for a while.
 
-## \[Feature [#15326](https://bugs.ruby-lang.org/issues/15326)\] Proposal: Enable refinements to #public\_send (osyo)
+## [[Feature #15326]](https://bugs.ruby-lang.org/issues/15326) Proposal: Enable refinements to #public\_send (osyo)
 
 
 - Matz: this one makes sense. Accepted.
 
-## \[Feature [#15114](https://bugs.ruby-lang.org/issues/15114)\] Symbol#to\_proc does not work with refinements? (osyo)
+## [[Feature #15114]](https://bugs.ruby-lang.org/issues/15114) Symbol#to\_proc does not work with refinements? (osyo)
 
 
 - I want to more refinements!
@@ -313,7 +313,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Matz: sounds like a bug?
 - assign nobu
 
-## \[Feature [#15330](https://bugs.ruby-lang.org/issues/15330)\] Proposal: autoload\_relative (marcandre)
+## [[Feature #15330]](https://bugs.ruby-lang.org/issues/15330) Proposal: autoload\_relative (marcandre)
 
 
 - This feature is actually more useful than autoload and should be added to 2.6

--- a/2018/DevMeeting-2018-12-12.md
+++ b/2018/DevMeeting-2018-12-12.md
@@ -89,7 +89,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From Attendees
 
-- \[Bug [#15303](https://bugs.ruby-lang.org/issues/15303)\] Return tracepoint doesn't fire when tailcall optimization is applied (ko1)
+- [[Bug #15303]](https://bugs.ruby-lang.org/issues/15303) Return tracepoint doesn't fire when tailcall optimization is applied (ko1)
 
 - tailcall skips return event and it breaks a debugger's logic. there are several ideas, and we need to introduce a solution for ruby 2.6.
 
@@ -101,7 +101,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 - \-> (4)
 
-- \[Feature [#15287](https://bugs.ruby-lang.org/issues/15287)\] New TracePoint events to support loading features (ko1)
+- [[Feature #15287]](https://bugs.ruby-lang.org/issues/15287) New TracePoint events to support loading features (ko1)
 
 - Ruby 2.6
 - I already introduced script\_compiled TracePoint event. We need to decide related methods.
@@ -135,40 +135,40 @@ foo("str" => 1, :sym => 2)
 
 ## Non-attendees
 
-- \[Feature [#15230](https://bugs.ruby-lang.org/issues/15230)\] RubyVM.resolve\_feature\_path
+- [[Feature #15230]](https://bugs.ruby-lang.org/issues/15230) RubyVM.resolve\_feature\_path
 
 - 2.6 issue
 - Mame: no fix on 2.6. Consider on next version.
 
-- \[Feature [#13581](https://bugs.ruby-lang.org/issues/13581)\] Syntax sugar for method reference
+- [[Feature #13581]](https://bugs.ruby-lang.org/issues/13581) Syntax sugar for method reference
 
 - 2.7 or later
 - knu: Introducing “…” (as in Lua) would allow for writing this way: ary.each { puts(...) }
 - Matz: Allowing omission of “self” sounds like a bad idea because that makes each(&:puts) and each(&.:puts) look very similar but act so differently.
 
-- \[Feature [#10771](https://bugs.ruby-lang.org/issues/10771)\] An easy way to get the source location of a constant
+- [[Feature #10771]](https://bugs.ruby-lang.org/issues/10771) An easy way to get the source location of a constant
 
 - 2.7 or later
 - Matz: OK, but wait for 2.7.
 
-- \[Feature [#15373](https://bugs.ruby-lang.org/issues/15373)\] Proposal: Enable refinements to #method and #instance\_method
+- [[Feature #15373]](https://bugs.ruby-lang.org/issues/15373) Proposal: Enable refinements to #method and #instance\_method
 
 - 2.7 or later
 - Matz: ok to introduce.
 
-- \[Feature [#15374](https://bugs.ruby-lang.org/issues/15374)\] Proposal: Enable refinements to #method\_missing
+- [[Feature #15374]](https://bugs.ruby-lang.org/issues/15374) Proposal: Enable refinements to #method\_missing
 
 - 2.7 or later
 - Matz: let me think about it for a while.
 
-- \[Feature [#15007](https://bugs.ruby-lang.org/issues/15007)\] Proposal: Introduce support for cold function attributes (clang and GCC)
+- [[Feature #15007]](https://bugs.ruby-lang.org/issues/15007) Proposal: Introduce support for cold function attributes (clang and GCC)
 
 - reduced scope PR [https://github.com/ruby/ruby/pull/2005](https://github.com/ruby/ruby/pull/2005) (rb\_memerror, rb\_bug, rb\_warn)
 - Already  merged.
 
-- \[Bug [#15394](https://bugs.ruby-lang.org/issues/15394)\] Ruby adds unexpected HTTP header value when using symbol key
+- [[Bug #15394]](https://bugs.ruby-lang.org/issues/15394) Ruby adds unexpected HTTP header value when using symbol key
 
 - This is a small change I think, but could make codes less buggy
 - Already solved.
 
-- \[Feature [#15066](https://bugs.ruby-lang.org/issues/15066)\] Documentation and providing better API for accessing Complex numbers functions in C extensions
+- [[Feature #15066]](https://bugs.ruby-lang.org/issues/15066) Documentation and providing better API for accessing Complex numbers functions in C extensions

--- a/2019/DevMeeting-2019-01-10.md
+++ b/2019/DevMeeting-2019-01-10.md
@@ -80,7 +80,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From Attendees
 
-- \[Feature [#6012](https://bugs.ruby-lang.org/issues/6012)\] Proc#source\_location (ko1)
+- [[Feature #6012]](https://bugs.ruby-lang.org/issues/6012) Proc#source\_location (ko1)
 
 - nobu: this breaks compatibility
 - ko1: how about specifying the new behaviour by some optional parameter?
@@ -91,7 +91,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - usa: if you really concern to keep compatibility, you should propose this feature as new method.
 - shyouhei: this feature seems not yet mature.
 
-- Frozen string literal \[Feature [#11473](https://bugs.ruby-lang.org/issues/11473)\]
+- Frozen string literal [[Feature #11473]](https://bugs.ruby-lang.org/issues/11473)
 
 - Matz: give up on Ruby 3.0. Maybe far future.
 - Matz: Maybe we should provide our coding style to recommend style and obsolete bad style by something like rubocop.
@@ -119,72 +119,72 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Akr: “lambda without block” has been already warned since 2003 (ruby-1.8.0), How about changing it to an exception?
 - Matz: accepted.
 
-- \[Bug [#15404](https://bugs.ruby-lang.org/issues/15404)\] Endless range has inconsistent chaining behaviour (mame)
+- [[Bug #15404]](https://bugs.ruby-lang.org/issues/15404) Endless range has inconsistent chaining behaviour (mame)
 
 - Can we prohibit (1.. ..1) and (1..1)..1 as a SyntaxError?
 - matz: ok, prohibit
 - usa: please add test cases into test\_syntax.rb
 
-- \[Feature [#14799](https://bugs.ruby-lang.org/issues/14799)\] Startless range (aycabta)
+- [[Feature #14799]](https://bugs.ruby-lang.org/issues/14799) Startless range (aycabta)
 
 - Matz: try it.
 
-- \[Bug [#15460](https://bugs.ruby-lang.org/issues/15460)\] Behaviour of String#setbyte changed (shyouhei)
+- [[Bug #15460]](https://bugs.ruby-lang.org/issues/15460) Behaviour of String#setbyte changed (shyouhei)
 
 - What is the expected / desired way to fix this?
 
-- \[Bug [#7300](https://bugs.ruby-lang.org/issues/7300)\] Hash#\[\] の挙動が 1.9.3 と異なっている (mame)
+- [[Bug #7300]](https://bugs.ruby-lang.org/issues/7300) Hash#\[\] の挙動が 1.9.3 と異なっている (mame)
 
 - I think we can remove the compatibility layer for 1.9: Hash\[\[nil\]\] #=> {}
 
-- \[Misc [#15347](https://bugs.ruby-lang.org/issues/15347)\] Require C99 (k0kubun)
-- \[Feature [#15445](https://bugs.ruby-lang.org/issues/15445)\] Reject '.123' in Float() method (mrkn)
+- [[Misc #15347]](https://bugs.ruby-lang.org/issues/15347) Require C99 (k0kubun)
+- [[Feature #15445]](https://bugs.ruby-lang.org/issues/15445) Reject '.123' in Float() method (mrkn)
 
 - Matz: I’d like to keep the behavior.  Rather, I’d like to allow “123.” too.
 
-- \[Bug [#15500](https://bugs.ruby-lang.org/issues/15500)\] Behavior of require method in 2.5 is different from 2.4 and 2.6 (mrkn)
+- [[Bug #15500]](https://bugs.ruby-lang.org/issues/15500) Behavior of require method in 2.5 is different from 2.4 and 2.6 (mrkn)
 
 - usa: It seems bug.  let’s ask hsbt-san
 
-- \[Feature [#15477](https://bugs.ruby-lang.org/issues/15477)\] Proc#arity returns -1 for composed lambda Procs of known arguments
+- [[Feature #15477]](https://bugs.ruby-lang.org/issues/15477) Proc#arity returns -1 for composed lambda Procs of known arguments
 
 - matz: ok
 
 ## Non-attendees
 
-- \[Feature [#14444](https://bugs.ruby-lang.org/issues/14444)\] MatchData: alias for #\[\]
+- [[Feature #14444]](https://bugs.ruby-lang.org/issues/14444) MatchData: alias for #\[\]
 
 - Naruse: \`next\_page = response.dig('meta', 'pagination', 'next')&.slice(/&page=(\\d+)/, 1)\` is better
 
-- \[Feature [#14784](https://bugs.ruby-lang.org/issues/14784)\] Comparable#clamp with a range
+- [[Feature #14784]](https://bugs.ruby-lang.org/issues/14784) Comparable#clamp with a range
 
 - usa: the reporter seems have no interest about startless/endless clamp.  But we recognize that we can’t approve range as parameter before accepting startless/endless clamp.
 - akr: we have to consider many corner cases if accepting Range.  Request for feedback.
 
-- \[Feature [#14145](https://bugs.ruby-lang.org/issues/14145)\] Better Method#inspect
+- [[Feature #14145]](https://bugs.ruby-lang.org/issues/14145) Better Method#inspect
 
 - usa: a patch is welcome.  We might need to discuss the implementation detail, though.
 - Matz: the proposal is accepted
 - Naruse: just an idea, ArgumentError which is raised by arity check should also show such signature.
 
-- \[Bug [#15428](https://bugs.ruby-lang.org/issues/15428)\] Refactor Proc#>> and #<< (it regards the same problem as [#15483](https://bugs.ruby-lang.org/issues/15483) above, but approaches it from a different point of view)
+- [[Bug #15428]](https://bugs.ruby-lang.org/issues/15428) Refactor Proc#>> and #<< (it regards the same problem as [#15483](https://bugs.ruby-lang.org/issues/15483) above, but approaches it from a different point of view)
 
 - Mame: Use a block.  You then want syntactic sugar for passing an argument, and then for partial application, blah blah blah.
 - knu: We should not add fancy new features around procs and symbols if the real problem is that block syntax is not good enough, like \`|x|\` is always necessary. (See above for the default block parameter syntax)
 - Matz: raise an error when the argument does not respond to :call
 
-- \[Misc [#15486](https://bugs.ruby-lang.org/issues/15486)\] Default gems README.md
+- [[Misc #15486]](https://bugs.ruby-lang.org/issues/15486) Default gems README.md
 
-- \[Misc [#15487](https://bugs.ruby-lang.org/issues/15487)\] Clarify default gems maintenance policy
-- \[Feature [#15373](https://bugs.ruby-lang.org/issues/15373)\] Proposal: Enable refinements to #method and #instance\_method
+- [[Misc #15487]](https://bugs.ruby-lang.org/issues/15487) Clarify default gems maintenance policy
+- [[Feature #15373]](https://bugs.ruby-lang.org/issues/15373) Proposal: Enable refinements to #method and #instance\_method
 
 - matz: go ahead
 
-- \[Feature [#15374](https://bugs.ruby-lang.org/issues/15374)\] Proposal: Enable refinements to #method\_missing
+- [[Feature #15374]](https://bugs.ruby-lang.org/issues/15374) Proposal: Enable refinements to #method\_missing
 
 - matz: wait a month
 
-- \[Bug [#15416](https://bugs.ruby-lang.org/issues/15416)\] 配列リテラル内の引数を伴う括弧なしのメソッド呼び出しで syntax error
+- [[Bug #15416]](https://bugs.ruby-lang.org/issues/15416) 配列リテラル内の引数を伴う括弧なしのメソッド呼び出しで syntax error
 
 - History:
 
@@ -198,21 +198,21 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - f.(Math.sqrt 2)
 - f\[Math.sqrt 2\]
 
-- \[Bug [#2250](https://bugs.ruby-lang.org/issues/2250)\] IO::for\_fd() objects' finalization dangerously closes underlying fds (eregon)
+- [[Bug #2250]](https://bugs.ruby-lang.org/issues/2250) IO::for\_fd() objects' finalization dangerously closes underlying fds (eregon)
 
 - The current behavior is dangerous and has caused many spurious test/spec failures which are hard to find and debug. I plan to submit a patch, but I'd like opinions regarding compatibility.
 
-- \[Bug [#15488](https://bugs.ruby-lang.org/issues/15488)\] const\_defined?("File::NULL") の挙動
+- [[Bug #15488]](https://bugs.ruby-lang.org/issues/15488) const\_defined?("File::NULL") の挙動
 
 - What is the expected behavior?
 - matz: ok, try to return “true” in this case. if we find something wrong, will give up.
 
-- \[Feature [#15456](https://bugs.ruby-lang.org/issues/15456)\] Adopt some kind of consistent versioning mechanism
+- [[Feature #15456]](https://bugs.ruby-lang.org/issues/15456) Adopt some kind of consistent versioning mechanism
 
 - More uniformity within the ecosystem would be nice.
 - Naruse replied it.
 
-- \[Feature [#11473](https://bugs.ruby-lang.org/issues/11473)\] Immutable String literal in Ruby 3
+- [[Feature #11473]](https://bugs.ruby-lang.org/issues/11473) Immutable String literal in Ruby 3
 
 - Mame: As I recall, matz said that this has been cancelled at the old developers' meeting. I'd like to confirm.
 

--- a/2019/DevMeeting-2019-02-07.md
+++ b/2019/DevMeeting-2019-02-07.md
@@ -96,40 +96,40 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 
 ## Non-attendees
 
-- \[Feature [#6470](https://bugs.ruby-lang.org/issues/6470)\] Make attr\_accessor return the list of generated method (eregon)
+- [[Feature #6470]](https://bugs.ruby-lang.org/issues/6470) Make attr\_accessor return the list of generated method (eregon)
 
 - What’s volatile?  No one understand.
 - Matz: if volatile is needed, it would be better to define volatile\_attr\_reader etc.
 
-- \[Bug [#14353](https://bugs.ruby-lang.org/issues/14353)\] $SAFE should stay at least thread-local for compatibility (eregon)
+- [[Bug #14353]](https://bugs.ruby-lang.org/issues/14353) $SAFE should stay at least thread-local for compatibility (eregon)
 
 - I would like matz's opinion on this. It seems the compatibility risks and debugging problems is not worth making $SAFE global, unless there is a good reason to be global? Should there still be $SAFE checks at all, for e.g., tainted Strings?
 - Naruse: $SAFE should be removed
 - Matz: Make $SAFE no effect in 2.7 or 3.0
 
-- \[Feature [#5653](https://bugs.ruby-lang.org/issues/5653)\] "I strongly discourage the use of autoload in any standard libraries" (eregon)
+- [[Feature #5653]](https://bugs.ruby-lang.org/issues/5653) "I strongly discourage the use of autoload in any standard libraries" (eregon)
 
 - It would be useful to reach a decision for this. What does it gain, and at what cost for compatibility? Is there going to be a replacement?
 - (investigated the circumstance and history of Rails…)
 - Matz: keep autoload (for a while)? Seems impossible to remove it now.  May be removed in 4.0 :-)
 
-- \[Feature [#14344](https://bugs.ruby-lang.org/issues/14344)\] refine at class level (kddeisz)
+- [[Feature #14344]](https://bugs.ruby-lang.org/issues/14344) refine at class level (kddeisz)
 
 - Shorter refinement syntax proposed based on common use cases. Proposed either refine\_class or using blocks for shorthand. What do you think?
 - Matz: I understand the needs, but I don’t like the style.  Please propose other styles.
 
-- \[Feature [#14680](https://bugs.ruby-lang.org/issues/14680)\] Adding +@ and -@ to hash and array (kddeisz)
+- [[Feature #14680]](https://bugs.ruby-lang.org/issues/14680) Adding +@ and -@ to hash and array (kddeisz)
 
 - Since we have -@ and +@ for strings and it's very useful I'd like to propose adding the same API to hash and array.
 - Urabe: It is arguable that -@ reads better than .freeze
 - Matz: I don’t see the strong reason to add
 
-- \[Feature [#15567](https://bugs.ruby-lang.org/issues/15567)\] Allow ensure to match specific situations. (ioquatix)
+- [[Feature #15567]](https://bugs.ruby-lang.org/issues/15567) Allow ensure to match specific situations. (ioquatix)
 
 - Matz: wait real-world use case
 - Mame: I don’t want to see a strange API that depends the difference between throw and break.
 
-- \[Feature [#15560](https://bugs.ruby-lang.org/issues/15560)\] Add support for read/write offsets. (ioquatix)
+- [[Feature #15560]](https://bugs.ruby-lang.org/issues/15560) Add support for read/write offsets. (ioquatix)
 
 - Can we get consensus on whether we can add this?
 - Doesn’t the current Ruby have this feature? … Check later.
@@ -138,35 +138,35 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 - Mrkn: How about a view (or slice) of a string?
 - Matz: Let’s discuss it the next meeting.
 
-- \[Feature [#10098](https://bugs.ruby-lang.org/issues/10098)\] Timing-safe string comparison for OpenSSL::HMAC (bdewater)
+- [[Feature #10098]](https://bugs.ruby-lang.org/issues/10098) Timing-safe string comparison for OpenSSL::HMAC (bdewater)
 
 - The feature is done (the title is old, it will be implemented in String) but blocked on picking a method name. I would like to ask for opinions so this can move forward.
 -  ???
 
-- \[Feature [#15331](https://bugs.ruby-lang.org/issues/15331)\] \[PATCH\] Faster hashing for short string literals
+- [[Feature #15331]](https://bugs.ruby-lang.org/issues/15331) \[PATCH\] Faster hashing for short string literals
 
 - Looking for feedback on this patch.
 - Nobu: I tested, but cannot confirm the speed up
 - Matz: Umm.
 
-- \[Feature [#15374](https://bugs.ruby-lang.org/issues/15374)\] Proposal: Enable refinements to #method\_missing
+- [[Feature #15374]](https://bugs.ruby-lang.org/issues/15374) Proposal: Enable refinements to #method\_missing
 
 - waited one month.
 - Matz: will reject.
 
-- \[Feature [#14609](https://bugs.ruby-lang.org/issues/14609)\] Kernel#p without args shows the receiver (osyo)
+- [[Feature #14609]](https://bugs.ruby-lang.org/issues/14609) Kernel#p without args shows the receiver (osyo)
 
 - I feel this feature is very useful and some people say :+1: so let discuss about this feature.
 - Need to discuss when we have ko1.  He left, so discuss it at the next meeting.
 
-- \[Feature [#15588](https://bugs.ruby-lang.org/issues/15588)\] String#each\_chunk and #chunks
+- [[Feature #15588]](https://bugs.ruby-lang.org/issues/15588) String#each\_chunk and #chunks
 
 - Looking for feedback on this patch.
 - Matz: use case.
 
 ## From Attendees
 
-- \[Feature [#15554](https://bugs.ruby-lang.org/issues/15554)\] warn/error passing a block to a method which never use a block (ko1)
+- [[Feature #15554]](https://bugs.ruby-lang.org/issues/15554) warn/error passing a block to a method which never use a block (ko1)
 
 - I want to share the ticket and survey on some product.
 - Ko1: It requires many fixes, but it actually found some real bugs.
@@ -178,24 +178,24 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 - knu: Autoloading itself is a feature that you can't miss in application development.  Especially in Rails, it takes a very long time to load all ActiveRecord model files eagerly because each one of them accesses the database to load the table schema, and it'd be painful to have to load everything just to run, for example, a single unit test.
 - Matz: OK, I give up. Autoload will stay, at least until before Ruby 4.x.
 
-- \[Feature [#15581](https://bugs.ruby-lang.org/issues/15581)\] Split tool/\* files to tool and script directories
+- [[Feature #15581]](https://bugs.ruby-lang.org/issues/15581) Split tool/\* files to tool and script directories
 
 - What's a concern about this?
 
--  \[Feature [#4475](https://bugs.ruby-lang.org/issues/4475)\] default variable name for parameter (aycabta)
+-  [[Feature #4475]](https://bugs.ruby-lang.org/issues/4475) default variable name for parameter (aycabta)
 
 - In [#15483](https://bugs.ruby-lang.org/issues/15483), matz said "I feel the expression ary.map(&(:to\_i << :chr)) is far less readable than ary.map{|x|x.to\_i.chr}.", and "And this can lead to the default block parameter like it."
 - nobu is wriing a patch for \`@1\`. so, let’s try it.
 
-- \[Feature [#5632](https://bugs.ruby-lang.org/issues/5632)\] Attempt to open included class shades it instead. (mame)
+- [[Feature #5632]](https://bugs.ruby-lang.org/issues/5632) Attempt to open included class shades it instead. (mame)
 
 - Matz: sorry, it was not mame’s task. reject it.
 
-- \[Feature [#11076](https://bugs.ruby-lang.org/issues/11076)\] Enumerable method count\_by
+- [[Feature #11076]](https://bugs.ruby-lang.org/issues/11076) Enumerable method count\_by
 
 - Matz: ok, introduce \`tally\`.
 
-- \[Feature [#15573](https://bugs.ruby-lang.org/issues/15573)\] Permit zero step in Numeric#step and Range#step
+- [[Feature #15573]](https://bugs.ruby-lang.org/issues/15573) Permit zero step in Numeric#step and Range#step
 
 \>> (10 .. 0).step(-1).to\_a
 

--- a/2019/DevMeeting-2019-03-11.md
+++ b/2019/DevMeeting-2019-03-11.md
@@ -87,7 +87,7 @@ done
 
 ## Carry-over from previous meeting(s)
 
-- \[Feature [#14609](https://bugs.ruby-lang.org/issues/14609)\] Kernel#p without args shows the receiver (aycabta)
+- [[Feature #14609]](https://bugs.ruby-lang.org/issues/14609) Kernel#p without args shows the receiver (aycabta)
 
 - the name of the method is not determined yet.
 
@@ -97,19 +97,19 @@ done
 
 ## Non-attendees
 
-- \[Feature [#14799](https://bugs.ruby-lang.org/issues/14799)\] Startless range
+- [[Feature #14799]](https://bugs.ruby-lang.org/issues/14799) Startless range
 
 - mame: I’ve forgotten to commit.  just a moment.
 
-- \[Bug [#15620](https://bugs.ruby-lang.org/issues/15620)\] Block argument usage affects lambda semantic
+- [[Bug #15620]](https://bugs.ruby-lang.org/issues/15620) Block argument usage affects lambda semantic
 
 - nobu: yes, it’s a bug.
 
-- \[Misc [#15617](https://bugs.ruby-lang.org/issues/15617)\] Release 2.5.4? (blowmage)
+- [[Misc #15617]](https://bugs.ruby-lang.org/issues/15617) Release 2.5.4? (blowmage)
 
 - usa: nagachika-san is planning to release in this month.
 
-- \[Feature [#15323](https://bugs.ruby-lang.org/issues/15323)\] Proposal: Add Enumerable#filter\_map
+- [[Feature #15323]](https://bugs.ruby-lang.org/issues/15323) Proposal: Add Enumerable#filter\_map
 
 - naruse: Sequel uses \`select\_filter\` as another meaning
 - usa: also need \`select\_map\` as alias?
@@ -119,7 +119,7 @@ done
 - matz: filter\_map is not simply combination of filter and map.  so mame’s concern is needless fears.
 - matz: ok, accepted \`filter\_map\`.
 
-- \[Feature [#14145](https://bugs.ruby-lang.org/issues/14145)\] Proposal: Better Method#inspect
+- [[Feature #14145]](https://bugs.ruby-lang.org/issues/14145) Proposal: Better Method#inspect
 
 - ko1: I’m against to show the name of parameters.  we only need line no.  doesn’t it?
 - matz: ask the original author.
@@ -131,7 +131,7 @@ done
 - naruse: path name is already long.
 - ko1: ah, may be so.  but source location is useful than parameters.
 
-- \[Feature [#15653](https://bugs.ruby-lang.org/issues/15653)\] Proposal: Add Time#floor
+- [[Feature #15653]](https://bugs.ruby-lang.org/issues/15653) Proposal: Add Time#floor
 
 - naruse: isn’t it \`trunc\`?  see SQL.
 - akr: truncate means rounding to zero.  conceptually, zero is the first time, but we often assume the zero time as UNIX epoch.
@@ -141,43 +141,43 @@ done
 
 ## From Attendees
 
-- \[Misc [#15615](https://bugs.ruby-lang.org/issues/15615)\] File.birthtimeがLinux環境で有効なファイル作成時刻を得られなかった場合の挙動について
+- [[Misc #15615]](https://bugs.ruby-lang.org/issues/15615) File.birthtimeがLinux環境で有効なファイル作成時刻を得られなかった場合の挙動について
 
 - should raises \`NotImplementedError\` both \`File.birthtime\` and \`File::Stat#birthtime\` if birthtime is not available.
 - akr: \`respond\_to?\` should always return \`true\`.
 - akr: we also have to implement \`birthtime\` to \`Pathname\`, don’t it?
 - usa: yes
 
-- \[Feature [#15195](https://bugs.ruby-lang.org/issues/15195)\] How to deal with new Japanese era
+- [[Feature #15195]](https://bugs.ruby-lang.org/issues/15195) How to deal with new Japanese era
 
 - martin: just a reminder.
 - naruse: I’m planning to release 2.6.2 sooner.  and 2.6.3 will be released at Apr.
 - martin: ok
 
-- \[Bug [#15598](https://bugs.ruby-lang.org/issues/15598)\] Deadlock on mutual reference of autoloaded constants
+- [[Bug #15598]](https://bugs.ruby-lang.org/issues/15598) Deadlock on mutual reference of autoloaded constants
 
 - (see next)
 
-- \[Bug [#15599](https://bugs.ruby-lang.org/issues/15599)\] Mixing autoload and require causes deadlock and incomplete definition.
+- [[Bug #15599]](https://bugs.ruby-lang.org/issues/15599) Mixing autoload and require causes deadlock and incomplete definition.
 
 - akr: IMO, these are bugs.  I propose that autoload should use one global lock instead of locks per constants.
 
-- \[Feature [#15618](https://bugs.ruby-lang.org/issues/15618)\] Implement Enumerator::Yielder#to\_proc
+- [[Feature #15618]](https://bugs.ruby-lang.org/issues/15618) Implement Enumerator::Yielder#to\_proc
 
 - matz: ok, accepted.
 
-- \[Feature [#15553](https://bugs.ruby-lang.org/issues/15553)\] Addrinfo.getaddrinfo supports timeout
+- [[Feature #15553]](https://bugs.ruby-lang.org/issues/15553) Addrinfo.getaddrinfo supports timeout
 
 - akr: this implementation is not acceptable, but the feature is ok.
 - glass\_saga: I see.  BTW, is using Resolv acceptable?
 - akr: yes.
 - Even if it doesn’t support getaddrinfo with timeout (non glibc), it should ignore because we want to use the same code on macOS and Linux.
 
-- \[Bug [#15652](https://bugs.ruby-lang.org/issues/15652)\] Profiler\_\_ is not working correctly (ruby 2.6)
+- [[Bug #15652]](https://bugs.ruby-lang.org/issues/15652) Profiler\_\_ is not working correctly (ruby 2.6)
 
 - usa, naruse: kill it
 
-- \[Feature [#15626](https://bugs.ruby-lang.org/issues/15626)\] Manual Compaction for MRI’s GC (\`GC.compact\`)
+- [[Feature #15626]](https://bugs.ruby-lang.org/issues/15626) Manual Compaction for MRI’s GC (\`GC.compact\`)
 
 - matz: current status?
 - ko1: I think this is mergeable.  But one incompatibility exists.   if an C extension keeps pointers without mark (expecting to mark via Ruby code), GC cannot change the pointers.


### PR DESCRIPTION
## Summary

Older meeting logs (2014-2019) use a format where only the ticket number is a link:

```markdown
\[Feature [#12345](https://bugs.ruby-lang.org/issues/12345)\]
```

Modern logs (2019+) wrap the entire ticket reference as the link text:

```markdown
[[Feature #12345]](https://bugs.ruby-lang.org/issues/12345)
```

## Changes

Normalize all ticket references to the modern format:

```diff
-\[Feature [#12345](https://bugs.ruby-lang.org/issues/12345)\]
+[[Feature #12345]](https://bugs.ruby-lang.org/issues/12345)
```

1025 replacements across 44 files. Handles `Feature`, `Bug`, `Misc`, and `Discussion` ticket types.

## Affected files

44 files across 2014-2019 (full list in the diff).

---

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.