### PR TITLE
Remove escaped underscores, backticks, and brackets from Google Docs exports

### DIFF
--- a/2013/DevMeeting-2013-12-05.md
+++ b/2013/DevMeeting-2013-12-05.md
@@ -76,7 +76,7 @@ Season's greetings everyone!
 
 You can watch the recording from Thursday's meeting on[ustream](http://www.ustream.tv/recorded/41393753), thanks to[@mrkn](https://twitter.com/mrkn) for the recording!
 
-Although we didn't have a video recording from the meeting on Friday, werecorded our skype conference and is available on[soundcloud](https://soundcloud.com/zzak-2/ruby-core-developer-meeting). Thanksto [@sora\_h](https://twitter.com/sora_h) for the recording and moderating skype!
+Although we didn't have a video recording from the meeting on Friday, werecorded our skype conference and is available on[soundcloud](https://soundcloud.com/zzak-2/ruby-core-developer-meeting). Thanksto [@sora_h](https://twitter.com/sora_h) for the recording and moderating skype!
 
 Below I have summarized the meetings for each day and organized them intoagenda items. Each agenda item should have an associated ticket on our [bugtracker](http://bugs.ruby-lang.org/) that you can follow for more information.I will be updating these tickets with our conclusion shortly!
 
@@ -115,38 +115,38 @@ To summarize:
 - We accept proposal of [@hsbt](https://twitter.com/hsbt)
 - The following proposal will begin with 2.1.0
 
-#### Version Schema \`ruby-{MAJOR}.{MINOR}.{TEENY}\`[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Version-Schema-ruby-MAJORMINORTEENY)
+#### Version Schema `ruby-{MAJOR}.{MINOR}.{TEENY}`[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Version-Schema-ruby-MAJORMINORTEENY)
 
-- \`MAJOR\`: increased when incompatible change which can't be released in MINOR
+- `MAJOR`: increased when incompatible change which can't be released in MINOR
 - "MAJOR is for party", reserved for special events
-- \`MINOR\`: increased every christmas, may be API incompatible
-- \`TEENY\`: security or bug fix which maintains API compatibility
-- \`PATCH\`: number of commits since last MINOR release (will be reset at 0 when releasing MINOR)
+- `MINOR`: increased every christmas, may be API incompatible
+- `TEENY`: security or bug fix which maintains API compatibility
+- `PATCH`: number of commits since last MINOR release (will be reset at 0 when releasing MINOR)
 
-\`TEENY\` may be increased more than 10 (such as \`2.1.11\`), and will be releasedevery 2-3 months.
+`TEENY` may be increased more than 10 (such as `2.1.11`), and will be releasedevery 2-3 months.
 
-Matz and other attendees were concerned about \`TEENY >= 10\`.
+Matz and other attendees were concerned about `TEENY >= 10`.
 
 #### Branches[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Branches)
 
 We will maintain the following branches:
 
 - trunk
-- \`ruby\_{MAJOR}\_{MINOR}\`
-- \`ruby\_{MAJOR}\_{MINOR}\` across \`TEENY\` releases
+- `ruby_{MAJOR}_{MINOR}`
+- `ruby_{MAJOR}_{MINOR}` across `TEENY` releases
 - tags will be used for each release
 
 #### API Compatibility[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#API-Compatibility)
 
 - Removing API is an incompatible change
-- such as (\`STDIO\_READ\_DATA\_PENDING\`, etc.) must wait for 2.2.0
-- an incompatible change must increase \`MINOR\`
+- such as (`STDIO_READ_DATA_PENDING`, etc.) must wait for 2.2.0
+- an incompatible change must increase `MINOR`
 
 #### ABI Compatibility[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#ABI-Compatibility)
 
-- Scheme of \`{MAJOR}.{MINOR}.0\`
-- Keep ABI compatibility with same \`MINOR\` release, so \`TEENY\` is fixed at 0
-- Retain compatibility across \`TEENY\` releases
+- Scheme of `{MAJOR}.{MINOR}.0`
+- Keep ABI compatibility with same `MINOR` release, so `TEENY` is fixed at 0
+- Retain compatibility across `TEENY` releases
 
 We are concerned with changes required for existing tools, such as:
 
@@ -155,7 +155,7 @@ We are concerned with changes required for existing tools, such as:
 
 #### Documentation[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Documentation)
 
-We need to announce our plans for removing patch level semantics, in order touse \`{MAJOR}.{MINOR}.{TEENY}\`.
+We need to announce our plans for removing patch level semantics, in order touse `{MAJOR}.{MINOR}.{TEENY}`.
 
 ### Maintenance Policy for 1.8.7 and 1.9.2[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Maintenance-Policy-for-187-and-192)
 
@@ -163,10 +163,10 @@ We need to announce our plans for removing patch level semantics, in order touse
 
 1.8.7 and 1.9.2 will be supported for security fixes until June 2014.
 
-- [@hone02](https://twitter.com/hone02) and [@\_zzak](https://twitter.com/_zzak) will assume maintainership
+- [@hone02](https://twitter.com/hone02) and [@_zzak](https://twitter.com/_zzak) will assume maintainership
 - After the 6 month maintenance period, we can add more committers to extend another 6 months.
 
-In the past we have supported vendors who wish to maintain legacy versions. In2009 the maintenance of Ruby \`1.8.6\` was transferred to Engine Yard when theyreleased \`1.8.6-p369\`.
+In the past we have supported vendors who wish to maintain legacy versions. In2009 the maintenance of Ruby `1.8.6` was transferred to Engine Yard when theyreleased `1.8.6-p369`.
 
 We were given permission from Matz to release backport versions of Ruby forsecurity fixes.
 
@@ -222,7 +222,7 @@ Every issue can escalate to Matz, should he become inactive maybe we need torepl
 
 Asking to declare an expected maintenance period during appointment was rejected, see below:
 
-[@nagachika](https://twitter.com/nagachika), current maintainer of \`2.0.0\` madethe following comment:
+[@nagachika](https://twitter.com/nagachika), current maintainer of `2.0.0` madethe following comment:
 
 I never publish maintenance period for 2.0.0. I thought I can maintain it
 for 2 years in "normal maintenance mode" and then turn into "security only
@@ -264,8 +264,8 @@ We discussed this ticket, and concluded the following statements:
 
 After watching the video I wrote a [roughsummary](https://gist.github.com/zzak/7821769), since most of thediscussion was in English. The following other events took place during themeeting:
 
-- [@a\_matsuda](https://twitter.com/a_matsuda) commits typo patches, he is the typo monster!
+- [@a_matsuda](https://twitter.com/a_matsuda) commits typo patches, he is the typo monster!
 - [Martin Duerst commits too!](https://github.com/ruby/ruby/commit/737c7d8)
 - [@hone02](https://twitter.com/hone02) joined the skype call to discuss his feedback on maintainer appointment and discharge
-- [@a\_matsuda](https://twitter.com/a_matsuda) will propose gemifying the stdlib at the next meeting
+- [@a_matsuda](https://twitter.com/a_matsuda) will propose gemifying the stdlib at the next meeting
 

--- a/2013/DevMeeting-2013-12-06.md
+++ b/2013/DevMeeting-2013-12-06.md
@@ -58,15 +58,15 @@ Please follow the [[DevelopersMeetingIRCGuidelines]] for irc
 
 On Friday, several committers met to discuss the events that took place duringthe previous meeting. We made important decisions on the maintenance policy forbackport versions and commercial support.
 
-### Branch Schema for Semantic Versioning \`ruby\_MAJOR\_MINOR\`[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Branch-Schema-for-Semantic-Versioning-ruby_MAJOR_MINOR)
+### Branch Schema for Semantic Versioning `ruby_MAJOR_MINOR`[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Branch-Schema-for-Semantic-Versioning-ruby_MAJOR_MINOR)
 
 [misc. #8835](http://bugs.ruby-lang.org/issues/8835)
 
 We discussed a concern with handling security releases given the proposed branching schema.
 
-During the 1.8 series we had a dedicated ruby\_1\_8 branch with no \`TEENY\`version in the name. In this time we had to release a security fix from thisbranch, however there were existing unreleased bug fix patches on this branchcausing a regression.
+During the 1.8 series we had a dedicated ruby_1_8 branch with no `TEENY`version in the name. In this time we had to release a security fix from thisbranch, however there were existing unreleased bug fix patches on this branchcausing a regression.
 
-The previous solution was to create a new branch (\`ruby\_1\_8\_6\`) and beginmaintaining two branches for the 1.8 series.
+The previous solution was to create a new branch (`ruby_1_8_6`) and beginmaintaining two branches for the 1.8 series.
 
 - Additional branches may be added to support cherry-picking of security fixes.
 
@@ -74,9 +74,9 @@ We are concerned because security versions may occur more frequently betweenMINO
 
 #### SemVer[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#SemVer)
 
-After reviewing the discussion from the previous meeting we discussed theconcern of \`TEENY >= 10\`.
+After reviewing the discussion from the previous meeting we discussed theconcern of `TEENY >= 10`.
 
-- String comparison bugs exist, such as: \`"2.2.2" <= "2.2.10" #=> false\`
+- String comparison bugs exist, such as: `"2.2.2" <= "2.2.10" #=> false`
 - We can fix this by abandoning strings
 - The version number can be anything that acts like String
 - We will postpone this situation
@@ -157,7 +157,7 @@ That about wraps up the summary of both meetings, thank you to everyone who coul
 Thanks for everyone who helped make this meeting possible, especially:
 
 - Cookpad for hosting both meetings on short notice
-- [@sora\_h](https://twitter.com/sora_h) for moderating irc, skype, and creating the audio recordings
+- [@sora_h](https://twitter.com/sora_h) for moderating irc, skype, and creating the audio recordings
 - [@mrkn](https://twitter.com/mrkn) for the video recording on Thursday
 - [@lchin](https://twitter.com/lchin) for translation support on Friday
 - Everyone who attended and helped discuss the future of Ruby

--- a/2014/DevMeeting-2014-05-17.md
+++ b/2014/DevMeeting-2014-05-17.md
@@ -31,7 +31,7 @@ Attendees: sign up required: http://cruby.doorkeeper.jp/events/10778
 
 # Log
 
-attendee: sora\_h, shyouhei, akr, naruse, ko1, hsbt, tarui
+attendee: sora_h, shyouhei, akr, naruse, ko1, hsbt, tarui
 
 online: matz, n0kada,
 
@@ -109,7 +109,7 @@ bundle gem にして、time が依存する箇所だけ ext に持っていく. 
 
 →matzがOKと返信する
 
-## [[Feature #9826]](https://bugs.ruby-lang.org/issues/9826) Enumerable#slice\_between (akr)
+## [[Feature #9826]](https://bugs.ruby-lang.org/issues/9826) Enumerable#slice_between (akr)
 
 ニーズはある
 
@@ -117,7 +117,7 @@ matz: 機能としては採用してあげたいけど、この名前では採�
 
 #slice? → Array#slice があるのでNG
 
-## [[Feature #9071]](https://bugs.ruby-lang.org/issues/9071) Enumerable#slice\_after (akr)
+## [[Feature #9071]](https://bugs.ruby-lang.org/issues/9071) Enumerable#slice_after (akr)
 
 対称性
 
@@ -145,11 +145,11 @@ Matz: sysconf と confstr で同じ機能だけど、数値と文字列を返す
 
 Windows でどうしよう →NotImplementedError
 
-## [[Feature #9834]](https://bugs.ruby-lang.org/issues/9834) Float#{next\_float,prev\_float} (akr)
+## [[Feature #9834]](https://bugs.ruby-lang.org/issues/9834) Float#{next_float,prev_float} (akr)
 
 これは用途があまり明らかでない→テストで便利(printfのテストとか)。
 
-## [[Feature #9632]](https://bugs.ruby-lang.org/issues/9632) \[offtopic\] remove doxygen?
+## [[Feature #9632]](https://bugs.ruby-lang.org/issues/9632) [offtopic] remove doxygen?
 
 ccan フォルダの追加に伴って doxygen の警告が凄いでてきた、そもそも使ってないなら消したい
 
@@ -157,7 +157,7 @@ ko1: 消すのではなくて、デフォルトで動くのはやめて make dox
 
 Matz: デフォルトでは動かさないようにして、何かレポートきたら誰か頑張る.
 
-## [[Feature #9711]](https://bugs.ruby-lang.org/issues/9711) Remove test-unit and minitest from stdlib. Can I remove test-unit? /cc sora\_h (hsbt)
+## [[Feature #9711]](https://bugs.ruby-lang.org/issues/9711) Remove test-unit and minitest from stdlib. Can I remove test-unit? /cc sora_h (hsbt)
 
 lib/test, lib/minitest を使うのはもうやめている.
 
@@ -199,7 +199,7 @@ ko1: gem にしてメンテナンスサイクルを分けよう
 
 Matz: 名前がイマイチ
 
-## \[ANN\] chkbuildXXX.hsbt.org
+## [ANN] chkbuildXXX.hsbt.org
 
 Ruby Association の資金で4台マシンを用意しました. 必要に応じてアカウント作るのでご連絡ください.
 
@@ -226,7 +226,7 @@ pLinux が何なのかよくわからないので RubyCI のサーバー名を�
 
 ## Attendance[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Attendance)
 
-- in person: sora\_h, shyouhei, akr, naruse, ko1, hsbt, tarui
+- in person: sora_h, shyouhei, akr, naruse, ko1, hsbt, tarui
 - online: matz, n0kada
 
 ## \[Feature [#9772](https://bugs.ruby-lang.org/issues/9772 "Feature: IO#statfs and File::Statfs (Rejected)")\] IO#statfs and File::Statfs[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9772-IOstatfs-and-FileStatfs)
@@ -252,11 +252,11 @@ going separate it into a bundled gem
 
 accepted
 
-## \[Feature [#9826](https://bugs.ruby-lang.org/issues/9826 "Feature: Enumerable#slice_between (Closed)")\] Enumerable#slice\_between (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9826-Enumerableslice_between-akr)
+## \[Feature [#9826](https://bugs.ruby-lang.org/issues/9826 "Feature: Enumerable#slice_between (Closed)")\] Enumerable#slice_between (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9826-Enumerableslice_between-akr)
 
 Matz likes the idea, but it needs a better name. There is already Array#slice.
 
-## \[Feature [#9071](https://bugs.ruby-lang.org/issues/9071 "Feature: Enumerable#slice_after (Closed)")\] Enumerable#slice\_after (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9071-Enumerableslice_after-akr)
+## \[Feature [#9071](https://bugs.ruby-lang.org/issues/9071 "Feature: Enumerable#slice_after (Closed)")\] Enumerable#slice_after (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9071-Enumerableslice_after-akr)
 
 accepted
 
@@ -268,15 +268,15 @@ accepted
 
 accepted
 
-## \[Feature [#9834](https://bugs.ruby-lang.org/issues/9834 "Feature: Float#{next_float,prev_float} (Closed)")\] Float#{next\_float,prev\_float} (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9834-Floatnext_floatprev_float-akr)
+## \[Feature [#9834](https://bugs.ruby-lang.org/issues/9834 "Feature: Float#{next_float,prev_float} (Closed)")\] Float#{next_float,prev_float} (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9834-Floatnext_floatprev_float-akr)
 
 accepted
 
-## \[Feature [#9632](https://bugs.ruby-lang.org/issues/9632 "Feature: [PATCH 0/2] speedup IO#close with linked-list from ccan (Closed)")\] \[offtopic\] remove doxygen?[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9632-offtopic-remove-doxygen)
+## \[Feature [#9632](https://bugs.ruby-lang.org/issues/9632 "Feature: [PATCH 0/2] speedup IO#close with linked-list from ccan (Closed)")\] [offtopic] remove doxygen?[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9632-offtopic-remove-doxygen)
 
 dropping support for doxygen
 
-## \[Feature [#9711](https://bugs.ruby-lang.org/issues/9711 "Feature: Remove test-unit and minitest from stdlib. (Closed)")\] Remove test-unit and minitest from stdlib. Can I remove test-unit? /cc sora\_h (hsbt)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9711-Remove-test-unit-and-minitest-from-stdlib-Can-I-remove-test-unit-cc-sora_h-hsbt)
+## \[Feature [#9711](https://bugs.ruby-lang.org/issues/9711 "Feature: Remove test-unit and minitest from stdlib. (Closed)")\] Remove test-unit and minitest from stdlib. Can I remove test-unit? /cc sora_h (hsbt)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9711-Remove-test-unit-and-minitest-from-stdlib-Can-I-remove-test-unit-cc-sora_h-hsbt)
 
 continuing to discuss about bundling test libraries test-unit/minitest.
 
@@ -296,11 +296,11 @@ accepted: going to fade out callcc support
 - unclear what the usecase is
 - continue to discuss on redmine
 
-## \[ANN\] chkbuildXXX.hsbt.org[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#ANN-chkbuildXXXhsbtorg)
+## [ANN] chkbuildXXX.hsbt.org[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#ANN-chkbuildXXXhsbtorg)
 
 Using Ruby Association's funds, 4 machines have been prepared for chkbuild. chkbuild is the Ruby CI platform powering [http://rubyci.org](http://rubyci.org/). We also want something besides Intel like running ARM on top of QEMU.
 
 ## Next Meetings[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Next-Meetings)
 
-- 6/18, 18:30 JST: discussing \[Feature [#9711](https://bugs.ruby-lang.org/issues/9711 "Feature: Remove test-unit and minitest from stdlib. (Closed)")\], [doorkeeper](http://cruby.doorkeeper.jp/events/11795?utm_campaign=event_11795_7773&utm_medium=email&utm_source=not_replied_message)
+- 6/18, 18:30 JST: discussing [Feature [#9711](https://bugs.ruby-lang.org/issues/9711 "Feature: Remove test-unit and minitest from stdlib. (Closed)")], [doorkeeper](http://cruby.doorkeeper.jp/events/11795?utm_campaign=event_11795_7773&utm_medium=email&utm_source=not_replied_message)
 - 7/26: big features for 2.2

--- a/2014/DevMeeting-2014-07-26.md
+++ b/2014/DevMeeting-2014-07-26.md
@@ -30,7 +30,7 @@ log: https://docs.google.com/document/d/1g2mu2qngyxw3ge-EbDGLsDDZR-Uj_6fWaVb0YPw
 
 # Log
 
-- attendee: ko1, sora\_h, akr, naruse, knu, duerst
+- attendee: ko1, sora_h, akr, naruse, knu, duerst
 - on-line: matz, zzak, nobu, kosaki
 
 # [[Feature #7797]](https://bugs.ruby-lang.org/issues/7797) Hash should be renamed to StrictHash and a new Hash should be created to behave like AS HashWithIndifferentAccess
@@ -41,9 +41,9 @@ matz: I have to reject, since it breaks compatibility
 
 # [[Feature #9980]](https://bugs.ruby-lang.org/issues/9980) Create HashWithIndiferentAccess using new syntax {a: 1}i
 
-matz: Suffix \`i\` is used for complex (imaginary) numbers. It's bit confusing.
+matz: Suffix `i` is used for complex (imaginary) numbers. It's bit confusing.
 
-Maybe what you want can be gained by shorter/nicer name for Hash#compare\_by\_identity.
+Maybe what you want can be gained by shorter/nicer name for Hash#compare_by_identity.
 
 → reject
 
@@ -55,15 +55,15 @@ Action: Matz  to write a few questions back to the proposer
 
 Now it can be implemnted with Pure Ruby.
 
-If hash is given, what will be \`self\` of ERB?
+If hash is given, what will be `self` of ERB?
 
-# [[Bug #8543]](https://bugs.ruby-lang.org/issues/8543) rb\_iseq\_load
+# [[Bug #8543]](https://bugs.ruby-lang.org/issues/8543) rb_iseq_load
 
 Modify it (best effort).
 
 # [[Feature #10084]](https://bugs.ruby-lang.org/issues/10084) Add Unicode String Normalization to String class
 
-Proposed method names by Matz: unicode\_normalize or normalize\_kd,... (not too short)
+Proposed method names by Matz: unicode_normalize or normalize_kd,... (not too short)
 
 How to deal with non-Unicode encodings: Matz: raise Exception
 
@@ -71,9 +71,9 @@ Other than UTF-8: UTF8-Mac: return type should be UTF-8, or deal with it as lega
 
 Todo (for eprun): measure load time, compare with unf, avoid Module Normalize
 
-require “unicode\_normalize”
+require “unicode_normalize”
 
-method name: String#unicode\_normalize(form)
+method name: String#unicode_normalize(form)
 
 form: :nfc, :nfd, :nfkc, :nfkd
 
@@ -93,11 +93,11 @@ no objection.
 
 approval.
 
-# [[Feature #9781]](https://bugs.ruby-lang.org/issues/9781) Feature Proposal: Method#super\_method
+# [[Feature #9781]](https://bugs.ruby-lang.org/issues/9781) Feature Proposal: Method#super_method
 
 super: ambiguous which is calling method or getting method object of super.
 
-\-> “super\_method”
+\-> “super_method”
 
 # [[Feature #10095]](https://bugs.ruby-lang.org/issues/10095) Object#as
 
@@ -113,7 +113,7 @@ bike shed discussion
 
 (1 + 2 + 3 + 4).with{|x| x \*\* 2}
 
-alias as instance\_exec
+alias as instance_exec
 
 with(1 + 2 + 3 + 4){|x| x \*\* 2}
 
@@ -139,9 +139,9 @@ continue
 
 (1 + 2 + 3 + 4).then{|x| x \*\* 2}
 
-reverse\_call
+reverse_call
 
-(1 + 2 + 3 + 4).\_{|x| x \*\* 2}
+(1 + 2 + 3 + 4)._{|x| x \*\* 2}
 
 (1 + 2 + 3 + 4) -> {|x| x \*\* 2}
 

--- a/2014/DevMeeting-2014-09-04.md
+++ b/2014/DevMeeting-2014-09-04.md
@@ -42,7 +42,7 @@ Attendees: sign up required: http://cruby.doorkeeper.jp/events/13742
 
 # Log
 
-- attendee: ko1, sora\_h, akr, naruse, ayumin, a\_matsuda
+- attendee: ko1, sora_h, akr, naruse, ayumin, a_matsuda
 - on-line: matz, nobu
 
 ## [[Feature #10199]](https://bugs.ruby-lang.org/issues/10199) Drop to support Symbian (hsbt)
@@ -55,13 +55,13 @@ akr: no need to think about it now.
 
 hsbt: I will remove.
 
-## [[Feature #10200]](https://bugs.ruby-lang.org/issues/10200) Symbol API (static count, dynamic count, all\_symbols and so on) (ko1)
+## [[Feature #10200]](https://bugs.ruby-lang.org/issues/10200) Symbol API (static count, dynamic count, all_symbols and so on) (ko1)
 
-Symbol.all\_symbols:
+Symbol.all_symbols:
 
-matsuda: Symbol.all\_symbols is used by pry to make completion.
+matsuda: Symbol.all_symbols is used by pry to make completion.
 
-matz: leave Symbol.all\_symbols as current behavior
+matz: leave Symbol.all_symbols as current behavior
 
 Symbol.find():
 

--- a/2014/DevMeeting-2014-10-29.md
+++ b/2014/DevMeeting-2014-10-29.md
@@ -56,7 +56,7 @@ martin: latestの方が好み（だが、ここではおいておく）
 
 martin: 7.0.0を8.0.0に変えた時、うまく（改めて）ダウンロードしてビルドして欲しい
 
-naruse: unicode\_normalizeだけでなくOnigmo等、それぞれ個別に新バージョンに対応する必要がある
+naruse: unicode_normalizeだけでなくOnigmo等、それぞれ個別に新バージョンに対応する必要がある
 
 martin: 個々のファイルには、バージョン番号が入っていないものもある（過去との互換性）
 
@@ -72,7 +72,7 @@ knu: libyamlも同様の理由で同梱している
 
 naruse: libffiはpermissiveなライセンスだったはず（※MIT License）
 
-knu: 余談だけど1.9, 2.0, 2.1のDL/Fiddleの差異や、ffi gemともまた違うという件についてkakasi gemというのを作ったのでご覧ください [https://github.com/knu/kakasi\_ffi](https://github.com/knu/kakasi_ffi) （どのバージョンのrubyでも使えるdl gemを作る場合の非互換性について参考になるかも）
+knu: 余談だけど1.9, 2.0, 2.1のDL/Fiddleの差異や、ffi gemともまた違うという件についてkakasi gemというのを作ったのでご覧ください [https://github.com/knu/kakasi_ffi](https://github.com/knu/kakasi_ffi) （どのバージョンのrubyでも使えるdl gemを作る場合の非互換性について参考になるかも）
 
 akr: すぐDLを消すとWindowsで困る（usaさんが怒る）のでは？
 
@@ -90,7 +90,7 @@ matzがこれに関しては一貫性を取る（このリグレッションは�
 
 # [[Feature #9612]](https://bugs.ruby-lang.org/issues/9612) Gemify OpenSSL(hsbt)
 
-akr: experimental 実装について gemのバージョンは、OpenSSL (OpenSSL::OPENSSL\_VERSION)そのものではなく、OpenSSL拡張ライブラリのバージョン (OpenSSL::VERSION) にするべき（※libsslランタイムのバージョンはOpenSSL::OPENSSL\_LIBRARY\_VERSION）
+akr: experimental 実装について gemのバージョンは、OpenSSL (OpenSSL::OPENSSL_VERSION)そのものではなく、OpenSSL拡張ライブラリのバージョン (OpenSSL::VERSION) にするべき（※libsslランタイムのバージョンはOpenSSL::OPENSSL_LIBRARY_VERSION）
 
 akr: ext/openssl に脆弱性があったら、ruby 本体をリリースせざるを得ないのでrubyリリースエンジニア側には gem 化のメリットはなさそう
 
@@ -100,7 +100,7 @@ matz: 異議はありません
 
 naruse さんが issue にコメントする
 
-# \[misc [#10287](https://bugs.ruby-lang.org/issues/10287)\] rename COLON3 to COLON2\_HEAD. (hsbt)
+# \[misc [#10287](https://bugs.ruby-lang.org/issues/10287)\] rename COLON3 to COLON2_HEAD. (hsbt)
 
 \*: COLON3がおかしいのはおっしゃる通りだが、名前が「HEAD」はちょっと違う気がするので「TOP」?
 
@@ -108,7 +108,7 @@ akr: 「議論はしましたがいい名前が浮かばない」
 
 ko1: matz にふっておきましょう
 
-# [[Feature #8976]](https://bugs.ruby-lang.org/issues/8976) file-scope freeze\_string directive (akr)
+# [[Feature #8976]](https://bugs.ruby-lang.org/issues/8976) file-scope freeze_string directive (akr)
 
 matz: 遠い未来には賛成
 
@@ -141,7 +141,7 @@ matz: 嫌な予感がするので2.2では（実験的実装も含めて）や�
 
 2.3（以降）に照準を合わせる
 
-# [[Feature #10344]](https://bugs.ruby-lang.org/issues/10344) \[PATCH\] Implement Fiber#raise (ko1)
+# [[Feature #10344]](https://bugs.ruby-lang.org/issues/10344) [PATCH] Implement Fiber#raise (ko1)
 
 ko1: Thread#raiseは危険なのでなくした経緯
 

--- a/2015/DevMeeting-2015-04-08.md
+++ b/2015/DevMeeting-2015-04-08.md
@@ -80,7 +80,7 @@ matz, akr, hsbt, nurse, nobu, ayumin, sora, ko1
 - (3) cache directory content before (make file list file)
 - (4) zip (or other format) archive
 
-- Compatibility problem (\_\_FILE\_\_, open(\_\_FILE\_\_))
+- Compatibility problem (__FILE__, open(__FILE__))
 
 - AOT compile
 
@@ -95,7 +95,7 @@ matz, akr, hsbt, nurse, nobu, ayumin, sora, ko1
 
 - grep -v (sora) -> make a ticket
 
-- grep\_v(re)
+- grep_v(re)
 - grep!(re) (naruse)
 - grep(-/re/) (Regexp#-@, Regexp#~@) (nobu)
 - Regexp#~@(nobu)
@@ -104,7 +104,7 @@ matz, akr, hsbt, nurse, nobu, ayumin, sora, ko1
 
 - [https://bugs.ruby-lang.org/issues/8579](https://bugs.ruby-lang.org/issues/8579)
 - https://bugs.ruby-lang.org/issues/8976
-- rdoc uses force\_encoding where the string is not created
+- rdoc uses force_encoding where the string is not created
 - matz don’t like pragma
 
 - gemify
@@ -158,7 +158,7 @@ matz, akr, hsbt, nurse, nobu, ayumin, sora, ko1
 
 (ko1) no problem except the name and “include ObjectSpace”.
 
-## [GitHub #858](https://github.com/ruby/ruby/pull/858) Add a RUBY\_ENGINE\_VERSION constant (tenderlove)
+## [GitHub #858](https://github.com/ruby/ruby/pull/858) Add a RUBY_ENGINE_VERSION constant (tenderlove)
 
 (matz) approved.
 

--- a/2015/DevMeeting-2015-05-14.md
+++ b/2015/DevMeeting-2015-05-14.md
@@ -47,7 +47,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 # Log
 
-Attendee: ko1,ayumin,akr,hsbt,naruse; matz,sora\_h
+Attendee: ko1,ayumin,akr,hsbt,naruse; matz,sora_h
 
 ## [[Feature #11084]](https://bugs.ruby-lang.org/issues/11084) Use rb-readline instead of ext/readline
 
@@ -97,7 +97,7 @@ hsbt: Not sure.
 
 Matz: I accept bundled gem.
 
-## [[Feature #11082]](https://bugs.ruby-lang.org/issues/11082) Remove condition of RUBY\_VERSION < 1.9 (hsbt)
+## [[Feature #11082]](https://bugs.ruby-lang.org/issues/11082) Remove condition of RUBY_VERSION < 1.9 (hsbt)
 
 hsbt: Title is wrong. Not < 1.9, but <= 1.9.
 
@@ -123,11 +123,11 @@ ayumin: Positive because using newer features helps to evaluate such features.
 
 ko1: Use newer features with keeping compatibility.
 
-## [[Feature #11049]](https://bugs.ruby-lang.org/issues/11049) Enumerable#grep\_v (inversed grep) (sorah)
+## [[Feature #11049]](https://bugs.ruby-lang.org/issues/11049) Enumerable#grep_v (inversed grep) (sorah)
 
-matz: are you okay to use the name “grep\_v”
+matz: are you okay to use the name “grep_v”
 
-sora\_h: Personally, grep\_v is acceptable.
+sora_h: Personally, grep_v is acceptable.
 
 matz: Other languages?
 
@@ -137,13 +137,13 @@ ayumin: keyword parameter ?
 
 matz: grep(pattern, inverse: true) ?
 
-matz: but grep\_v() is okay. -> accept on ticket.
+matz: but grep_v() is okay. -> accept on ticket.
 
 naruse: How about reject(pattern) ?
 
 ## [[Bug #10967]](https://bugs.ruby-lang.org/issues/10967) Remove "private attribute?" warning (zzak)
 
-akr: self.private\_something\_method is accepted recently.
+akr: self.private_something_method is accepted recently.
 
 naruse: test can find problem, so warning is not needed.
 
@@ -240,35 +240,35 @@ end
 
 Matz: positive
 
-# \[ruby-list:50135\] \[ANN\] Enumerator::Parallel v0.1.1
+# [ruby-list:50135] [ANN] Enumerator::Parallel v0.1.1
 
 Matz: how about to introduce it as bundled gem?
 
 ---
 
-# \[ruby-list:50120\] \[ANN\] Kasen(下線) v0.1.1
+# [ruby-list:50120] [ANN] Kasen(下線) v0.1.1
 
 Matz: I like this idea.
 
 Which is favorite?
 
-\[1, 2, 3\].map { |n| (n + 1).to\_s }
+[1, 2, 3].map { |n| (n + 1).to_s }
 
-\[1, 2, 3\].map &(\_ + 1).to\_s     # Kasen enables
+[1, 2, 3].map &(_ + 1).to_s     # Kasen enables
 
-\[1, 2, 3\].map { ($1 + 1).to\_s } # use #11141
+[1, 2, 3].map { ($1 + 1).to_s } # use #11141
 
-\[1, 2, 3\].map { (@1 + 1).to\_s } # use #11141
+[1, 2, 3].map { (@1 + 1).to_s } # use #11141
 
-\[1, 2, 3\].map { (\_ + 1).to\_s }  # use #11141
+[1, 2, 3].map { (_ + 1).to_s }  # use #11141
 
-\[1, 2, 3\].map (\_ + 1).to\_s
+[1, 2, 3].map (_ + 1).to_s
 
-\[1, 2, 3\].map &:+.curry{1}
+[1, 2, 3].map &:+.curry{1}
 
-\[1, 2, 3\].map &(+ 1)
+[1, 2, 3].map &(+ 1)
 
-(\[1, 2, 3\].map + 1).to\_s.to\_a
+([1, 2, 3].map + 1).to_s.to_a
 
 Next action: ko1 will add discussion into 11141.
 
@@ -291,19 +291,19 @@ other idea is providing feature of binding. However, it needs long strokes.
 
 a = b = 1
 
-local\_variables #=> \[:a, :b\]
+local_variables #=> [:a, :b]
 
-local\_variables #=> {:a => 1, :b => 1}
+local_variables #=> {:a => 1, :b => 1}
 
-local\_variables\_set #=> {:a => 1, :b => 1}
+local_variables_set #=> {:a => 1, :b => 1}
 
-local\_variables\_get(%i(a b)) #=> {:a => 1, :b => 1}
+local_variables_get(%i(a b)) #=> {:a => 1, :b => 1}
 
-Binding#local\_variable\_set(:a, 1)
+Binding#local_variable_set(:a, 1)
 
 {a, b, c}
 
-binding.local\_variables(%i(a b c))
+binding.local_variables(%i(a b c))
 
 ## Next meeting
 

--- a/2015/DevMeeting-2015-06-12.md
+++ b/2015/DevMeeting-2015-06-12.md
@@ -55,7 +55,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 Attendee: akr, hsbt, ko1, matz, naruse, nobu
 
-## [[Feature #7148]](https://bugs.ruby-lang.org/issues/7148) Improved Tempfile w/o DelegateClass (glass\_saga)
+## [[Feature #7148]](https://bugs.ruby-lang.org/issues/7148) Improved Tempfile w/o DelegateClass (glass_saga)
 
 matz: I have some issue on this proposal. Tempfile should not be a subclass of File. It is different concept from File. I’m okay to implement Tempfile without delegator. However, I’m not sure it implemeted with subclass of File.
 
@@ -63,7 +63,7 @@ File is a wrapper of fd. Tempfile is not only a wrapper but handle other informa
 
 Action: Matz will reply this issue.
 
-## [[Feature #11218]](https://bugs.ruby-lang.org/issues/11218) File.open FILE\_SHARE\_DELETE (naruse)
+## [[Feature #11218]](https://bugs.ruby-lang.org/issues/11218) File.open FILE_SHARE_DELETE (naruse)
 
 naruse: (explain about this proposal). This proposal is only for Windows.
 
@@ -77,15 +77,15 @@ matz: How about providing Interger constant?
 
 akr: How about larger than 32bit integer
 
-akr: use O\_SHARE\_DELETE
+akr: use O_SHARE_DELETE
 
 matz: integer is preferrable, symbol is also ok
 
-naruse: I need modestr2modeint for add the new integer flag (rb\_io\_modestr\_oflags)
+naruse: I need modestr2modeint for add the new integer flag (rb_io_modestr_oflags)
 
 Action: Discuss on ticket
 
-## [[Feature #11251]](https://bugs.ruby-lang.org/issues/11251) pthread\_set\_name\_np (naruse)
+## [[Feature #11251]](https://bugs.ruby-lang.org/issues/11251) pthread_set_name_np (naruse)
 
 ko1: Interface?
 
@@ -109,15 +109,15 @@ matz: $2 and $3 can be removed.
 
 Action: Matz will reply on ticket. hsbt-san will try implent.
 
-## [[Feature #10730]](https://bugs.ruby-lang.org/issues/10730) Implement Array#bsearch\_index(hsbt)
+## [[Feature #10730]](https://bugs.ruby-lang.org/issues/10730) Implement Array#bsearch_index(hsbt)
 
 matz: go ahead.
 
 Action: Matz will reply. nobu will merge.
 
-## [[Feature #10017]](https://bugs.ruby-lang.org/issues/10017) Add Hash#values\_at!(hsbt)
+## [[Feature #10017]](https://bugs.ruby-lang.org/issues/10017) Add Hash#values_at!(hsbt)
 
-matz: approved (Hash#fetch\_values).
+matz: approved (Hash#fetch_values).
 
 Action: Matz will reply. Nobu will merge it.
 
@@ -129,17 +129,17 @@ Action: Matz will reply.
 
 Action: continue to discuss how to implement (nobu)
 
-## \[Feature #11215\] pack/unpack for (u)intptr\_t
+## \[Feature #11215\] pack/unpack for (u)intptr_t
 
 Action: Matz will approve it.
 
-## \[Feature #10769\] Negative counterpart to Enumerable#slice\_when
+## \[Feature #10769\] Negative counterpart to Enumerable#slice_when
 
-## \[Feature #11253\] rb\_io\_modestr\_oflags for Ruby API
+## \[Feature #11253\] rb_io_modestr_oflags for Ruby API
 
 matz: add keyword argument “flags”, which is OR-ed with 2nd argument mode.
 
-\[Feature #11158\] Introduce a Symbol.count API as a more efficient alternative to Symbol.all\_symbols.size
+\[Feature #11158\] Introduce a Symbol.count API as a more efficient alternative to Symbol.all_symbols.size
 
 naruse: If they use this for metrics, it should show 3 different count for each symbol types
 

--- a/2015/DevMeeting-2015-07-28.md
+++ b/2015/DevMeeting-2015-07-28.md
@@ -87,7 +87,7 @@ akr pointed out that it will introduce incompatibility compare with C implemente
 
  …
 
-this code can leak \`fd’ if some exception is occur before making IO object (IO object will free fd). In this case, we need to make C functions to make IO objects.
+this code can leak `fd’ if some exception is occur before making IO object (IO object will free fd). In this case, we need to make C functions to make IO objects.
 
 Also, additional TracePoint will be introduced.
 
@@ -101,7 +101,7 @@ Also, additional TracePoint will be introduced.
 
 Resolved.
 
-## [[Feature #8919]](https://bugs.ruby-lang.org/issues/8919) Queue as embedded class: please determine whether or not it should be introduced. (glass\_saga)
+## [[Feature #8919]](https://bugs.ruby-lang.org/issues/8919) Queue as embedded class: please determine whether or not it should be introduced. (glass_saga)
 
 Matz: seems good.
 
@@ -109,7 +109,7 @@ Nobu: how is SizedQueue? They share same codes.
 
 … no conclusion. Koichi will try.
 
-# Feature #10600: \[PATCH\] Queue#close [https://bugs.ruby-lang.org/issues/10600](https://bugs.ruby-lang.org/issues/10600)
+# Feature #10600: [PATCH] Queue#close [https://bugs.ruby-lang.org/issues/10600](https://bugs.ruby-lang.org/issues/10600)
 
 Matz: seems good.
 
@@ -117,6 +117,6 @@ akr: What happens on pushing/popping closed Queue?
 
 ko1: there are discussions on ticket. I’ll take it.
 
-## [[Feature #11297]](https://bugs.ruby-lang.org/issues/11297) Allow private method of self to be called (a\_matsuda)
+## [[Feature #11297]](https://bugs.ruby-lang.org/issues/11297) Allow private method of self to be called (a_matsuda)
 
 Matz: seems good

--- a/2015/DevMeeting-2015-08-20.md
+++ b/2015/DevMeeting-2015-08-20.md
@@ -40,11 +40,11 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 Attendee: akr, ayumin, hsbt, ko1, matz, naruse, nobu, kosaki, usa, yuki, amatsuda
 
-# did\_you\_mean gem (Yuki Nishijima)
+# did_you_mean gem (Yuki Nishijima)
 
-- Naming: did\_you\_mean or correctable?
+- Naming: did_you_mean or correctable?
 
-- did\_you\_mean is acceptable, but it’s determined by what feature set is bundled.
+- did_you_mean is acceptable, but it’s determined by what feature set is bundled.
 
 - Bundled gem or stdlib? It's going to be reuiqred in prelude (Yuki still doesn't know what it is)
 
@@ -58,14 +58,14 @@ Attendee: akr, ayumin, hsbt, ko1, matz, naruse, nobu, kosaki, usa, yuki, amatsud
 - Why want to disable in production? -> Because it makes rails slow.
 - Why slow? -> Rails parses the message of NameError exception for rails’ autoload feature.
 
-- \`time ruby --disable-gem -e1\`: 0.061s
-- \`time ruby -e1\`: 0.083s
-- \`time ruby -rdid\_you\_mean -e1\`: 0.109s
-- (ruby 2.2.2p95 (2015-04-13 revision 50295) \[x86\_64-darwin14\])
-- Like --disable-gem, we can extend --disable-did\_you\_mean
+- `time ruby --disable-gem -e1`: 0.061s
+- `time ruby -e1`: 0.083s
+- `time ruby -rdid_you_mean -e1`: 0.109s
+- (ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin14])
+- Like --disable-gem, we can extend --disable-did_you_mean
 
 - \-> We should change Rails, and we should offer a new API to take the qualified name of the Class/Module.
-- Current Rails parses error message like “NameError: undefined local variable or method \`foo' for main:Object”
+- Current Rails parses error message like “NameError: undefined local variable or method `foo' for main:Object”
 
 - Use NameError#name
 - NameError#name doesn’t include parent modeule names which is included in the error message. We need a new API including this.
@@ -73,18 +73,18 @@ Attendee: akr, ayumin, hsbt, ko1, matz, naruse, nobu, kosaki, usa, yuki, amatsud
 
 - More succinct message.  Delete two empty line and indent.
 
-% ruby -rdid\_you\_mean -e '
+% ruby -rdid_you_mean -e '
 class C
  def bar
  end
 end
 C.new.baz
 '
-\-e:6:in \`<main>': undefined method \`baz' for #<C:0x007f790863e880> (NoMethodError)
+\-e:6:in `<main>': undefined method `baz' for #<C:0x007f790863e880> (NoMethodError)
 
    Did you mean? #bar
 
-zsh: exit 1     /home/akr/alias/ruby -rdid\_you\_mean -e
+zsh: exit 1     /home/akr/alias/ruby -rdid_you_mean -e
 
 % ocaml
        OCaml version 4.01.0
@@ -113,7 +113,7 @@ empty line is not needed because lines of display is essential resource. indent 
 
 - How to disable this?
 
-- Use \`--disable=’ commandline option.
+- Use `--disable=’ commandline option.
 - Need to implement API in ruby level to take what features are disabled.
 
 - global method? global variable? constant?
@@ -162,7 +162,7 @@ Default of the status of String Literal will be frozen from Ruby 3.0.
 - it has been rejected before 2.2 by matz
 - it has been rejected again early 2.3 development by matz
 - amatsuda: tired of seeing pull requests adding “..”.freeze here and there. This is ugly.
-- amatsuda: please reconsider akr’s magic comment solution \[[https://bugs.ruby-lang.org/issues/8976](https://bugs.ruby-lang.org/issues/8976)\]
+- amatsuda: please reconsider akr’s magic comment solution [[https://bugs.ruby-lang.org/issues/8976](https://bugs.ruby-lang.org/issues/8976)]
 - matz: accepted. As a migration path, magic comment is reasonable. naming is still problem.
 
 - command line option to frozen string literal by default
@@ -175,12 +175,12 @@ Default of the status of String Literal will be frozen from Ruby 3.0.
 - String.new(“...”) is preferred over “...”.dup.
 - magic comment candidates
 
-- freeze\_string: true \[[https://bugs.ruby-lang.org/issues/8976](https://bugs.ruby-lang.org/issues/8976)\]
-- freeze\_string\_literal: true
-- frozen\_string\_literal: true \[prefered by matz\]
-- freezing\_string\_literal: true
-- mutable\_string\_literal: false
-- immutable: string \[[https://github.com/ruby/ruby/pull/487](https://github.com/ruby/ruby/pull/487)\]
+- freeze_string: true [[https://bugs.ruby-lang.org/issues/8976](https://bugs.ruby-lang.org/issues/8976)]
+- freeze_string_literal: true
+- frozen_string_literal: true [prefered by matz]
+- freezing_string_literal: true
+- mutable_string_literal: false
+- immutable: string [[https://github.com/ruby/ruby/pull/487](https://github.com/ruby/ruby/pull/487)]
 
 - command line option candidates
 

--- a/2015/DevMeeting-2015-10-21.md
+++ b/2015/DevMeeting-2015-10-21.md
@@ -41,9 +41,9 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 # Log
 
-# Decide whether -\*- should be required for frozen\_string\_literal magic comments [[Feature #8976]](https://bugs.ruby-lang.org/issues/8976)
+# Decide whether -\*- should be required for frozen_string_literal magic comments [[Feature #8976]](https://bugs.ruby-lang.org/issues/8976)
 
-naruse: vim’s indicator is “vim: …” [http://vim.wikia.com/wiki/Modeline\_magic](http://vim.wikia.com/wiki/Modeline_magic)
+naruse: vim’s indicator is “vim: …” [http://vim.wikia.com/wiki/Modeline_magic](http://vim.wikia.com/wiki/Modeline_magic)
 
 nobu: should be have an indicator of pragrma.
 
@@ -109,7 +109,7 @@ akr: …
 
 matz: I don’t like magic comment, so that I hesitate to introduce it.
 
-a\_matsuda: + and - seems string operation.  << -”foo” can be seen as a here document.
+a_matsuda: + and - seems string operation.  << -”foo” can be seen as a here document.
 
 matz: I understand.  + and - is not good idea.
 
@@ -129,7 +129,7 @@ ko1: this pragma is for experimental feature. if we decide to reject default fro
 
 matz: i will remain it.
 
-deep\_freeze
+deep_freeze
 
 → traversal framework?
 
@@ -137,7 +137,7 @@ inspect に引数を渡したい
 
 → inspect2? not clean.
 
-naruse: On 1.9 I tried to implement such logic, but I gave  up and use Encoding.default\_internal/Encoding.default\_external
+naruse: On 1.9 I tried to implement such logic, but I gave  up and use Encoding.default_internal/Encoding.default_external
 
 # .?
 
@@ -146,8 +146,8 @@ nobu: syntax fixed? there are 3 possibilities.
 obj.?foo =>
 
 1. obj != nil ? obj.foo : nil
-2. obj.respond\_to?(:foo) ? obj.foo : obj
-3. obj.respond\_to?(:foo) ? obj.foo : nil
+2. obj.respond_to?(:foo) ? obj.foo : obj
+3. obj.respond_to?(:foo) ? obj.foo : nil
 
 matz: 1.
 
@@ -159,7 +159,7 @@ akr: obj.&foo, obj.&&foo is proposed. how about it?
 
 matz: i can accept original proposal.
 
-\[ruby-core:70854\] \[Ruby trunk - Feature #11537\]
+[ruby-core:70854] [Ruby trunk - Feature #11537]
 
 # Misc
 
@@ -246,7 +246,7 @@ other ideas:
 
 str = ?’foo’
 
-str = !’foo’ -> bad idea (ex: str = !’foo’.start\_with(‘f’))
+str = !’foo’ -> bad idea (ex: str = !’foo’.start_with(‘f’))
 
 # [https://twitter.com/sferik/status/642063693304451072](https://twitter.com/sferik/status/642063693304451072)
 

--- a/2015/DevMeeting-2015-11-09.md
+++ b/2015/DevMeeting-2015-11-09.md
@@ -44,7 +44,7 @@ Attendees: matz, nobu, hsbt, akr, naruse, sorah, yuki, ko1
 
 2015/12/07 Mon 14:00 JST at SFDC
 
-## [[Feature #8976]](https://bugs.ruby-lang.org/issues/8976) file-scope freeze\_string directive
+## [[Feature #8976]](https://bugs.ruby-lang.org/issues/8976) file-scope freeze_string directive
 
 ## freeze dynamic string literal or not?
 
@@ -72,9 +72,9 @@ Attendees: matz, nobu, hsbt, akr, naruse, sorah, yuki, ko1
 - current implementation:
 
 - $ ./ruby --enable-frozen-string-literal -e 'p "" << "a"'
-    \-e:1:in \`<main>': can't modify frozen String (RuntimeError)
+    \-e:1:in `<main>': can't modify frozen String (RuntimeError)
 - $ ./ruby --enable-frozen-string-literal --enable-frozen-string-literal-debug -e 'p "" << "a"'
-    \-e:1:in \`<main>': can't modify frozen String, created at -e:1 (RuntimeError)
+    \-e:1:in `<main>': can't modify frozen String, created at -e:1 (RuntimeError)
 
 - How about enabling it by deafult? (ko1)
 
@@ -244,8 +244,8 @@ Matz: acceptable, but name is problem.
 Candidates:
 
 - dig
-- fetch\_in
-- assoc\_in (from Clojure): https://clojuredocs.org/clojure.core/assoc-in
+- fetch_in
+- assoc_in (from Clojure): https://clojuredocs.org/clojure.core/assoc-in
 
 Example:
 
@@ -253,11 +253,11 @@ h = {a: {b: {c: 1}}}
 
 h.dig(:a, :b, :c) #=> 1
 
-h.fetch\_in(:a, :b, :c) #=> 1
+h.fetch_in(:a, :b, :c) #=> 1
 
-Note that Matz doesn’t like &.\[\] (safe navigation operator with \[\]).
+Note that Matz doesn’t like &.[] (safe navigation operator with []).
 
-Nishijima-san mentioned past rejected proposals in Rails [\[1\]](https://groups.google.com/d/topic/rubyonrails-core/hww2nP8Zx4w/discussion) [\[2\]](https://twitter.com/a_matsuda/status/592849107762475009), they were rejected because such object in use cases should be wrapped with proper objects.
+Nishijima-san mentioned past rejected proposals in Rails [[1]](https://groups.google.com/d/topic/rubyonrails-core/hww2nP8Zx4w/discussion) [[2]](https://twitter.com/a_matsuda/status/592849107762475009), they were rejected because such object in use cases should be wrapped with proper objects.
 
 - pros
 
@@ -333,7 +333,7 @@ Matz accepted this feature. Pass to knu -san (maintainer).
 - ex) disabling future incompatibility warning is useful for production system.
 
 - disabling/catching warning in test is desireble
-- Rails has assert\_deprecated
+- Rails has assert_deprecated
 
 - cons
 
@@ -344,13 +344,13 @@ Matz accepted this feature. Pass to knu -san (maintainer).
 
 - no conclusion.
 
-## [[Feature #11653]](https://bugs.ruby-lang.org/issues/11653) Add to\_proc on Hash
+## [[Feature #11653]](https://bugs.ruby-lang.org/issues/11653) Add to_proc on Hash
 
 class Hash
 
- def to\_proc
+ def to_proc
 
- proc{|key| self\[key\]}
+ proc{|key| self[key]}
 
  end
 
@@ -362,11 +362,11 @@ h = {1 => 10,
 
  3 => 30}
 
-p \[1, 2, 3\].map(&h) #=> \[10, 20, 30\]
+p [1, 2, 3].map(&h) #=> [10, 20, 30]
 
 Matz: acceptable
 
-Matz: to\_proc is intended for & argument operator. So it is reasonable to add.
+Matz: to_proc is intended for & argument operator. So it is reasonable to add.
 
 ## [[Feature #10984]](https://bugs.ruby-lang.org/issues/10984) Hash#contain? to check whether hash contains other hash
 
@@ -380,9 +380,9 @@ Method name candidates:
 
 - sorah: Set class?
 
-- actual\_hash\_include?
-- hash\_include?
-- super\_hash?
+- actual_hash_include?
+- hash_include?
+- super_hash?
 - \=~
 - sub === h
 - h > sub, sub < h Perl6 way
@@ -397,11 +397,11 @@ Current status: naming issue, select and reject are acceptable for Matz.
 
 - select and reject return Enumerator when no block is given
 
-- so args = \[\]; {...}.select(\*args) returns an Enumerator object
+- so args = []; {...}.select(\*args) returns an Enumerator object
 
-- Akr proposed the methods that accept only one Array arg for this case, not va\_arg.
+- Akr proposed the methods that accept only one Array arg for this case, not va_arg.
 
-- {...}.select(\[:k1, :k2, :k3\])
-- Hash accepts Array as a key, we can’t distingush Array keys and argument for the method. So we can’t support both form (accepting va\_arg and Array argument)
+- {...}.select([:k1, :k2, :k3])
+- Hash accepts Array as a key, we can’t distingush Array keys and argument for the method. So we can’t support both form (accepting va_arg and Array argument)
 
 no conclusion yet

--- a/2016/DevMeeting-2016-01-18.md
+++ b/2016/DevMeeting-2016-01-18.md
@@ -70,7 +70,7 @@ Attendees: unak, mrkn, naruse, ayumin, ko1, sorah, zack, martin
 
 ## [[Feature #11949]](https://bugs.ruby-lang.org/issues/11949) Allow @/$ prefix in Regexp's named captures (naruse)
 
-/(?<[@timestamp](https://github.com/timestamp)\>\[^ \]\*): / =~
+/(?<[@timestamp](https://github.com/timestamp)\>[^ ]\*): / =~
 
 \>> /(?<@a>.)/ =~ 'x'
 
@@ -88,7 +88,7 @@ valid: > /(?<a@-あfoo>a)/.match("a")
 
  /(?<a@$b>.)/ =~ 'x'
 
- p \[$~.names, binding.local\_variables\] #=> \[\["a@$b"\], \[\]\]
+ p [$~.names, binding.local_variables] #=> [["a@$b"], []]
 
 }
 
@@ -96,7 +96,7 @@ valid: > /(?<a@-あfoo>a)/.match("a")
 
  /(?<ab>.)/ =~ 'x'
 
- p \[$~.names, binding.local\_variables\] #=> \[\["a@$b"\], \[:ab\]\]
+ p [$~.names, binding.local_variables] #=> [["a@$b"], [:ab]]
 
 }
 
@@ -114,7 +114,7 @@ valid: > /(?<a@-あfoo>a)/.match("a")
 
 Conclusion: acceptable confusion or not. Matz is positive to accept this feature
 
-## [[Feature #11987]](https://bugs.ruby-lang.org/issues/11987) daemons can't show the backtrace of rb\_bug
+## [[Feature #11987]](https://bugs.ruby-lang.org/issues/11987) daemons can't show the backtrace of rb_bug
 
 Process.daemon closes STDERR (or redirect to /dev/null).
 
@@ -253,21 +253,21 @@ Current: Don't download at all
 
 Ideal: Always check for updates (with If-Modified-Since); don't actually download data if nothing new
 
-Currently, there's a flag (ALWAYS\_UPDATE\_UNICODE = yes at common.mk: 1002) that needs to be manually changed to do 2) but has a comment suggesting 1). If that flag isn't activated, what happens is 5), but we need at least 4), and a reload when we change the version.
+Currently, there's a flag (ALWAYS_UPDATE_UNICODE = yes at common.mk: 1002) that needs to be manually changed to do 2) but has a comment suggesting 1). If that flag isn't activated, what happens is 5), but we need at least 4), and a reload when we change the version.
 
 Conclusion: Change to update whenever ‘make up’ is activated
 
 ## List each Unicode Data file only once
 
-Currently, each file is listed twice (UNICODE\_FILES at common.mk:1004 and ./.unicode-$(UNICODE\_VERSION).time at common.mk:1021); it would be great if this could be reduced to list each file only once.
+Currently, each file is listed twice (UNICODE_FILES at common.mk:1004 and ./.unicode-$(UNICODE_VERSION).time at common.mk:1021); it would be great if this could be reduced to list each file only once.
 
 Conclusion: Nobu to try to find a solution to avoid duplication, but not make it too complicated, please!
 
 # Use of Unicode in Source Files
 
-C source shouldn’t include non ASCII, because there may be some old compilers that bark on it (e.g. working in Shift\_JIS and thus barking on UTF-8 input).
+C source shouldn’t include non ASCII, because there may be some old compilers that bark on it (e.g. working in Shift_JIS and thus barking on UTF-8 input).
 
-lib/unicode\_normalize/tables.rb: is auto generated code; raw Unicode character is acceptable.
+lib/unicode_normalize/tables.rb: is auto generated code; raw Unicode character is acceptable.
 
 raw Unicode characters are also acceptable in test files
 

--- a/2016/DevMeeting-2016-02-16.md
+++ b/2016/DevMeeting-2016-02-16.md
@@ -65,7 +65,7 @@ Members: hsbt, akr, mrkn, shyouhei, naruse, nobu, ko1, sorah, matz (skype)
 - [https://github.com/etsy/hound](https://github.com/etsy/hound) is webapp which uses the algorithm same as [https://github.com/google/codesearch](https://github.com/google/codesearch).
 - What we need is a server with big (such as 1Tbytes) storage.
 
-## \[[Misc #12004](https://bugs.ruby-lang.org/issues/12004)\] CoC
+## [[Misc #12004](https://bugs.ruby-lang.org/issues/12004)] CoC
 
 - Matz does not want to include CoC in repository nor release tarball
 - Based on PostgreSQL’s CoC v2
@@ -101,7 +101,7 @@ Members: hsbt, akr, mrkn, shyouhei, naruse, nobu, ko1, sorah, matz (skype)
 
 GitHub: web [https://github.com/ruby/www.ruby-lang.org/issues](https://github.com/ruby/www.ruby-lang.org/issues)
 
-## [[Feature #11666]](https://bugs.ruby-lang.org/issues/11666) IPAddr#private? (glass\_saga)
+## [[Feature #11666]](https://bugs.ruby-lang.org/issues/11666) IPAddr#private? (glass_saga)
 
 - feature issues
 
@@ -116,9 +116,9 @@ GitHub: web [https://github.com/ruby/www.ruby-lang.org/issues](https://github.co
 
 - Naming differencies with Addrinfo
 
-- The name “ipv4\_private?” is clear that the method returns false on IPv6 addresses.
+- The name “ipv4_private?” is clear that the method returns false on IPv6 addresses.
 
-## [[Feature #12046]](https://bugs.ruby-lang.org/issues/12046) Allow attr\_reader :foo? to define instance method foo? for accessing @foo (mrkn)
+## [[Feature #12046]](https://bugs.ruby-lang.org/issues/12046) Allow attr_reader :foo? to define instance method foo? for accessing @foo (mrkn)
 
 - matz: Still negative; I’m not good to have difference in ivar name and method name
 - behavior issues:
@@ -133,12 +133,12 @@ Reported by ko1.
 
 ---
 
-## [[Feature #11999]](https://bugs.ruby-lang.org/issues/11999) MatchData#to\_h to get a Hash from named captures (sorah)
+## [[Feature #11999]](https://bugs.ruby-lang.org/issues/11999) MatchData#to_h to get a Hash from named captures (sorah)
 
-- #to\_h is inappropriate name while non-named capture exists
+- #to_h is inappropriate name while non-named capture exists
 
 - Return Hash with integer keys? ( {0 => "a", 1 => "b"} )
-- #named\_captures
+- #named_captures
 
 - matz: acceptable
 
@@ -147,7 +147,7 @@ Reported by ko1.
 - Return last matched value
 
 - reg = /(?<a>b)|(?<a>x)/ \# => /(?<a>b)|(?<a>x)/
-    reg.match("abc").to\_h #=> {"a" => "b"}
+    reg.match("abc").to_h #=> {"a" => "b"}
 
 - Behavior when named captures didn’t match anything
 
@@ -155,7 +155,7 @@ Reported by ko1.
 
 - Behavior when no named captures
 
-- #captures return \[\] when no capture, so #named\_captures returns {} when no named capture
+- #captures return [] when no capture, so #named_captures returns {} when no named capture
 
 ## [[Bug #9810]](https://bugs.ruby-lang.org/issues/9810) Numeric#step behavior with mixed Float, String arguments inconsistent with documentation
 
@@ -175,7 +175,7 @@ $ ruby -e 'def foo;return :a=>1; end'
 
 $ ruby -e 'def foo;return a: 1; end'
 
-\-e:1: syntax error, unexpected ':', expecting keyword\_end
+\-e:1: syntax error, unexpected ':', expecting keyword_end
 
 def foo;return a: 1; end
 
@@ -185,14 +185,14 @@ matz rejected it because return is not a method call.  Matz wants to split kwar
 
 ## [[Feature #10121]](https://bugs.ruby-lang.org/issues/10121) Dir.empty?
 
-- \`Dir.entries(dir).size == 2\` is not efficient.  Also not platform-agnostic.
+- `Dir.entries(dir).size == 2` is not efficient.  Also not platform-agnostic.
 - It is useful to write spec which checkes test files are crrectly cleaned.
 - matz: accepted.
 
 ## [[Feature #12075]](https://bugs.ruby-lang.org/issues/12075) some container#nonempty?
 
-- nobu: you can write \`ary&.empty?.!\`.
-- mrkn: How about \`ary.include\_something?\` ?
+- nobu: you can write `ary&.empty?.!`.
+- mrkn: How about `ary.include_something?` ?
 
 ## [[Feature #12024]](https://bugs.ruby-lang.org/issues/12024) Add String.buffer, for creating strings with large capacities
 
@@ -204,12 +204,12 @@ matz: accepted.
 
 ## [[Bug #11991]](https://bugs.ruby-lang.org/issues/11991) Symbol#match
 
-## [[Feature #12043]](https://bugs.ruby-lang.org/issues/12043) NoMethodError#private\_call?
+## [[Feature #12043]](https://bugs.ruby-lang.org/issues/12043) NoMethodError#private_call?
 
 bikeshed problem (naming issue).
 
-- private\_call?
-- private\_callable?
-- were\_you\_private?
-- funcall\_style\_call?
+- private_call?
+- private_callable?
+- were_you_private?
+- funcall_style_call?
 - …

--- a/2016/DevMeeting-2016-03-16.md
+++ b/2016/DevMeeting-2016-03-16.md
@@ -78,7 +78,7 @@ Attendees: Matz, ko1, nobu, akr, naruse, mrkn, shyouhei, sorah, martin, hsbt
 
 2016/04/13 13:00 @ Money Forward
 
-## \[[#10098](https://bugs.ruby-lang.org/issues/10098)\] Timing-safe string comparison for OpenSSL::HMAC (naruse)
+## [[#10098](https://bugs.ruby-lang.org/issues/10098)] Timing-safe string comparison for OpenSSL::HMAC (naruse)
 
 - (n0kada) name not fixed.
 - Rack implements this in pure-ruby
@@ -93,10 +93,10 @@ Attendees: Matz, ko1, nobu, akr, naruse, mrkn, shyouhei, sorah, martin, hsbt
 
 - Does OpenSSL has this feature?
 
-- Yes.  There is CRYPTO\_memcmp.
+- Yes.  There is CRYPTO_memcmp.
 - Why not just export this to ruby?
 
-- naruse: How about OpenSSL.foo\_bar() ?
+- naruse: How about OpenSSL.foo_bar() ?
 
 - OpenSSL.memcmp() ?
 
@@ -145,7 +145,7 @@ github.com/k-takata/Onigmo
 
 - Titlecase and String#swapcase
 
-- In unicode there is a special case called titlecase cf [http://unicode.org/faq/casemap\_charprop.html#4](http://unicode.org/faq/casemap_charprop.html#4)
+- In unicode there is a special case called titlecase cf [http://unicode.org/faq/casemap_charprop.html#4](http://unicode.org/faq/casemap_charprop.html#4)
 - How should swapcase behave?
 - Or, how should swapcase behave in general?
 - Other languages:
@@ -224,7 +224,7 @@ github.com/k-takata/Onigmo
 - (usa): Will C API be changed?
 
 1. Expected to keep compatibility as far as we can.
-2. For example rb\_fix\_hoge, and LONG2FIX.
+2. For example rb_fix_hoge, and LONG2FIX.
 
 - Proposed migration process
 
@@ -238,7 +238,7 @@ github.com/k-takata/Onigmo
 - Codesearch is done using rubygems-mirror
 - 500GB storage, memory unknown
 
-## \[ruby-core:74355\] Ruby+OMR: how should we proceed?
+## [ruby-core:74355] Ruby+OMR: how should we proceed?
 
 - Thanks a lot for contacting us.
 - Normal pull-request is the ideal way.
@@ -263,15 +263,15 @@ github.com/k-takata/Onigmo
 ## [[Feature #12172]](https://bugs.ruby-lang.org/issues/12172) Array#max and Array#min (mame)
 
 - Nobody is against Array#max
-- (shyouhei): Why only opt\_newarray\_max?
+- (shyouhei): Why only opt_newarray_max?
 
 - (mame) When Array include another module which redefines max/min, current implementation can’t detect it.
-- (mame) opt\_newarray\_max is only for literal.
+- (mame) opt_newarray_max is only for literal.
 
-- Nobody except ko1 is against opt\_newarray\_max
+- Nobody except ko1 is against opt_newarray_max
 
 - Koichi afraids that increase VM complexity and other people want to add other methods.
-- However, \[...\].min or .max are used CPU intensive cases. So that it is acceptable. If other techniques are invented, then Koichi will remove them.
+- However, [...].min or .max are used CPU intensive cases. So that it is acceptable. If other techniques are invented, then Koichi will remove them.
 
 ## [[Feature #9969]](https://bugs.ruby-lang.org/issues/9969) Add File.empty? as alias to File.zero? (shyouhei)
 
@@ -280,7 +280,7 @@ github.com/k-takata/Onigmo
 
 ## [[Bug #12121]](https://bugs.ruby-lang.org/issues/12121)異なる名前空間にある同名の定数により Module.constants の結果の並びが変わる (shyouhei)
 
-- The reason behind this is we introduced id\_table, which does not preserve order.
+- The reason behind this is we introduced id_table, which does not preserve order.
 - We did not, and do not want to, warrant such thing.
 - This is a doc issue.
 
@@ -296,7 +296,7 @@ github.com/k-takata/Onigmo
 
 - Assign to knu
 
-## [[Bug #12126]](https://bugs.ruby-lang.org/issues/12126) \[PATCH\] openssl: accept moving write buffer for write\_nonblock (shyouhei)
+## [[Bug #12126]](https://bugs.ruby-lang.org/issues/12126) [PATCH] openssl: accept moving write buffer for write_nonblock (shyouhei)
 
 - Seems ok
 
@@ -310,7 +310,7 @@ github.com/k-takata/Onigmo
 
 ## [[Feature #12096]](https://bugs.ruby-lang.org/issues/12096) New notation for instance variables and class variables (shyouhei)
 
-- This is metaprogramming.  And having a metaprogramming in syntax is \`\`wrong’’.
+- This is metaprogramming.  And having a metaprogramming in syntax is ``wrong’’.
 - Being able to write identical variable in different form is problematic (both for users and editors)
 
 ## [[Bug #12104]](https://bugs.ruby-lang.org/issues/12104) Procs keyword arguments affect value of previous argument (shyouhei)
@@ -329,7 +329,7 @@ github.com/k-takata/Onigmo
 
 Good example.
 
-## [[Feature #12119]](https://bugs.ruby-lang.org/issues/12119) next\_prime for lib/prime.rb (shyouhei)
+## [[Feature #12119]](https://bugs.ruby-lang.org/issues/12119) next_prime for lib/prime.rb (shyouhei)
 
 - Assign to yugui.
 
@@ -347,7 +347,7 @@ Good example.
 - (naruse) Current patch fails CI.
 - Generally ok, but it must works with nmake.
 
-## [[Bug #12139]](https://bugs.ruby-lang.org/issues/12139) return OpenSSL::Random.random\_bytes(n) call takes to long. OpenSSL:: bug on windows. (naruse)
+## [[Bug #12139]](https://bugs.ruby-lang.org/issues/12139) return OpenSSL::Random.random_bytes(n) call takes to long. OpenSSL:: bug on windows. (naruse)
 
-- (naruse) How about using Random.naw\_seed on Windows
+- (naruse) How about using Random.naw_seed on Windows
 - (akr) ok while it doesn’t cost too much entropy.

--- a/2016/DevMeeting-2016-04-13.md
+++ b/2016/DevMeeting-2016-04-13.md
@@ -90,7 +90,7 @@ venue: TBD
 - example: [http://www.atdot.net/~ko1/diary/201502.html#d16](http://www.atdot.net/~ko1/diary/201502.html#d16)
 
 - naruse: I doubt the reporter’s true working code is
-    a, b = some\_method\_returning\_array\_or\_nil
+    a, b = some_method_returning_array_or_nil
     if a || b
     \# method returned an array (possibly empty)
     else
@@ -114,9 +114,9 @@ venue: TBD
 - assign to knu-san
 - naruse: mentioned to knu
 
-## [[Feature #6647]](https://bugs.ruby-lang.org/issues/6647) Exceptions raised in threads should be logged, Thread#report\_on\_exception= (eregon) Can we agree on the feature?
+## [[Feature #6647]](https://bugs.ruby-lang.org/issues/6647) Exceptions raised in threads should be logged, Thread#report_on_exception= (eregon) Can we agree on the feature?
 
-Matz is positive to provide Thread#report\_on\_exception, but negative to turning it on by default.
+Matz is positive to provide Thread#report_on_exception, but negative to turning it on by default.
 
 ## [[Feature #12026]](https://bugs.ruby-lang.org/issues/12026) Support warning processor
 
@@ -132,10 +132,10 @@ Matz is positive to provide Thread#report\_on\_exception, but negative to turnin
 - matz: Adding Array#sum is ok
 - Revert r54237 and optimization for Float
 
-## [[Bug #12271]](https://bugs.ruby-lang.org/issues/12271) Time#to\_time removes timezone information
+## [[Bug #12271]](https://bugs.ruby-lang.org/issues/12271) Time#to_time removes timezone information
 
 - nobu: It is a bug, so I commited
-- yui\_knk: ActiveSupport was testing this behavior (FYI)
+- yui_knk: ActiveSupport was testing this behavior (FYI)
 
 ## [[Feature #12157]](https://bugs.ruby-lang.org/issues/12157) Is the option hash necessary for future Rubys?
 
@@ -154,7 +154,7 @@ Matz is positive to provide Thread#report\_on\_exception, but negative to turnin
 
 - Assigned to appropriate maintainer.
 
-## [[Bug #12184]](https://bugs.ruby-lang.org/issues/12184) Cygwin LANG=ja\_JP.SJIS 環境でコマンドライン引数に日本語が渡せない
+## [[Bug #12184]](https://bugs.ruby-lang.org/issues/12184) Cygwin LANG=ja_JP.SJIS 環境でコマンドライン引数に日本語が渡せない
 
 - nobu: Cygwin only supports UTF-8
 - nobu(?) will reply something
@@ -181,6 +181,6 @@ Matz is positive to provide Thread#report\_on\_exception, but negative to turnin
 - note that @sorah is also a w.r-l.o editorial.
 - next action: @sorah will continue setting up.
 
-\[FYI\] Cookpad’s styleguide of the number of characters in a line:
+[FYI] Cookpad’s styleguide of the number of characters in a line:
 
 [https://github.com/cookpad/styleguide/blob/master/ruby.ja.md#line-columns](https://github.com/cookpad/styleguide/blob/master/ruby.ja.md#line-columns)

--- a/2016/DevMeeting-2016-05-17.md
+++ b/2016/DevMeeting-2016-05-17.md
@@ -121,7 +121,7 @@ Milestones
 - (Martin) I support it.
 - next action?
 
-- Matz needs a ChangeLog because he wants to look at commit log in file, not by svn log (because \`svn log\` needs internet).  But it’s OK for him to auto-generate.
+- Matz needs a ChangeLog because he wants to look at commit log in file, not by svn log (because `svn log` needs internet).  But it’s OK for him to auto-generate.
 - ChangeLog is needed as long as we stick to svn.
 - (conclusion) lets auto-generate ChangeLog, like we do in version.h.
 - nobu and naruse will look at it.
@@ -132,7 +132,7 @@ Milestones
 
 ## [[Feature #6647]](https://bugs.ruby-lang.org/issues/6647) Exceptions raised in threads should be logged (shyouhei) what was the reason against defaulting true?
 
-- Thread\[.#\]report\_on\_exception= is accepted
+- Thread[.#]report_on_exception= is accepted
 - Matz does not want this default true, because it breaks current situations where programmer expects dead threads to silently exit.
 - what happens on join?
 
@@ -180,7 +180,7 @@ Milestones
 
 - matz: example seems illustrative.  any real-world use-case?
 
-## [[Bug #4388]](https://bugs.ruby-lang.org/issues/4388) open-uriで環境変数http\_proxyを使うときに認証付きのProxyが使えません
+## [[Bug #4388]](https://bugs.ruby-lang.org/issues/4388) open-uriで環境変数http_proxyを使うときに認証付きのProxyが使えません
 
 - akr: hsbt already introduced this at r54432.
 - lets ask if trunk is ok.
@@ -207,7 +207,7 @@ Milestones
 
 - convenient, but is #create an appropriate name?
 - no one is against? (except naming)
-- nobu: Hash#to\_struct(klass)
+- nobu: Hash#to_struct(klass)
 - create! doesnt follow naming convention.
 
 ## [[Feature #6739]](https://bugs.ruby-lang.org/issues/6739) One-line rescue statement should support specifying an exception class
@@ -280,10 +280,10 @@ Milestones
 
 ## [[Feature #12357]](https://bugs.ruby-lang.org/issues/12357) Random#initialize with a String (nobu)
 
-- akr: you can pass bignum to Random.new\_seed
+- akr: you can pass bignum to Random.new_seed
 - naruse: bignum is not useful when people port code from different languages e.g. python
 - akr: array of integers must be more “appropriate” than binary string.
-- nobu: I want to pass Random.raw\_seed to it
+- nobu: I want to pass Random.raw_seed to it
 - akr: why? no need seems there be. 128 bits should be sufficient.
 - naruse: Linux’s urandom (or getrandom) manual says that.
 
@@ -301,6 +301,6 @@ Milestones
 - mrkn: difficult to use in SQL becasue it breaks spaces inside string literals.
 - ko1: can be useful than #rjust.
 - akr: this can be as strange as Unicode-aware strip
-- nobu: how about extending #tr\_s so that it accepts arbitrary character class?
+- nobu: how about extending #tr_s so that it accepts arbitrary character class?
 - shyouhei: how about #strip that accepts regexp? -> NG, squish is not a strip.
 - akr: is this worth providing in-core?

--- a/2016/DevMeeting-2016-06-13.md
+++ b/2016/DevMeeting-2016-06-13.md
@@ -135,10 +135,10 @@ matz: acceptable
 
 nobu: this patch requires some tests, and fixes.
 
-- ar = \[1\]; ar.concat(ar, ar) #=> \[1,1,1\]? or \[1,1,1,1\]?
+- ar = [1]; ar.concat(ar, ar) #=> [1,1,1]? or [1,1,1,1]?
 
-- mrkn: we can make \[1, 1, 1, 1\] with a.concat(ar).concat(ar)
-- Matz: Maybe programer may get \[1, 1, 1\]. So use it.
+- mrkn: we can make [1, 1, 1, 1] with a.concat(ar).concat(ar)
+- Matz: Maybe programer may get [1, 1, 1]. So use it.
 
 - see https://bugs.ruby-lang.org/projects/ruby/wiki/DeveloperHowto
 
@@ -146,21 +146,21 @@ nobu: this patch requires some tests, and fixes.
 
 What’s happen?
 
-ary = \[:a, :b, :c, :d, :e\]
+ary = [:a, :b, :c, :d, :e]
 
 ary.delete(:a, :f, :c) #=> ???
 
-\# (1) \[:a, :c\]
+\# (1) [:a, :c]
 
-\# (2) \[:a, nil, :c\]
+\# (2) [:a, nil, :c]
 
 - ko1: who requires return value (array)?
-- sora\_h: With (2), we can use a return value with multiple assignment
+- sora_h: With (2), we can use a return value with multiple assignment
 
 - x, y, z = ary.delete(:a, :f, :c)
 - Especially for Hash#delete (this is out of scope, but we should consier consistency)
 
-## [[Bug #12295]](https://bugs.ruby-lang.org/issues/12295) Ripper not emitting on\_parse\_error for global variable name syntax errors (shyouhei) is this the right design?
+## [[Bug #12295]](https://bugs.ruby-lang.org/issues/12295) Ripper not emitting on_parse_error for global variable name syntax errors (shyouhei) is this the right design?
 
 Assigned to Minero Aoki.
 
@@ -173,7 +173,7 @@ Assigned to Minero Aoki.
 
 Assigned to shugo.
 
-## \[Feature #12086\] using: option for instance\_eval etc.
+## \[Feature #12086\] using: option for instance_eval etc.
 
 Motivation is replace self and using context.
 
@@ -185,13 +185,13 @@ Matz will comment it.
 
 - Q. Endian? #=> Little endian
 - Q. how about negative integers? #=> Math::DomainError
-- Q. how about 0? #=> \[0\] or \[\] #=> \[0\]
+- Q. how about 0? #=> [0] or [] #=> [0]
 
 matz: i’m not sure how it is convinience. but ok.
 
 ## [[Feature #12299]](https://bugs.ruby-lang.org/issues/12299) Add Warning module for customized warning handling (jeremyevans)
 
-naruse: it sounds useful with Gem.loaded\_specs\[ gem\_name \].full\_gem\_path.
+naruse: it sounds useful with Gem.loaded_specs[ gem_name ].full_gem_path.
 
 matz: ok (except naming).
 
@@ -201,7 +201,7 @@ h[ttps://bugs.ruby-lang.org/projects/ruby-trunk/wiki/SupportedPlatforms](https:/
 
 ## [[Feature #12460]](https://bugs.ruby-lang.org/issues/12460) Make Unicode Version directly available in Ruby (duerst)
 
-Approved; name as proposed by Nobu: RbConfig::CONFIG\['UNICODE\_VERSION'\]; implementation: Nobu or Martin.
+Approved; name as proposed by Nobu: RbConfig::CONFIG['UNICODE_VERSION']; implementation: Nobu or Martin.
 
 # Non-ASCII in rdoc comments in C source (duerst)
 
@@ -209,8 +209,8 @@ See [https://github.com/rdoc/rdoc/issues/409](https://github.com/rdoc/rdoc/issue
 
 ## [[Bug #12427]](https://bugs.ruby-lang.org/issues/12427) the way that extension libraries know if Integer is integrated (nobu)
 
-Nobu prepared a patch to show warning for rb\_cFixnum and rb\_cBignum, so developers can recognize this change. However, there are risks to compile broken code (assume passed parameters are Fixnum, but passed BIgnums. In this case, it is difficult to check Fixnum asusmed methods because Bignum may be rare to use, in general).
+Nobu prepared a patch to show warning for rb_cFixnum and rb_cBignum, so developers can recognize this change. However, there are risks to compile broken code (assume passed parameters are Fixnum, but passed BIgnums. In this case, it is difficult to check Fixnum asusmed methods because Bignum may be rare to use, in general).
 
-We can recognize this change with removing rb\_cFixnum and rb\_cBignum, but there are several gems causing compile errors.
+We can recognize this change with removing rb_cFixnum and rb_cBignum, but there are several gems causing compile errors.
 
-→ try to remove rb\_cFixnum, rb\_cBignum at Ruby 2.4  preview 1 to check people’s responses
+→ try to remove rb_cFixnum, rb_cBignum at Ruby 2.4  preview 1 to check people’s responses

--- a/2016/DevMeeting-2016-07-19.md
+++ b/2016/DevMeeting-2016-07-19.md
@@ -168,10 +168,10 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - akr: this one is preferrable over [#12092](https://bugs.ruby-lang.org/issues/12092)
 - matz: sounds reasonable.
 
-- [[Feature #11090]](https://bugs.ruby-lang.org/issues/11090) Enumerable#each\_uniq and #each\_uniq\_by (shyouhei)
+- [[Feature #11090]](https://bugs.ruby-lang.org/issues/11090) Enumerable#each_uniq and #each_uniq_by (shyouhei)
 
 - akr: the definition of uniq is not clear here.
-- Martin: where is the difference between each\_uniq and each.uniq ?
+- Martin: where is the difference between each_uniq and each.uniq ?
 - mrkn: Enumerable has no #uniq now.  Isn’t this a problem?
 - matz: Enumerable#uniq sounds reasonable, also Lasy#uniq.
 
@@ -187,7 +187,7 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - shyouhei: is this a bug?
 - matz: yes.
 
-- [[Feature #12138]](https://bugs.ruby-lang.org/issues/12138) Support Kernel#load\_with\_env (shyouhei)
+- [[Feature #12138]](https://bugs.ruby-lang.org/issues/12138) Support Kernel#load_with_env (shyouhei)
 
 - shyouhei: I understand the needs of such feature, but not this name.
 - ko1: maybe the OP wants C’s #include<...> like token pasting?
@@ -226,7 +226,7 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 
 - [[Feature #3187]](https://bugs.ruby-lang.org/issues/3187) Allow dynamic Fiber stack size (shyouhei)
 
-- ko1: it seems they implemented Thread.new(stack\_size: nnn)
+- ko1: it seems they implemented Thread.new(stack_size: nnn)
 - matz: but it’s Fiber.
 - ko1: yes but Fiber and Thread are API-compatible now.  Should we break it?
 - matz: I prefer Rubinius way (Fiber.new to eat the kwarg).
@@ -241,7 +241,7 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - matz: I can accept tail call as transparent optimization but should we encourage such thing?
 - Martin: is there any language where one have to explicitly state “this is a tail call”?
 
-- [[Feature #11813]](https://bugs.ruby-lang.org/issues/11813) Extend safe navigation operator for \[\] and \[\]= with syntax sugar (shyouhei)
+- [[Feature #11813]](https://bugs.ruby-lang.org/issues/11813) Extend safe navigation operator for [] and []= with syntax sugar (shyouhei)
 
 - rejected
 
@@ -253,7 +253,7 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - [[Feature #12481]](https://bugs.ruby-lang.org/issues/12481) Add Array#view to allow opt-in copy-on-write sharing of Array contents (shyouhei)
 
 - matz: why Array.new(0) then view?  Why not ary1.view…
-- nurse: possible use case might be Array#each\_cons(3) and such.
+- nurse: possible use case might be Array#each_cons(3) and such.
 - akr: one can implement this on top of #replace
 - matz: what use case?
 - nobu: should this be mutatable?
@@ -262,11 +262,11 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - [[Feature #12057]](https://bugs.ruby-lang.org/issues/12057) Allow methods with yield to be called without a block (shyouhei)
 
 - akr: we already have Enumerator.
-- akr: maybe this is automation of enum\_for(\_\_method\_\_) unless block\_given?
+- akr: maybe this is automation of enum_for(__method__) unless block_given?
 
 - [[Feature #12297]](https://bugs.ruby-lang.org/issues/12297) Ruby stdlib date can parse non-existent date with year 0 (shyouhei)
 
-- Wasn't this intentional? cf [https://en.wikipedia.org/wiki/0\_(year)](https://en.wikipedia.org/wiki/0_(year))
+- Wasn't this intentional? cf [https://en.wikipedia.org/wiki/0_(year)](https://en.wikipedia.org/wiki/0_(year))
 - [http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/10241](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-dev/10241)
 
 - [[Feature #12461]](https://bugs.ruby-lang.org/issues/12461) Hash & keys to make subset. (shyouhei)
@@ -278,21 +278,21 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - hmm…
 - akr: what’s useful with this?
 
-- [[Feature #12512]](https://bugs.ruby-lang.org/issues/12512) Import Hash#transform\_values and its destructive version from ActiveSupport (shyouhei, mrkn)
+- [[Feature #12512]](https://bugs.ruby-lang.org/issues/12512) Import Hash#transform_values and its destructive version from ActiveSupport (shyouhei, mrkn)
 
 - shyouhei: no one is against the feature itself but name.
 - akr: should this yield what? → it seems values only.
 - mrkn: I’d like to have both key and value
-- akr: it seems the usage being hash.transform\_values(&:to\_s) or such, on such assumption value-only usage seems reasonable.
+- akr: it seems the usage being hash.transform_values(&:to_s) or such, on such assumption value-only usage seems reasonable.
 - matz: the naming doesn’t charm me.
-- akr: what about #map\_v?
+- akr: what about #map_v?
 
-- [[Feature #10208]](https://bugs.ruby-lang.org/issues/10208) Passing block to Enumerable#to\_h (shyouhei)
+- [[Feature #10208]](https://bugs.ruby-lang.org/issues/10208) Passing block to Enumerable#to_h (shyouhei)
 
 - matz: I don’t like the name.
-- shyouhei: knu proposes #to\_h again.
-- nobu: there is no other to\_\* method that takes a block.
-- ko1: what about collect\_\*?
+- shyouhei: knu proposes #to_h again.
+- nobu: there is no other to_\* method that takes a block.
+- ko1: what about collect_\*?
 - matz: collect implies Array because it collects something.
 
 - [[Feature #11741]](https://bugs.ruby-lang.org/issues/11741) Migrate Ruby to Git from Subversion (shyouhei) Situation?
@@ -315,17 +315,17 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - Matz: we can do nothing to it.  This is a matter of Unicode consortium versus POSIX group.
 - cf: [http://pubs.opengroup.org/onlinepubs/9699919799/functions/ispunct.html](http://pubs.opengroup.org/onlinepubs/9699919799/functions/ispunct.html)
 
-- [[Feature #12546]](https://bugs.ruby-lang.org/issues/12546) Remove UnicodeNormalize::UNICODE\_VERSION (duerst)
+- [[Feature #12546]](https://bugs.ruby-lang.org/issues/12546) Remove UnicodeNormalize::UNICODE_VERSION (duerst)
 
 - Matz: OK.
 
-- [[Bug #12547]](https://bugs.ruby-lang.org/issues/12547) Remove ONIG\_UNICODE\_VERSION\_... in enc/unicode/case-folding.rb, casefold.h (duerst)
+- [[Bug #12547]](https://bugs.ruby-lang.org/issues/12547) Remove ONIG_UNICODE_VERSION_... in enc/unicode/case-folding.rb, casefold.h (duerst)
 
 - Martin: why is it?
 - nobu: I’d like to check unicode version of each generated file.
 - akr: I don’t understand.
 - Martin: why the C constant everywhere?
-- nobu: we should check in-core Unicode version in enc/unicode.o and lib/unicode\_normalize propagated from common.mk (or command line) each other.
+- nobu: we should check in-core Unicode version in enc/unicode.o and lib/unicode_normalize propagated from common.mk (or command line) each other.
 
 - [[Bug #12597]](https://bugs.ruby-lang.org/issues/12597) Produce test failure if some tests cannot be executed due to lacking data (duerst)
 
@@ -333,7 +333,7 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 - akr: skip is silently discarded so not helpful.
 - nobu: false. skip says something when it has message argument.
 
-- [[Feature #12386]](https://bugs.ruby-lang.org/issues/12386) Move definition of ONIG\_CASE\_MAPPING compilation switch outside onigumo files (duerst)
+- [[Feature #12386]](https://bugs.ruby-lang.org/issues/12386) Move definition of ONIG_CASE_MAPPING compilation switch outside onigumo files (duerst)
 
 - Martin: I’d like to ask nobu where is a proper place to define this macro.
 - naruse: you can simply delete this #ifdef.  This part is ruby-specitic.
@@ -350,7 +350,7 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 
 ## From non-attendees
 
-- [[Feature #12086]](https://bugs.ruby-lang.org/issues/12086) using: option for instance\_eval etc. (shugo)
+- [[Feature #12086]](https://bugs.ruby-lang.org/issues/12086) using: option for instance_eval etc. (shugo)
 
 - Can I commit it?
 - matz: Charles Nutter must be consulted before committing this.
@@ -358,5 +358,5 @@ attendees: shyouhei, hsbt, matz, yuki24, nobu, mrkn, akr, ko1
 ## Rope progress (ko1)
 
 - merged to String
-- [https://github.com/spinute/ruby/commits/implement\_ropestring](https://github.com/spinute/ruby/commits/implement_ropestring)
+- [https://github.com/spinute/ruby/commits/implement_ropestring](https://github.com/spinute/ruby/commits/implement_ropestring)
 - better than String#+, comparable to String#concat

--- a/2016/DevMeeting-2016-08-09.md
+++ b/2016/DevMeeting-2016-08-09.md
@@ -155,7 +155,7 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - nobu: it is interpreted as “(var1 = Date.parse var1) rescue nil”
 - mrkn: in which way should we fix this, if we consider this as a bug?
 - Matz: Smells like a bug to me.
-- nobu: What happens when you combine rescue\_mod with massign?
+- nobu: What happens when you combine rescue_mod with massign?
 - assigning to nobu.
 
 - [[Bug #12489]](https://bugs.ruby-lang.org/issues/12489) hppa problems on Debian GNU/Linux (shyouhei) who to look at it?
@@ -173,13 +173,13 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - naruse: negative.  shadowing itself is a bad idea and should be warned.
 - Matz: reject.
 
-- [[Feature #3511]](https://bugs.ruby-lang.org/issues/3511) rb\_path\_to\_class should call custom const\_defined? methods (shyouhei)
+- [[Feature #3511]](https://bugs.ruby-lang.org/issues/3511) rb_path_to_class should call custom const_defined? methods (shyouhei)
 
 - akr: this is dangerous to implement.
 - ko1: is this backward compatible? akr: it seems.
 - Matz: It seems it hurts than it gains.
 
-- [[Feature #12508]](https://bugs.ruby-lang.org/issues/12508) Integer#mod\_pow(shyouhei)
+- [[Feature #12508]](https://bugs.ruby-lang.org/issues/12508) Integer#mod_pow(shyouhei)
 
 - Matz: 2-argument version of pow is seen in other language (e.g. python)
 - akr: there is no pow method in Ruby sadly
@@ -195,7 +195,7 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 
 - Matz: what’s good with it?  compared to taking everything with \*\*arg.
 
-- [[Feature #11195]](https://bugs.ruby-lang.org/issues/11195) Add "no\_proxy" parameter to Net::HTTP.new (shyouhei)
+- [[Feature #11195]](https://bugs.ruby-lang.org/issues/11195) Add "no_proxy" parameter to Net::HTTP.new (shyouhei)
 
 - shyouhei: would like to assign this to someone.
 - akr: what about requesting a patch
@@ -207,8 +207,8 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - [[Feature #12586]](https://bugs.ruby-lang.org/issues/12586) Hash#sample (shyouhei)
 
 - mrkn: use case?
-- naruse: doesn’t hash\[hash.keys.sample\] make sense?
-- mrkn: I want to see a real-world use case.  Is there a need of to\_h?
+- naruse: doesn’t hash[hash.keys.sample] make sense?
+- mrkn: I want to see a real-world use case.  Is there a need of to_h?
 
 - [[Feature #12553]](https://bugs.ruby-lang.org/issues/12553) IO.readlines(filename, chomp: true) (shyouhei)
 
@@ -216,7 +216,7 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - mrkn: readlines itself takes argument to reflect $/
 - naruse: chomp should work the same way like #chomp
 - Matz: which methods are affected?
-- naruse: IO.readlines, IO.foreach, IO#each\_line
+- naruse: IO.readlines, IO.foreach, IO#each_line
 - Matz: accept for those three
 
 - [[Bug #12548]](https://bugs.ruby-lang.org/issues/12548) Rounding modes inconsistency between round versus sprintf (shyouhei) maybe round(mode: "even") or something like that?
@@ -243,8 +243,8 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 
 - Matz: accept.
 
-- [[Feature #3511]](https://bugs.ruby-lang.org/issues/3511) rb\_path\_to\_class should call custom const\_defined? methods (shyouhei)
-- [[Feature #10098]](https://bugs.ruby-lang.org/issues/10098) \[PATCH\] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
+- [[Feature #3511]](https://bugs.ruby-lang.org/issues/3511) rb_path_to_class should call custom const_defined? methods (shyouhei)
+- [[Feature #10098]](https://bugs.ruby-lang.org/issues/10098) [PATCH] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
 - [[Feature #12591]](https://bugs.ruby-lang.org/issues/12591) Allow ruby to either catch misspelled "ailas" statements or, possibly more accurately, be more specific in what it reports as an error to the end-user (shyouhei)
 - [[Feature #12594]](https://bugs.ruby-lang.org/issues/12594) The class does not inherit from a module the modules that were included after the inclusion (shyouhei)
 - [[Feature #12596]](https://bugs.ruby-lang.org/issues/12596) Add Pathname#empty? to be consistent with Dir.empty? and File.empty? (shyouhei)
@@ -252,7 +252,7 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 
 - matz wil respond
 
-- [[Feature #12602]](https://bugs.ruby-lang.org/issues/12602) Add NilClass#to\_d (shyouhei)
+- [[Feature #12602]](https://bugs.ruby-lang.org/issues/12602) Add NilClass#to_d (shyouhei)
 - [[Feature #12607]](https://bugs.ruby-lang.org/issues/12607) Ruby needs an atomic integer (shyouhei)
 - [[Feature #12608]](https://bugs.ruby-lang.org/issues/12608) Proposal to replace unless in Ruby (shyouhei)
 
@@ -276,32 +276,32 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 - [[Feature #12374]](https://bugs.ruby-lang.org/issues/12374) SingletonClass (sawa)
 
 - ko1: this is GoF’s singleton pattern.
-- sawa: I want to have a reverse of Object#singleton\_class
+- sawa: I want to have a reverse of Object#singleton_class
 - akr: what use case?
-- Matz: this is technically possible, but what poupose?  There is singleton\_class?
+- Matz: this is technically possible, but what poupose?  There is singleton_class?
 
 - [[Feature #9704]](https://bugs.ruby-lang.org/issues/9704) Refinements as files instead of modules (shyouhei)
 - [[Feature #12637]](https://bugs.ruby-lang.org/issues/12637) Unified and consistent method naming for safe and dangerous methods (shyouhei)
-- [[Feature #8643]](https://bugs.ruby-lang.org/issues/8643) Add Binding.from\_hash (shyouhei)
+- [[Feature #8643]](https://bugs.ruby-lang.org/issues/8643) Add Binding.from_hash (shyouhei)
 - [[Feature #12650]](https://bugs.ruby-lang.org/issues/12650) Use UTF-8 encoding for ENV on Windows (shyouhei)
-- [[Feature #12648]](https://bugs.ruby-lang.org/issues/12648) Enumerable#sort\_by with descending option (shyouhei)
+- [[Feature #12648]](https://bugs.ruby-lang.org/issues/12648) Enumerable#sort_by with descending option (shyouhei)
 
-- akr: sort\_by with multiple arguments is odd.
+- akr: sort_by with multiple arguments is odd.
 - shyouhei: I sometimes need secondary sort key
 - Matz: I think such complex sort shall be another method.
-- akr: I think sort\_by with descending option is okay
-- naruse: isn’t reverse\_sort\_by OK?
+- akr: I think sort_by with descending option is okay
+- naruse: isn’t reverse_sort_by OK?
 - Matz: I understand the needs of reverse sort.
-- sawa: I can settle with sort\_by.reverse
+- sawa: I can settle with sort_by.reverse
 
 - [[Feature #12574]](https://bugs.ruby-lang.org/issues/12574) Remove TRUE, FALSE, and NIL (shyouhei)
 - [[Feature #12655]](https://bugs.ruby-lang.org/issues/12655) accessing a method visibility (shyouhei)
 - [[Feature #9612]](https://bugs.ruby-lang.org/issues/9612) Gemify OpenSSL (hsbt)
 - [[Feature #8539]](https://bugs.ruby-lang.org/issues/8539) Unbundle ext/tk (hsbt)
-- [[Feature #12512]](https://bugs.ruby-lang.org/issues/12512) Import Hash#transform\_values and its destructive version from ActiveSupport
+- [[Feature #12512]](https://bugs.ruby-lang.org/issues/12512) Import Hash#transform_values and its destructive version from ActiveSupport
 
-- Matz: accept Enumerable#map\_v
-- Matz: not now for map\_k, map\_kv
+- Matz: accept Enumerable#map_v
+- Matz: not now for map_k, map_kv
 
 ## From non-attendees
 
@@ -313,7 +313,7 @@ We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 
 - shyouhei: shoudl this be a method of Comparable?
 - nobu: can be a method of Range
-- akr: what about exclude\_end
+- akr: what about exclude_end
 - naruse: how about providing two:
 
 - Comparable#clamp(range)

--- a/2016/DevMeeting-2016-09-07.md
+++ b/2016/DevMeeting-2016-09-07.md
@@ -110,10 +110,10 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 
 ## Carry-over from previous meeting(s)
 
-- [[Feature #10098]](https://bugs.ruby-lang.org/issues/10098) \[PATCH\] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
+- [[Feature #10098]](https://bugs.ruby-lang.org/issues/10098) [PATCH] Timing-safe string comparison for OpenSSL::HMAC (shyouhei) status?
 
 - naruse: I don’t feel comfortable to its naming.
-- naruse: I think CRYPTO\_memcmp() is a bad interface so I don’t want to introduce it.
+- naruse: I think CRYPTO_memcmp() is a bad interface so I don’t want to introduce it.
 
 - [[Feature #12591]](https://bugs.ruby-lang.org/issues/12591) Allow ruby to either catch misspelled "ailas" statements or, possibly more accurately, be more specific in what it reports as an error to the end-user (shyouhei)
 
@@ -123,7 +123,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 
 - shugo: matz please respond.
 
-- [[Feature #8643]](https://bugs.ruby-lang.org/issues/8643) Add Binding.from\_hash (shyouhei) conclusion?
+- [[Feature #8643]](https://bugs.ruby-lang.org/issues/8643) Add Binding.from_hash (shyouhei) conclusion?
 
 - ko1: I’ll ask seki-san.
 
@@ -144,15 +144,15 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 
 ## From attendees
 
-- [[Feature #12512]](https://bugs.ruby-lang.org/issues/12512) Import Hash#transform\_values and its destructive version from ActiveSupport (eregon): we should discuss the name and maybe other methods like #map\_keys, #map\_pairs.
+- [[Feature #12512]](https://bugs.ruby-lang.org/issues/12512) Import Hash#transform_values and its destructive version from ActiveSupport (eregon): we should discuss the name and maybe other methods like #map_keys, #map_pairs.
 
-- matz: I have a plan to have similar methods also on Enumerable.  In doing so, map\_pairs is problematic because “pairs” does not always fit (they might not be key-value pairs).  This prevents me to introduce map\_keys/values/pairs.
-- matz: OK, I accept #transform\_values.
+- matz: I have a plan to have similar methods also on Enumerable.  In doing so, map_pairs is problematic because “pairs” does not always fit (they might not be key-value pairs).  This prevents me to introduce map_keys/values/pairs.
+- matz: OK, I accept #transform_values.
 - naruse: Is this behavior is same as ActiveSupports’s?
 - mrkn: Yes.
-- eregon: #map\_values, keys, pairs is intuitive on Hash and has been asked many times. The Enumerable method to create a Hash is a different issue: the input might aready be key-value pairs in which case #to\_h is enough or it might not, in which case we might want a new method (build\_hash, associate ?).
+- eregon: #map_values, keys, pairs is intuitive on Hash and has been asked many times. The Enumerable method to create a Hash is a different issue: the input might aready be key-value pairs in which case #to_h is enough or it might not, in which case we might want a new method (build_hash, associate ?).
 
-- [[Bug #12689]](https://bugs.ruby-lang.org/issues/12689) Thread isolation of $~ and $\_ (eregon): Who can describe the semantics? Is the current sharing expected?
+- [[Bug #12689]](https://bugs.ruby-lang.org/issues/12689) Thread isolation of $~ and $_ (eregon): Who can describe the semantics? Is the current sharing expected?
 
 - ko1: I intentioanlly made VM this way, to behave simiarly with 1.8.x.
 - ko1: Toplevel $-variables are thread local, others like variables inside of methods are not. They are normal (local) variables, subject to be shared among threads.
@@ -197,33 +197,33 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 - akr: Maybe we should allow http->https by default.
 - akr: Ideally it should be configurable wether redirections are allowed or not but that’s a bit too big.
 - Strawman proposal from Carsten Bormann: make configurable, e.g. as follows:
-    ALLOW\_REDIRECTS = { ["http:ftp"](http://ftp/) => true, "ftp:http" => true, ["http:https"](http://https/)
+    ALLOW_REDIRECTS = { ["http:ftp"](http://ftp/) => true, "ftp:http" => true, ["http:https"](http://https/)
     \=> true }
     s1 = uri1.scheme.downcase
     s2 = uri2.scheme.downcase
-    s1 == s2 || ALLOW\_REDIRECTS\["#{s1}:#{s2}"\]
+    s1 == s2 || ALLOW_REDIRECTS["#{s1}:#{s2}"]
 
-- [[Feature #7418]](https://bugs.ruby-lang.org/issues/7418) Kernel#used\_refinements (shugo)
+- [[Feature #7418]](https://bugs.ruby-lang.org/issues/7418) Kernel#used_refinements (shugo)
 
 - shyouhei: what is returned from this method?
 - shugo: list of refinements (modules).
 - shyouhei: is that useful?  What use case?
 - shugo: maybe for debugging purpose.
 - nobu: or from pry.
-- nobu: I don’t think it’s strange, given there are #included\_modules.
+- nobu: I don’t think it’s strange, given there are #included_modules.
 - akr: is its behaviour well-defined?
 - shugo: I think yes.
 - matz: Should this belong Kernel# or Module. ?
 - akr: I don’t think it should be a global function unless this is very frequently used.
-- matz: accept Module.used\_refinements
+- matz: accept Module.used_refinements
 
-- [[Feature #9451]](https://bugs.ruby-lang.org/issues/9451) Refinements and unary & (to\_proc) (shugo)
+- [[Feature #9451]](https://bugs.ruby-lang.org/issues/9451) Refinements and unary & (to_proc) (shugo)
 
 - matz: I started thinking this can be okay.
 - nobu: I doubt if we can do this.
-- akr: what about adding a primitive method Proc#to\_refined or something?
+- akr: what about adding a primitive method Proc#to_refined or something?
 - akr: is that possible?
-- matz: Object#method\_with\_refinements or something can be possible.
+- matz: Object#method_with_refinements or something can be possible.
 - matz: for &(proc), it is a good-to-have. if possible.
 
 - [[Bug #10103]](https://bugs.ruby-lang.org/issues/10103) Unable to refine class with CONSTANT (shugo)
@@ -233,7 +233,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 - [[Bug #11182]](https://bugs.ruby-lang.org/issues/11182) Refinement with alias causes strange behavior (shugo)
 - [[Feature #11476]](https://bugs.ruby-lang.org/issues/11476) Methods defined in Refinements cannot be called via send (shugo)
 
-- matz: either add Object#refined\_send method or Object#method\_with\_refinements.
+- matz: either add Object#refined_send method or Object#method_with_refinements.
 - nobu: or to have a send-like operator.
 - ko1: what’s wrong with send being refinements-aware?
 - matz: how is it difficult to modify send?  I want that way.
@@ -251,7 +251,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 
 - duplicated.
 
-- [[Feature #12086]](https://bugs.ruby-lang.org/issues/12086) using: option for instance\_eval etc. (shugo)
+- [[Feature #12086]](https://bugs.ruby-lang.org/issues/12086) using: option for instance_eval etc. (shugo)
 
 - waiting for JRuby guys.
 - shugo: please nudge.
@@ -282,7 +282,7 @@ Venue: TKP Kyoto Shijo-karasuma Conference Center
 
 - ko1: accept.
 
-- [[Feature #12695]](https://bugs.ruby-lang.org/issues/12695) File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set (nobu)
+- [[Feature #12695]](https://bugs.ruby-lang.org/issues/12695) File.expand_path should resolve ~/ using /etc/passwd when HOME is not set (nobu)
 - [[Feature #12700]](https://bugs.ruby-lang.org/issues/12700) regexg heredoc support (nobu)
 
 - matz: rejected

--- a/2016/DevMeeting-2016-10-11.md
+++ b/2016/DevMeeting-2016-10-11.md
@@ -39,7 +39,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 * [Misc #12283] Obsolete ChangeLog and commit message in Git-style (shyouhei) situation and progress?
 * [Feature #12695] File.expand_path should resolve ~/ using /etc/passwd when HOME is not set (shyouhei) conclusion?
 * [Feature #12733] Bundle bundler to ruby core (shyouhei)
-* [Feature #6647] Exceptions raised in threads should be logged (shyouhei) Look at [\[ruby-core:77259\\]](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/77259)
+* [Feature #6647] Exceptions raised in threads should be logged (shyouhei) Look at [[ruby-core:77259]](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/77259)
 * [Feature #12744] Add str.reverse_each_char and str.reverse_chars (shyouhei) conclusion?
 * [Bug #11195] Add "no_proxy" parameter to Net::HTTP.new (shyouhei) Roman Bigler volunteers.
 * [Feature #12700] regexg heredoc support (shyouhei) the OP _might_ perhaps have real use case.
@@ -143,7 +143,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - no showstopper
 - what about the Rational renovation?
 
-- please nudge \_tad\_
+- please nudge _tad_
 
 ## (From RubyKaigi admin) for Keynote speakers
 
@@ -161,7 +161,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - Martin: the problem is not commit log, but to auto-generate ChanegLog.
 - naruse: I’ll do this on camp.
 
-- [[Feature #12695]](https://bugs.ruby-lang.org/issues/12695) File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set (shyouhei) conclusion?
+- [[Feature #12695]](https://bugs.ruby-lang.org/issues/12695) File.expand_path should resolve ~/ using /etc/passwd when HOME is not set (shyouhei) conclusion?
 
 - waiting for matz.
 
@@ -172,18 +172,18 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - nobu: it will be merged when rubygems side is OK.
 - hsbt: carefully watching rubygems’ progress.
 
-- [[Feature #6647]](https://bugs.ruby-lang.org/issues/6647) Exceptions raised in threads should be logged (shyouhei) Look at [\[ruby-core:77259\]](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/77259)
+- [[Feature #6647]](https://bugs.ruby-lang.org/issues/6647) Exceptions raised in threads should be logged (shyouhei) Look at [[ruby-core:77259]](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/77259)
 
 - akr: the proposal can be okay, but we currently do not implemnt thread GC mode.
 
-- [[Feature #12744]](https://bugs.ruby-lang.org/issues/12744) Add str.reverse\_each\_char and str.reverse\_chars (shyouhei) conclusion?
+- [[Feature #12744]](https://bugs.ruby-lang.org/issues/12744) Add str.reverse_each_char and str.reverse_chars (shyouhei) conclusion?
 
 - naruse: I agree this makes things faster a bit, but will it really be needed?
-- Martin: array allocation is avoided in the patch, but each\_char generates lots of strings anyways.
+- Martin: array allocation is avoided in the patch, but each_char generates lots of strings anyways.
 
-- [[Bug #11195]](https://bugs.ruby-lang.org/issues/11195) Add "no\_proxy" parameter to Net::HTTP.new (shyouhei) Roman Bigler volunteers.
+- [[Bug #11195]](https://bugs.ruby-lang.org/issues/11195) Add "no_proxy" parameter to Net::HTTP.new (shyouhei) Roman Bigler volunteers.
 
-- akr: +1 to refacor find\_proxy, then use it from Net::HTTP.
+- akr: +1 to refacor find_proxy, then use it from Net::HTTP.
 - let’s request a patch, then mentor by naruse.
 
 - [[Bug #12594]](https://bugs.ruby-lang.org/issues/12594) The class does not inherit from a module the modules that were included after the inclusion (shyouhei)
@@ -200,23 +200,23 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 - assign naruse
 
-- [[Bug #12509]](https://bugs.ruby-lang.org/issues/12509) Using qsort\_s in mingw-w64 causes failures (shyouhei) who to handle this?
+- [[Bug #12509]](https://bugs.ruby-lang.org/issues/12509) Using qsort_s in mingw-w64 causes failures (shyouhei) who to handle this?
 
 - assign nobu
 
-- [[Bug #8996]](https://bugs.ruby-lang.org/issues/8996) pthread\_mutex\_lock EINVAL (shyouhei) seems like a real bug?
+- [[Bug #8996]](https://bugs.ruby-lang.org/issues/8996) pthread_mutex_lock EINVAL (shyouhei) seems like a real bug?
 
 - assign ko1
 
-- [[Bug #12776]](https://bugs.ruby-lang.org/issues/12776) Flaky test case: TestThread#test\_thread\_name (shyouhei) seems like a real bug, or....?
+- [[Bug #12776]](https://bugs.ruby-lang.org/issues/12776) Flaky test case: TestThread#test_thread_name (shyouhei) seems like a real bug, or....?
 
 - closed, lets backport.
 
-- [[Feature #12656]](https://bugs.ruby-lang.org/issues/12656) Expand short paths with File.expand\_path (shyouhei)
+- [[Feature #12656]](https://bugs.ruby-lang.org/issues/12656) Expand short paths with File.expand_path (shyouhei)
 
 - assign cruby-windows
 
-- [[Bug #7877]](https://bugs.ruby-lang.org/issues/7877) E::Lazy#with\_index should be lazy (shyouhei)
+- [[Bug #7877]](https://bugs.ruby-lang.org/issues/7877) E::Lazy#with_index should be lazy (shyouhei)
 
 - assign nobu
 
@@ -227,10 +227,10 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - [[Feature #4897]](https://bugs.ruby-lang.org/issues/4897) Define Math::TAU and BigMath.TAU. The "true" circle constant, Tau=2\*Pi. See [http://tauday.com/](http://tauday.com/) (shyouhei)
 
 - mrkn: I suggest Math::TWOPI
-- akr: C has PI\_2, but this means π/2
+- akr: C has PI_2, but this means π/2
 - wating for matz (or time?)
 
-- [[Bug #12674]](https://bugs.ruby-lang.org/issues/12674) io/wait: not handling the case when the socket is closed before doing wait\_readable/writable with timeout (shyouhei) might be a design issue?
+- [[Bug #12674]](https://bugs.ruby-lang.org/issues/12674) io/wait: not handling the case when the socket is closed before doing wait_readable/writable with timeout (shyouhei) might be a design issue?
 
 - assign nobu
 
@@ -238,15 +238,15 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 - assign shugo
 
-- [[Bug #6783]](https://bugs.ruby-lang.org/issues/6783) Infinite loop in inspect, not overriding inspect, to\_s, and no known circular references. Stepping into inspect in debugger locks it up with 100% CPU. (shyouhei)
+- [[Bug #6783]](https://bugs.ruby-lang.org/issues/6783) Infinite loop in inspect, not overriding inspect, to_s, and no known circular references. Stepping into inspect in debugger locks it up with 100% CPU. (shyouhei)
 
 - akr: I have a conception of ritcher inspection framework that passes-around contexts, but have not implemented yet.
 
-- [[Bug #10222]](https://bugs.ruby-lang.org/issues/10222) require\_relative and require should be compatible with each other (shyouhei)
+- [[Bug #10222]](https://bugs.ruby-lang.org/issues/10222) require_relative and require should be compatible with each other (shyouhei)
 
-- akr: require\_relative expands real path, while require doesn’t.
+- akr: require_relative expands real path, while require doesn’t.
 - naruse: if we expand realpath on require, we need disk access every time we call require (even when the library is already loaded).
-- naruse: what about adding both real path and expanded path to $LOADED\_FEATURES at once for require?
+- naruse: what about adding both real path and expanded path to $LOADED_FEATURES at once for require?
 - shyouhei: I think for this shown use case b.rb shall not be called twice.
 
 - [[Bug #12705]](https://bugs.ruby-lang.org/issues/12705) yielding args to a lambda uses block/proc rather than lambda/method semantics (shyouhei)
@@ -255,19 +255,19 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - akr: someone broke here at 2.2.
 - ko1: maybe me.
 
-- [[Bug #4537]](https://bugs.ruby-lang.org/issues/4537) Incorrectly creating private method via attr\_accessor (shyouhei) cf. [[Bug #9005]](https://bugs.ruby-lang.org/issues/9005)
+- [[Bug #4537]](https://bugs.ruby-lang.org/issues/4537) Incorrectly creating private method via attr_accessor (shyouhei) cf. [[Bug #9005]](https://bugs.ruby-lang.org/issues/9005)
 
 - shyouhei: is this fixed already?
 - nobu: seems not.
 - shyouhei: updated ruby -v field.
 
-- [[Feature #12721]](https://bugs.ruby-lang.org/issues/12721) public\_module\_function (shyouhei)
+- [[Feature #12721]](https://bugs.ruby-lang.org/issues/12721) public_module_function (shyouhei)
 
 - waiting for matz.
 
 - [[Feature #12732]](https://bugs.ruby-lang.org/issues/12732) An option to pass to Integer, Float, to return nil instead of raise an exception (shyouhei)
 
-- akr: it seems there are needs of other conversion methods than to\_i or Integer
+- akr: it seems there are needs of other conversion methods than to_i or Integer
 - nobu: they just want to detect validity, not exceptions.
 - Martin: what about Integer?()
 - Martin: but Upcase?() is a new concept.
@@ -280,11 +280,11 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - akr: it breaks compatibility.
 - akira: what about passing extra second argument to the block, which happen to be a copy of $~
 - akr: that is possible.
-- nobu: what about defineing MatchData#to\_str ?
+- nobu: what about defineing MatchData#to_str ?
 - shyouhei: it might be possible to extend the passed string to define method that returns $~.
 - akr: adding a new method is the most clean way if we can find good method name.
 
-- [[Feature #12747]](https://bugs.ruby-lang.org/issues/12747) Add TracePoint#callee\_id (shyouhei)
+- [[Feature #12747]](https://bugs.ruby-lang.org/issues/12747) Add TracePoint#callee_id (shyouhei)
 
 - assign ko1.
 
@@ -301,16 +301,16 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - akr: I can’t read the output.
 - mrkn: yes.  I’ll fix this.  But it’s not that simple.
 
-- \[Feature #12005\] define rb\_cFixnum and rb\_Bignum again? (akr)
+- \[Feature #12005\] define rb_cFixnum and rb_Bignum again? (akr)
 
 - dependency hell
 
 - situation: we “tried” to delete them.  Main difficulty is “gem ‘json’, ‘~> 1.8.0’”
 - hsbt: I pushed this change (remove JSON’s version) to Rails 4
 
-- C-level constants: rb\_cFixnum and rb\_cBignum
+- C-level constants: rb_cFixnum and rb_cBignum
 
-- akr: resurrection of these constants does \_not\_ solve the issue.
+- akr: resurrection of these constants does _not_ solve the issue.
 
 - warnigs for Ruby-level constants: Fixnum and Bignum
 

--- a/2016/DevMeeting-2016-11-25.md
+++ b/2016/DevMeeting-2016-11-25.md
@@ -167,7 +167,7 @@ Issues
 - duest: I don’t think ? has any connection with symols or strings, it feels unnatural for this purpose
 - naruse: what about $foo?
 
-- matz: or \`foo (like lisp)
+- matz: or `foo (like lisp)
 
 - continue discussing.
 - mrkn: x.round(half::"up") -> x.round(half: :"up")
@@ -187,7 +187,7 @@ Issues
 
 - [[Bug #11929]](https://bugs.ruby-lang.org/issues/11929) No programatic way to check ability to dup/clone an object (duerst)
 
-- matz: respond\_to? is insufficient to check if it can be dup’ed, because it could raise exceptions.
+- matz: respond_to? is insufficient to check if it can be dup’ed, because it could raise exceptions.
 - matz: There is no way to change identity of a fixnum.
 - naruse: I’m not sure what OP wants to do.
 - duerst: I’d prefer failing silently.
@@ -198,17 +198,17 @@ Issues
 - duerst: not currently implemented.
 - naruse: I’ll take a look.
 
-- [[Feature #12695]](https://bugs.ruby-lang.org/issues/12695) File.expand\_path should resolve ~/ using /etc/passwd when HOME is not set
+- [[Feature #12695]](https://bugs.ruby-lang.org/issues/12695) File.expand_path should resolve ~/ using /etc/passwd when HOME is not set
 
 - matz: OK
 
 - [[Feature #4897]](https://bugs.ruby-lang.org/issues/4897) Define Math::TAU and BigMath.TAU. The "true" circle constant, Tau=2\*Pi. See [http://tauday.com/](http://tauday.com/)
 
-- mrkn: last time I suggested TWO\_PI.
-- matz: I don’t think TWO\_PI satisfies TAU fans.
+- mrkn: last time I suggested TWO_PI.
+- matz: I don’t think TWO_PI satisfies TAU fans.
 - matz: I want to leave it rejected.
 
-- [[Feature #12721]](https://bugs.ruby-lang.org/issues/12721) public\_module\_function
+- [[Feature #12721]](https://bugs.ruby-lang.org/issues/12721) public_module_function
 
 - nurse: わかる
 - matz: I’m not sure what benefits are there.
@@ -247,7 +247,7 @@ Issues
 - [[Feature #12752]](https://bugs.ruby-lang.org/issues/12752) Unpacking a value from a binary requires additional '.first'
 
 - matz: I would prefer keyword arguments but index:0 doesn’t much differ from .first
-- naruse: write”(‘C’)\[0\]” and let the interpreter optimize.
+- naruse: write”(‘C’)[0]” and let the interpreter optimize.
 - ko1: possibilities are:
 
 - new method
@@ -268,10 +268,10 @@ Issues
 
 - matz: reject. I can’t but read this being a String, not Symbol.
 
-- [[Feature #12770]](https://bugs.ruby-lang.org/issues/12770) Hash#left\_merge
+- [[Feature #12770]](https://bugs.ruby-lang.org/issues/12770) Hash#left_merge
 
-- akira: Rails has reverse\_merge.
-- naruse: the proposed functionality is not the identical to reverse\_merge.
+- akira: Rails has reverse_merge.
+- naruse: the proposed functionality is not the identical to reverse_merge.
 - ko1: chechk if hash entry is nil, is something new (not orignal behaviour of merge)
 
 - [[Feature #12760]](https://bugs.ruby-lang.org/issues/12760) Optional block argument for itself
@@ -305,7 +305,7 @@ Issues
 - ko1: maybe akr is interested in it.
 - shyouhei: introducing incompatibility only because it is inefficient is kind of weak.
 
-- [[Bug #9244]](https://bugs.ruby-lang.org/issues/9244) unexpected behaviour of 'require' when $LOAD\_PATH gets changed
+- [[Bug #9244]](https://bugs.ruby-lang.org/issues/9244) unexpected behaviour of 'require' when $LOAD_PATH gets changed
 
 - matz: I don’t immediately think it’s a bug.
 
@@ -329,7 +329,7 @@ Issues
 
 - [[Feature #12780]](https://bugs.ruby-lang.org/issues/12780) BigDecimal#round returns different types depending on argument
 
-- [[Feature #12813]](https://bugs.ruby-lang.org/issues/12813) Calling chunk\_while, slice\_after, slice\_before, slice\_when with no block
+- [[Feature #12813]](https://bugs.ruby-lang.org/issues/12813) Calling chunk_while, slice_after, slice_before, slice_when with no block
 
 - matz will think about it.
 

--- a/2016/DevMeeting-2016-12-21.md
+++ b/2016/DevMeeting-2016-12-21.md
@@ -176,7 +176,7 @@ Issues
 
 - akr: why not use ldd(1)?
 
-- [[Bug #12945]](https://bugs.ruby-lang.org/issues/12945) Use-after-free in vm\_trace.c
+- [[Bug #12945]](https://bugs.ruby-lang.org/issues/12945) Use-after-free in vm_trace.c
 
 - nobu: I think I fixed this
 
@@ -193,7 +193,7 @@ Issues
 
 - nobu it’s already assigned.
 
-- [[Bug #12907]](https://bugs.ruby-lang.org/issues/12907) rb\_respond\_to() return value is incorrect
+- [[Bug #12907]](https://bugs.ruby-lang.org/issues/12907) rb_respond_to() return value is incorrect
 
 - matz: this is a bug.
 - assign nagachika
@@ -206,7 +206,7 @@ Issues
 
 - assign shugo
 
-- [[Bug #13030]](https://bugs.ruby-lang.org/issues/13030) Unexpected T\_IMEMO object when building with VMDEBUG
+- [[Bug #13030]](https://bugs.ruby-lang.org/issues/13030) Unexpected T_IMEMO object when building with VMDEBUG
 
 - assign ko1
 
@@ -232,7 +232,7 @@ Issues
 
 - mrkn: what about Array#delete with multiple arguments?
 
-- [[Feature #2074]](https://bugs.ruby-lang.org/issues/2074) json の j や jj は module\_function にするべき？
+- [[Feature #2074]](https://bugs.ruby-lang.org/issues/2074) json の j や jj は module_function にするべき？
 
 - akr: This is a 3PI
 
@@ -248,14 +248,14 @@ Issues
 
 - [[Feature #12861]](https://bugs.ruby-lang.org/issues/12861) Lexically scoped super (nobu)
 
-- nobu: define\_method is the cause of evil
+- nobu: define_method is the cause of evil
 - matz: I’m not sure if lexically-scoped super would actually get used or not.
 
 - [[Bug #12812]](https://bugs.ruby-lang.org/issues/12812) Added Coverage#result= (shyuohei)
 
 - mame is assigned, let him handle this
 
-- [[Feature #12180]](https://bugs.ruby-lang.org/issues/12180) switch id\_table.c variant (shyouhei) ko1?
+- [[Feature #12180]](https://bugs.ruby-lang.org/issues/12180) switch id_table.c variant (shyouhei) ko1?
 
 - is it OK?
 
@@ -271,7 +271,7 @@ Issues
 
 - akr: we are not sure if it is safe, because curry is something very conceptual.
 
-- [[Bug #12855]](https://bugs.ruby-lang.org/issues/12855) Inconsistent keys identity in compare\_by\_identity Hash when using literals (shyouhei) bug or...?
+- [[Bug #12855]](https://bugs.ruby-lang.org/issues/12855) Inconsistent keys identity in compare_by_identity Hash when using literals (shyouhei) bug or...?
 
 - akr: this is an over-optimization.
 
@@ -287,22 +287,22 @@ Issues
 2. then implement.
 3. then this ticket should use that.
 
-- [[Feature #11286]](https://bugs.ruby-lang.org/issues/11286) \[PATCH\] Add case equality arity to Enumerable's sequence predicates. (shyouhei)
+- [[Feature #11286]](https://bugs.ruby-lang.org/issues/11286) [PATCH] Add case equality arity to Enumerable's sequence predicates. (shyouhei)
 
 - shyouhei: seems the OP wants some variant of grep
 - akr: regexp might be straight-forward to read but?
 - matz: positive, but might be better in another name?
 
-- [[Feature #5446]](https://bugs.ruby-lang.org/issues/5446) at\_fork callback API (shyouhei)
+- [[Feature #5446]](https://bugs.ruby-lang.org/issues/5446) at_fork callback API (shyouhei)
 
 - what about make it as a pure-ruby gem?
 
 - [[Feature #12780]](https://bugs.ruby-lang.org/issues/12780) BigDecimal#round returns different types depending on argument (shyouhei)
-- [[Feature #11428]](https://bugs.ruby-lang.org/issues/11428) system/exec/etc. should to\_s their argument to restore Pathname functionality as it was in 1.8 (shyouhei)
-- [[Feature #12180]](https://bugs.ruby-lang.org/issues/12180) switch id\_table.c variant (shyouhei)
+- [[Feature #11428]](https://bugs.ruby-lang.org/issues/11428) system/exec/etc. should to_s their argument to restore Pathname functionality as it was in 1.8 (shyouhei)
+- [[Feature #12180]](https://bugs.ruby-lang.org/issues/12180) switch id_table.c variant (shyouhei)
 
 - [[Feature #5481]](https://bugs.ruby-lang.org/issues/5481) [https://bugs.ruby-lang.org/issues/5481](https://bugs.ruby-lang.org/issues/5481)
 
-- \[Bug [#12998](https://bugs.ruby-lang.org/issues/12998)[\] paragraph mode inconsistency between](https://bugs.ruby-lang.org/issues/5481) [IO#each\_line](https://bugs.ruby-lang.org/issues/5481) [and](https://bugs.ruby-lang.org/issues/5481) [String#each\_line](https://bugs.ruby-lang.org/issues/5481)[(nobu)](https://bugs.ruby-lang.org/issues/5481)
+- \[Bug [#12998](https://bugs.ruby-lang.org/issues/12998)[\] paragraph mode inconsistency between](https://bugs.ruby-lang.org/issues/5481) [IO#each_line](https://bugs.ruby-lang.org/issues/5481) [and](https://bugs.ruby-lang.org/issues/5481) [String#each_line](https://bugs.ruby-lang.org/issues/5481)[(nobu)](https://bugs.ruby-lang.org/issues/5481)
 
-- akr: String#each\_line should be fixed in 2.5.
+- akr: String#each_line should be fixed in 2.5.

--- a/2017/DevMeeting-2017-01-19.md
+++ b/2017/DevMeeting-2017-01-19.md
@@ -154,7 +154,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 
 ## Carry-over from previous meeting(s)
 
-## [[Feature #12180]](https://bugs.ruby-lang.org/issues/12180) switch id\_table.c variant (shyouhei)
+## [[Feature #12180]](https://bugs.ruby-lang.org/issues/12180) switch id_table.c variant (shyouhei)
 
 
 - ko1: funny-falcon’s open addressing hash is beating mine.
@@ -191,7 +191,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - shyouhei: I will
 - matz: go ahead.
 
-## [[Bug #12998]](https://bugs.ruby-lang.org/issues/12998) paragraph mode inconsistency between IO#each\_line and String#each\_line(nobu)
+## [[Bug #12998]](https://bugs.ruby-lang.org/issues/12998) paragraph mode inconsistency between IO#each_line and String#each_line(nobu)
 
 
 - ko1: ideal behaviour?
@@ -291,7 +291,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - nobu: start as a gem.
 - matz: agree.
 
-## [[Feature #12931]](https://bugs.ruby-lang.org/issues/12931) Add support for Binding#instance\_eval (shyouhei)
+## [[Feature #12931]](https://bugs.ruby-lang.org/issues/12931) Add support for Binding#instance_eval (shyouhei)
 
 
 - shyouhei: what is needed ultimately is to pass a block to Binding#eval
@@ -335,7 +335,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 
 - shugo is handling.
 
-## [[Feature #12967]](https://bugs.ruby-lang.org/issues/12967) Add a default for RUBY\_GC\_HEAP\_GROWTH\_MAX\_SLOTS out-of-the-box (shyouhei)
+## [[Feature #12967]](https://bugs.ruby-lang.org/issues/12967) Add a default for RUBY_GC_HEAP_GROWTH_MAX_SLOTS out-of-the-box (shyouhei)
 
 
 - ko1: I’m not sure if this parameter is a sane default.
@@ -357,7 +357,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - shyouhei: understand that point.
 - naruse: you have to sort by length before union. Otherwise カ can match before ガ.
 
-## [[Bug #8241]](https://bugs.ruby-lang.org/issues/8241) If uri host-part has underscore ( '\_' ), 'URI#parse' raise 'URI::InvalidURIError' (shyouhei)
+## [[Bug #8241]](https://bugs.ruby-lang.org/issues/8241) If uri host-part has underscore ( '_' ), 'URI#parse' raise 'URI::InvalidURIError' (shyouhei)
 
 
 - naruse: I think this is done.
@@ -389,7 +389,7 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 - nobu: nobody is against the needs of macro but the name?
 - shyouhei: will update the ticket.
 
-## [[Bug #13127]](https://bugs.ruby-lang.org/issues/13127) DRb \`load': connection closed (DRb::DRbConnError) when client exit's from within a loop iterating over remote objects (shyouhei)
+## [[Bug #13127]](https://bugs.ruby-lang.org/issues/13127) DRb `load': connection closed (DRb::DRbConnError) when client exit's from within a loop iterating over remote objects (shyouhei)
 
 
 - assign seki
@@ -417,11 +417,11 @@ log: [https://docs.google.com/document/d/1ZKk-vxoYkq8b2H4ml2z4NhoHsi3GdZqhNXNgpB
 
 - shyouhei: I will
 
-- rename Random.raw\_seed to Random.urandom
+- rename Random.raw_seed to Random.urandom
 - try to use that from SecureRandom
 - if it fails, fallback to OpenSSL.
 
-- \[Bug #13135\] Regexp.last\_match returns nil with s.rindex(//)
+- \[Bug #13135\] Regexp.last_match returns nil with s.rindex(//)
 
 - everyone: isn’t it a bug?
 - ko1: assign shugo.

--- a/2017/DevMeeting-2017-03-13.md
+++ b/2017/DevMeeting-2017-03-13.md
@@ -160,13 +160,13 @@ log: TBD
 - naruse: that is byteoffset here.
 - akr: byteindex may have problem for inter-codepoint index.
 
-- [[Bug #13105]](https://bugs.ruby-lang.org/issues/13105) String#to\_f and String#to\_r don't stop successive underscores (nobu)
+- [[Bug #13105]](https://bugs.ruby-lang.org/issues/13105) String#to_f and String#to_r don't stop successive underscores (nobu)
 
 - nobu: is this intentional?
 - ko1: ignore all underscores?
 - shyouhei: all? at the beginning?
-- ko1: \_ generates zero for to\_i.
-- akr: to\_i once allowed multiple underscores but prohibits now.
+- ko1: _ generates zero for to_i.
+- akr: to_i once allowed multiple underscores but prohibits now.
 - tal: ruby’s parser does not allow multiple undersocres as literals.
 - matz: these days other languages follow us like java, python.
 
@@ -185,7 +185,7 @@ log: TBD
 - ko1: we introduced ad-hoc change to lambda creation but that turned out to be a mistake, and observed here.
 - ko1: to be fixed in 2.5.
 
-- [[Feature #13095]](https://bugs.ruby-lang.org/issues/13095) \[PATCH\] io.c (rb\_f\_syscall): remove deprecation notice (shyouhei)
+- [[Feature #13095]](https://bugs.ruby-lang.org/issues/13095) [PATCH] io.c (rb_f_syscall): remove deprecation notice (shyouhei)
 
 - shyouhei: do we want to remove system calls?
 - akr: yes.
@@ -195,7 +195,7 @@ log: TBD
 - akr: current situation is too difficult to use properly, too easy to get used.
 - akr: my suggestion is to move it to ext/syscall.
 
-- [[Feature #13122]](https://bugs.ruby-lang.org/issues/13122) Special syntax for Hash#default\_proc (shyouhei)
+- [[Feature #13122]](https://bugs.ruby-lang.org/issues/13122) Special syntax for Hash#default_proc (shyouhei)
 
 - tal: not only default proc, but also there are default values.
 - matz: reject
@@ -240,7 +240,7 @@ log: TBD
 - naruse: use case?
 - tal: rsplit(...,2) can be generally written using regexp. ohter cases when we cant do this using regexp?
 
-- [[Feature #4532]](https://bugs.ruby-lang.org/issues/4532) \[PATCH\] add IO#pread and IO#pwrite methods (shyouhei)
+- [[Feature #4532]](https://bugs.ruby-lang.org/issues/4532) [PATCH] add IO#pread and IO#pwrite methods (shyouhei)
 
 - akr: portability concern? This is POSIX but added recently.
 - shyouhei: POSIX issue 5
@@ -258,12 +258,12 @@ log: TBD
 
 ## From attendees
 
-- \[Bug #13304\] public function rb\_thread\_fd\_close is removed at r57422 (naruse)
+- \[Bug #13304\] public function rb_thread_fd_close is removed at r57422 (naruse)
 
 - naruse: there are usages for this function.
 - akr: why do you want to remove this?
-- nobu: this is not a function to close a fd (bad naming). rb\_io\_close shall be used instead.
-- ko1: then why not just let it an alias of rb\_io\_close?
+- nobu: this is not a function to close a fd (bad naming). rb_io_close shall be used instead.
+- ko1: then why not just let it an alias of rb_io_close?
 - nobu: shuld we deprecate?
 - naruse: no. you can’t deprecate without transition path.
 - conclusion: delete DEPRECATE
@@ -277,8 +277,8 @@ log: TBD
 - this week's "assign whom?" section (shyouhei)
 
 - [[Bug #13271]](https://bugs.ruby-lang.org/issues/13271) Clarifications on refinement spec
-- [[Bug #13269]](https://bugs.ruby-lang.org/issues/13269) test/readline/test\_readline.rb and mingw
-- [[Bug #13298]](https://bugs.ruby-lang.org/issues/13298) mingw SEGV TestEnumerable#test\_callcc
+- [[Bug #13269]](https://bugs.ruby-lang.org/issues/13269) test/readline/test_readline.rb and mingw
+- [[Bug #13298]](https://bugs.ruby-lang.org/issues/13298) mingw SEGV TestEnumerable#test_callcc
 - [[Bug #13280]](https://bugs.ruby-lang.org/issues/13280) net/ftp: Putbinaryfile (on Windows) requires blocksize equal to file size
 - [[Bug #13276]](https://bugs.ruby-lang.org/issues/13276) Dir.glob returns empty array when OS has no more file handles (expected exception)
 
@@ -286,18 +286,18 @@ log: TBD
 - matz: I don’t think so.
 
 - [[Bug #13284]](https://bugs.ruby-lang.org/issues/13284) IA64 ruby 2.4 miniruby segfault
-- [[Bug #13286]](https://bugs.ruby-lang.org/issues/13286) Segfault when using rb\_debug\_inspector\_open / rb\_debug\_inspector\_frame\_binding\_get with Fiddle, but not when directly from C extension
+- [[Bug #13286]](https://bugs.ruby-lang.org/issues/13286) Segfault when using rb_debug_inspector_open / rb_debug_inspector_frame_binding_get with Fiddle, but not when directly from C extension
 - [[Bug #13305]](https://bugs.ruby-lang.org/issues/13305) Occasional segfaults after defining methods while running coverage
 - [[Bug #13307]](https://bugs.ruby-lang.org/issues/13307) Changing scheme from http to https for the URI does not change the port number
 
-- [[Bug #13282]](https://bugs.ruby-lang.org/issues/13282) opt\_str\_freeze does not always dedupe (shyouhei)
+- [[Bug #13282]](https://bugs.ruby-lang.org/issues/13282) opt_str_freeze does not always dedupe (shyouhei)
 
-- shyouhei: this is about power\_assert
+- shyouhei: this is about power_assert
 - akr: what’s wrong with it?
 - shyouhei: seems tracepoint?
 - ko1: don’t know the exact reason.
 
-- [[Feature #13295]](https://bugs.ruby-lang.org/issues/13295) \[PATCH\] compile.c: apply opt\_str\_freeze to String#-@ (uminus) (shyohei) seems OK to me as well
+- [[Feature #13295]](https://bugs.ruby-lang.org/issues/13295) [PATCH] compile.c: apply opt_str_freeze to String#-@ (uminus) (shyohei) seems OK to me as well
 
 - ko1: this is buggy.  Can’t redefine \-@ in this patch.
 
@@ -305,9 +305,9 @@ log: TBD
 
 - nobu: #bury has already been rejected, no update since then.
 
-- [[Misc #13283]](https://bugs.ruby-lang.org/issues/13283) Disable \`&' interpreted as argument prefix warning when passing symbol to Enumerable#map (duerst)
+- [[Misc #13283]](https://bugs.ruby-lang.org/issues/13283) Disable `&' interpreted as argument prefix warning when passing symbol to Enumerable#map (duerst)
 
-- duerst: the warning is older than Symbol#to\_proc
+- duerst: the warning is older than Symbol#to_proc
 - shyouhei: why not suppress the warning for symbol literals, not for variables
 - nobu: lexer / parser gets complicated that case.
 - nobu: is this a warning shown everywhere? -> only when \-w
@@ -318,7 +318,7 @@ log: TBD
 
 - matz: I don’t understand the usage.  Let me ask the OP.
 
-- [[Feature #13077]](https://bugs.ruby-lang.org/issues/13077) \[PATCH\] introduce String#fstring method (ko1) some discussions on twitter they don't like \-'str' notation.
+- [[Feature #13077]](https://bugs.ruby-lang.org/issues/13077) [PATCH] introduce String#fstring method (ko1) some discussions on twitter they don't like \-'str' notation.
 
 - shyouhei: we can add other stylish names later. \-@ is “for the time being”.
 - matz: if you have opinions, have a separate issue.

--- a/2017/DevMeeting-2017-04-17.md
+++ b/2017/DevMeeting-2017-04-17.md
@@ -130,7 +130,7 @@ Place: Cookpad Inc. Headquarter
 
 Sign-up: [https://ruby.connpass.com/event/53124/](https://ruby.connpass.com/event/53124/)
 
-log edit: [https://docs.google.com/document/d/1\_tWfg7\_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit](https://docs.google.com/document/d/1_tWfg7_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit)
+log edit: [https://docs.google.com/document/d/1_tWfg7_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit](https://docs.google.com/document/d/1_tWfg7_t-JRXgGlMaOGnpyipGP7P-lKQ18NtciWhKIY/edit)
 
 log: TBD
 
@@ -157,14 +157,14 @@ log: TBD
 
 ## Carry-over from previous meeting(s)
 
-- [[Bug #13257]](https://bugs.ruby-lang.org/issues/13257) Symbol#respond\_to?(:singleton\_class) should be false (naruse)
+- [[Bug #13257]](https://bugs.ruby-lang.org/issues/13257) Symbol#respond_to?(:singleton_class) should be false (naruse)
 
 - akr: I feel it’s OK to undef them.
-- matz: I doubt to check behaviours using respond\_to?
+- matz: I doubt to check behaviours using respond_to?
 - nalsh: class << obj; creates a singleton class if not.  This is not good.
 - nobu: It seems what OP wants is actually a list of extended modules, which is not currently obtainable.
 
-- [[Misc #13163]](https://bugs.ruby-lang.org/issues/13163) Uncaught exceptions may not be reported when Thread#report\_on\_exception=true and Thread#abort\_on\_exception=true (naruse)
+- [[Misc #13163]](https://bugs.ruby-lang.org/issues/13163) Uncaught exceptions may not be reported when Thread#report_on_exception=true and Thread#abort_on_exception=true (naruse)
 
 - nobu: OK to me.
 
@@ -184,7 +184,7 @@ log: TBD
 
 - assign ko1
 
-- [[Feature #2740]](https://bugs.ruby-lang.org/issues/2740) Extend const\_missing to pass in the nesting (shyouhei)
+- [[Feature #2740]](https://bugs.ruby-lang.org/issues/2740) Extend const_missing to pass in the nesting (shyouhei)
 
 - matz: does this still work?
 - matz: also, I don’t like autoloading in general.
@@ -218,7 +218,7 @@ log: TBD
 - shyouhei: I don’t understand this.
 - matz: reject
 
-- [[Feature #13245]](https://bugs.ruby-lang.org/issues/13245) \[PATCH\] reject inter-thread TLS modification (shyouhei)
+- [[Feature #13245]](https://bugs.ruby-lang.org/issues/13245) [PATCH] reject inter-thread TLS modification (shyouhei)
 
 - ko1: we would like to forbid this in a future.
 - shyouhei: what about adding warning.
@@ -282,14 +282,14 @@ log: TBD
 - [[Feature #13303]](https://bugs.ruby-lang.org/issues/13303) String#any? as !String#empty? (shyouhei)
 
 - matz: I don’t like any? because Enumerable#any? cannot be applied to String straight-forward.
-- matz: str.not\_empty? seems inferior than !str.empty?
-- naruse: !str.empty? does not work for nil.  I want to do str\_or\_nil&.not\_empty?
+- matz: str.not_empty? seems inferior than !str.empty?
+- naruse: !str.empty? does not work for nil.  I want to do str_or_nil&.not_empty?
 - name candidates:
 
 - NG: present
 - NG: empty?
-- candicate: non\_empty?
-- candicate: not\_empty?
+- candicate: non_empty?
+- candicate: not_empty?
 
 ## From attendees
 
@@ -299,9 +299,9 @@ log: TBD
 
 - Assign who? section (shyouhei)
 
-- [[Bug #13228]](https://bugs.ruby-lang.org/issues/13228) s\[i\]=c(assigning a character) for String is slower than Array on Linux
+- [[Bug #13228]](https://bugs.ruby-lang.org/issues/13228) s[i]=c(assigning a character) for String is slower than Array on Linux
 
-- shyouhei: that search\_nonascii is unavoidable
+- shyouhei: that search_nonascii is unavoidable
 - naruse: 5x slower on my machine
 - nobu: no difference on my macine
 - shyouhei: what’s the cause?
@@ -314,10 +314,10 @@ log: TBD
 - [[Bug #13330]](https://bugs.ruby-lang.org/issues/13330) Array.include? is slow for symbols
 - [[Bug #13336]](https://bugs.ruby-lang.org/issues/13336) Default Parameters don't work
 - [[Bug #13337]](https://bugs.ruby-lang.org/issues/13337) Eval and Later Defined Local Variables
-- [[Bug #13338]](https://bugs.ruby-lang.org/issues/13338) MinGW SEGV in test/ruby/test\_keyword.rb svn 58034, ok in svn 58021.
+- [[Bug #13338]](https://bugs.ruby-lang.org/issues/13338) MinGW SEGV in test/ruby/test_keyword.rb svn 58034, ok in svn 58021.
 - [[Bug #13390]](https://bugs.ruby-lang.org/issues/13390) MinGW build test-all SEGV, issue in test framework or error recovery?
 - [[Bug #13350]](https://bugs.ruby-lang.org/issues/13350) File.read :newline option not respected on Linux
-- [[Feature #13362]](https://bugs.ruby-lang.org/issues/13362) \[PATCH\] socket: avoid fcntl for read/write\_nonblock on Linux
+- [[Feature #13362]](https://bugs.ruby-lang.org/issues/13362) [PATCH] socket: avoid fcntl for read/write_nonblock on Linux
 - [[Bug #13351]](https://bugs.ruby-lang.org/issues/13351) net/http: Net::HTTP.start sets wrong default arg value
 - watson's
 
@@ -325,7 +325,7 @@ log: TBD
 - [[Bug #13342]](https://bugs.ruby-lang.org/issues/13342) Improve yielding block performance
 - [[Bug #13354]](https://bugs.ruby-lang.org/issues/13354) Improve Time#<=> performance
 - [[Bug #13357]](https://bugs.ruby-lang.org/issues/13357) Improve Time#+ & Time#- performance
-- [[Bug #13365]](https://bugs.ruby-lang.org/issues/13365) Improve performance of rb\_equal() with special constants
+- [[Bug #13365]](https://bugs.ruby-lang.org/issues/13365) Improve performance of rb_equal() with special constants
 - [[Bug #13368]](https://bugs.ruby-lang.org/issues/13368) Improve performance of Array#sum with float elements
 - [[Bug #13374]](https://bugs.ruby-lang.org/issues/13374) Fix one of performance regressions in method calling
 - nobu: I call him for a volunteer.
@@ -334,7 +334,7 @@ log: TBD
 - [[Bug #13101]](https://bugs.ruby-lang.org/issues/13101) Date#rfc2822 and Time#rfc2822 don't return the same format
 - [[Bug #13312]](https://bugs.ruby-lang.org/issues/13312) String#casecmp raises TypeError instead of returning nil
 - [[Bug #12684]](https://bugs.ruby-lang.org/issues/12684) Delegator#eql? missing
-- [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) \[PATCH\] POP3 support timeout for TLS handshake
+- [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) [PATCH] POP3 support timeout for TLS handshake
 - [[Bug #13319]](https://bugs.ruby-lang.org/issues/13319) GC issues seen with GCC7
 - [[Bug #13404]](https://bugs.ruby-lang.org/issues/13404) Hash#any? yields arguments to lambdas with proc semantics
 - [[Bug #13406]](https://bugs.ruby-lang.org/issues/13406) URI.parse
@@ -345,7 +345,7 @@ log: TBD
 - [[Feature #13309]](https://bugs.ruby-lang.org/issues/13309) Locale paramter for Integer(), Float(), Rational() (shyouhei)
 - [[Feature #12733]](https://bugs.ruby-lang.org/issues/12733) Bundle bundler to ruby core (shyouhei) updates?
 - [[Feature #11302]](https://bugs.ruby-lang.org/issues/11302) Dir.entries and Dir.foreach without [".", ".."](https://bugs.ruby-lang.org/projects/ruby/wiki/shyouhei)
-- [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def\_instance\_delegator nil (shyouhei)
+- [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def_instance_delegator nil (shyouhei)
 - [[Feature #13334]](https://bugs.ruby-lang.org/issues/13334) Removed deprecated mathn extentions. (shyouhei)
 - [[Bug #12921]](https://bugs.ruby-lang.org/issues/12921) Retrieve user and password for proxy from env (shyouhei)
 
@@ -353,14 +353,14 @@ log: TBD
 
 - [[Feature #13333]](https://bugs.ruby-lang.org/issues/13333) block to yield (shyouhei)
 - [[Feature #13378]](https://bugs.ruby-lang.org/issues/13378) Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
-- [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+- [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) [PATCH] Expose rb_fstring and its family to C extensions (shyouhei)
 - [[Bug #13315]](https://bugs.ruby-lang.org/issues/13315) Single "%" at the end of printf format string appears in the result (shyouhei)
-- [[Feature #13385]](https://bugs.ruby-lang.org/issues/13385) \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
-- [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) \[PATCH\] Module#source\_location (shyouhei)
+- [[Feature #13385]](https://bugs.ruby-lang.org/issues/13385) [PATCH] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
+- [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) [PATCH] Module#source_location (shyouhei)
 - [[Feature #12063]](https://bugs.ruby-lang.org/issues/12063) KeyError#receiver and KeyError#name (shyouhei) status?
-- [[Bug #13397]](https://bugs.ruby-lang.org/issues/13397) #object\_id should not be signed (shyouhei)
+- [[Bug #13397]](https://bugs.ruby-lang.org/issues/13397) #object_id should not be signed (shyouhei)
 - [[Feature #13396]](https://bugs.ruby-lang.org/issues/13396) Net::HTTP has no write timeout (shyouhei)
-- [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+- [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv_nonblock but not send_nonblock... can we add it? (shyouhei)
 - [[Feature #13395]](https://bugs.ruby-lang.org/issues/13395) Add a method to check for not nil (shyouhei)
 
 ## From non-attendees

--- a/2017/DevMeeting-2017-05-19.md
+++ b/2017/DevMeeting-2017-05-19.md
@@ -140,7 +140,7 @@ Place: Speee Inc. Headquarter
 
 Sign-up: https://ruby.connpass.com/event/55487/
 
-log edit: [https://docs.google.com/document/d/1XolSYFFvBOj\_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit](https://docs.google.com/document/d/1XolSYFFvBOj_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit)
+log edit: [https://docs.google.com/document/d/1XolSYFFvBOj_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit](https://docs.google.com/document/d/1XolSYFFvBOj_EwtLeYrg8QMadKZpUDE3b2EHcXoklYA/edit)
 
 log: TBD
 
@@ -181,7 +181,7 @@ log: TBD
 - [[Bug #13320]](https://bugs.ruby-lang.org/issues/13320) rescue blocks get an entry in backtrace locations
 
 - shyouhei: can you look at it? > nobu
-- ko1: there are other corner cases in backtraces where \_unexpected\_-ish backtrace situation.
+- ko1: there are other corner cases in backtraces where _unexpected_-ish backtrace situation.
 - mrkn: does it cause any problems? is it worth deleting?
 - ko1: I tried this and the “bar” line seems indicating the method bar, not raise.
 
@@ -239,7 +239,7 @@ log: TBD
 - shyouhei: it ends with “nobu: seems fine”.
 - nobu: will look at it again.
 
-- [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) \[PATCH\] POP3 support timeout for TLS handshake
+- [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) [PATCH] POP3 support timeout for TLS handshake
 
 - assign who?
 - seems no one is active.
@@ -266,21 +266,21 @@ log: TBD
 
 - matz: OK.
 
-- [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def\_instance\_delegator nil (shyouhei)
+- [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def_instance_delegator nil (shyouhei)
 - [[Feature #13333]](https://bugs.ruby-lang.org/issues/13333) block to yield (shyouhei)
 
 - nobu: because we can.
 - ko1: I’m afraid there can be places where this breaks something in-core.
 
 - [[Feature #13378]](https://bugs.ruby-lang.org/issues/13378) Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
-- [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+- [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) [PATCH] Expose rb_fstring and its family to C extensions (shyouhei)
 - [[Bug #13315]](https://bugs.ruby-lang.org/issues/13315) Single "%" at the end of printf format string appears in the result (shyouhei)
-- [[Feature #13385]](https://bugs.ruby-lang.org/issues/13385) \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
-- [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) \[PATCH\] Module#source\_location (shyouhei)
+- [[Feature #13385]](https://bugs.ruby-lang.org/issues/13385) [PATCH] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
+- [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) [PATCH] Module#source_location (shyouhei)
 - [[Feature #12063]](https://bugs.ruby-lang.org/issues/12063) KeyError#receiver and KeyError#name (shyouhei) status?
-- [[Bug #13397]](https://bugs.ruby-lang.org/issues/13397) #object\_id should not be signed (shyouhei)
+- [[Bug #13397]](https://bugs.ruby-lang.org/issues/13397) #object_id should not be signed (shyouhei)
 - [[Feature #13396]](https://bugs.ruby-lang.org/issues/13396) Net::HTTP has no write timeout (shyouhei)
-- [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+- [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv_nonblock but not send_nonblock... can we add it? (shyouhei)
 - [[Feature #13395]](https://bugs.ruby-lang.org/issues/13395) Add a method to check for not nil (shyouhei)
 
 ## From attendees
@@ -298,10 +298,10 @@ log: TBD
 - watson continues to request pulling his ideas
 
 - [[Bug #13436]](https://bugs.ruby-lang.org/issues/13436) Improve performance of Array#<=> with Fixnum/Float/String elements
-- [[Bug #13437]](https://bugs.ruby-lang.org/issues/13437) Improve performance of Enumerable#{sort\_by,min\_by,max\_by,minmax\_by}
+- [[Bug #13437]](https://bugs.ruby-lang.org/issues/13437) Improve performance of Enumerable#{sort_by,min_by,max_by,minmax_by}
 - [[Bug #13443]](https://bugs.ruby-lang.org/issues/13443) Improve performance of Range#{min,max}
 - [[Bug #13482]](https://bugs.ruby-lang.org/issues/13482) Improve performance of "set instance variable"
-- [[Bug #13447]](https://bugs.ruby-lang.org/issues/13447) Improve performance of rb\_eql()
+- [[Bug #13447]](https://bugs.ruby-lang.org/issues/13447) Improve performance of rb_eql()
 - [[Bug #13503]](https://bugs.ruby-lang.org/issues/13503) Improve performance of some Time & Rational methods
 - [[Bug #13506]](https://bugs.ruby-lang.org/issues/13506) Improve performance of Complex#{+,-,,/,\*,abs2}
 - [[Bug #13519]](https://bugs.ruby-lang.org/issues/13519) Improve performance of some Time methods
@@ -310,25 +310,25 @@ log: TBD
 
 - assign who? corner (shyouhei)
 
-- [[Bug #13432]](https://bugs.ruby-lang.org/issues/13432) set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
+- [[Bug #13432]](https://bugs.ruby-lang.org/issues/13432) set_trace_funcにproc->is_from_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
 - [[Bug #13446]](https://bugs.ruby-lang.org/issues/13446) refinements with prepend for module has strange behavior
 - [[Bug #13492]](https://bugs.ruby-lang.org/issues/13492) Integer#prime? and Prime.each might produce false positives
 
 - akr: the patch seems ok.
 
-- [[Bug #13498]](https://bugs.ruby-lang.org/issues/13498) Weakref, Weakmap and define\_finalizer don't work on frozen objects
+- [[Bug #13498]](https://bugs.ruby-lang.org/issues/13498) Weakref, Weakmap and define_finalizer don't work on frozen objects
 - [[Bug #13513]](https://bugs.ruby-lang.org/issues/13513) Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
 - [[Bug #13501]](https://bugs.ruby-lang.org/issues/13501) Process.kill behaviour for negative pid is not documented and may be wrong
 - [[Bug #13515]](https://bugs.ruby-lang.org/issues/13515) Pathname#join doesn't add separator on UNC paths
-- [[Bug #13521]](https://bugs.ruby-lang.org/issues/13521) \[PATCH\] Add fallback for DNS resolver registry key on Wine
-- [[Bug #13537]](https://bugs.ruby-lang.org/issues/13537) ruby crash in rb\_gc\_mark
+- [[Bug #13521]](https://bugs.ruby-lang.org/issues/13521) [PATCH] Add fallback for DNS resolver registry key on Wine
+- [[Bug #13537]](https://bugs.ruby-lang.org/issues/13537) ruby crash in rb_gc_mark
 - [[Bug #13545]](https://bugs.ruby-lang.org/issues/13545) Ruby built by clang 4.0.0 parses Float literal wrongly
 
 - naruse: OK but I think this is a day-to-day fix.
 
-- [[Bug #13548]](https://bugs.ruby-lang.org/issues/13548) miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
-- [[Bug #13555]](https://bugs.ruby-lang.org/issues/13555) Disable TestTrace#test\_trace\_stackoverflow
-- [[Bug #13524]](https://bugs.ruby-lang.org/issues/13524) miniruby: \[BUG\] Segmentation fault at 0x0055e487e00230 ruby 2.4.1p111 (2017-03-22 revision 58053) \[x86\_64-li
+- [[Bug #13548]](https://bugs.ruby-lang.org/issues/13548) miniruby SEGV while building with non-default CFLAGS (caused by __builtin_setjmp)
+- [[Bug #13555]](https://bugs.ruby-lang.org/issues/13555) Disable TestTrace#test_trace_stackoverflow
+- [[Bug #13524]](https://bugs.ruby-lang.org/issues/13524) miniruby: [BUG] Segmentation fault at 0x0055e487e00230 ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-li
 - [[Bug #13557]](https://bugs.ruby-lang.org/issues/13557) there's no way to pass backtrace locations as a massaged backtrace
 - [[Bug #10290]](https://bugs.ruby-lang.org/issues/10290) segfault when calling a lambda recursively after rescuing SystemStackError
 
@@ -339,11 +339,11 @@ log: TBD
 
 - [[Bug #13549]](https://bugs.ruby-lang.org/issues/13549) MinGW / Windows encoding - Two issues
 - [[Bug #13556]](https://bugs.ruby-lang.org/issues/13556) MinGW readline Alt / Meta keys
-- [[Bug #13569]](https://bugs.ruby-lang.org/issues/13569) Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+- [[Bug #13569]](https://bugs.ruby-lang.org/issues/13569) Windows - TestRubyOptions#test_search - append to paths instead of replacing
 
 - [[Bug #13564]](https://bugs.ruby-lang.org/issues/13564) Exception message management
 
-- [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) \[PATCH\] Module#source\_location (shyouhei)
+- [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) [PATCH] Module#source_location (shyouhei)
 - [[Feature #13434]](https://bugs.ruby-lang.org/issues/13434) better method definition in C API (shyouhei)
 - [[Feature #13512]](https://bugs.ruby-lang.org/issues/13512) System Threads (shyouhei)
 - [[Feature #13518]](https://bugs.ruby-lang.org/issues/13518) Indented multiline comments (shyouhei)
@@ -354,18 +354,18 @@ log: TBD
 - akr: it’s ok to add.  Patch please.
 
 - [[Bug #13535]](https://bugs.ruby-lang.org/issues/13535) Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
-- [[Feature #13552]](https://bugs.ruby-lang.org/issues/13552) \[PATCH 0/2\] reimplement ConditionVariable, Queue, SizedQueue using ccan/list (shyouhei)
-- [[Feature #13568]](https://bugs.ruby-lang.org/issues/13568) File#path for O\_TMPFILE fds are unmeaning (sorah)
+- [[Feature #13552]](https://bugs.ruby-lang.org/issues/13552) [PATCH 0/2] reimplement ConditionVariable, Queue, SizedQueue using ccan/list (shyouhei)
+- [[Feature #13568]](https://bugs.ruby-lang.org/issues/13568) File#path for O_TMPFILE fds are unmeaning (sorah)
 
-- sorah: It makes no sense for O\_TMPFILE to have a path
+- sorah: It makes no sense for O_TMPFILE to have a path
 - nobu: but should it be nil?  There will be no way to obtain underlying filesystem then.
 - sorah: it might make sense to have a separate method that returns the “argument string passed to File.new”.
 - akr: that sounds too big.
 - akr: File#path is used as inspectation on logs. therefore it should return informational string
-- naruse: \`ls -al ll /proc/25378/fd/9\` returns “lrwx------ 1 naruse 64 May 19 17:13 9 -> /tmp/#14379824 (deleted)”
+- naruse: `ls -al ll /proc/25378/fd/9` returns “lrwx------ 1 naruse 64 May 19 17:13 9 -> /tmp/#14379824 (deleted)”
 
 - [[Feature #13563]](https://bugs.ruby-lang.org/issues/13563) Implement Hash#choice method. (shyouhei)
-- [[Feature #13562]](https://bugs.ruby-lang.org/issues/13562) Use a sized enumerator with #yield\_self (shyouhei) needs?
+- [[Feature #13562]](https://bugs.ruby-lang.org/issues/13562) Use a sized enumerator with #yield_self (shyouhei) needs?
 
 - [[Feature #13056]](https://bugs.ruby-lang.org/issues/13056) base option to Dir.glob (nobu)
 

--- a/2017/DevMeeting-2017-06-16.md
+++ b/2017/DevMeeting-2017-06-16.md
@@ -104,7 +104,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 Time: 14:00- 18:00 (JST)
 Place: Money Forward inc. Headquarter
 Sign-up: [https://ruby.connpass.com/event/57968/](https://ruby.connpass.com/event/57968/)
-log edit: [https://docs.google.com/document/d/1z19pKt8jlpiEUR3RnWWBCfs3OR\_hbiAZMwpQ6ZTllP0/edit#](https://docs.google.com/document/d/1z19pKt8jlpiEUR3RnWWBCfs3OR_hbiAZMwpQ6ZTllP0/edit#)
+log edit: [https://docs.google.com/document/d/1z19pKt8jlpiEUR3RnWWBCfs3OR_hbiAZMwpQ6ZTllP0/edit#](https://docs.google.com/document/d/1z19pKt8jlpiEUR3RnWWBCfs3OR_hbiAZMwpQ6ZTllP0/edit#)
 Attendees: duerst (Martin Dürst)
 Language: mostly Japanese (sorry for non native Japanese speakers)
 
@@ -138,7 +138,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: is there any blocker?
 - hsbt: rspec.
 
-## [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def\_instance\_delegator nil (shyouhei)
+## [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def_instance_delegator nil (shyouhei)
 
 
 - assign nobu
@@ -154,43 +154,43 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 - nobu: I don’t want to handle fds this way because we can’t close properly on exceptions. I think we should wrap them using IOs.
 
-## [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) [PATCH] Expose rb_fstring and its family to C extensions (shyouhei)
 
 
 - ko1: how about it? I don’t like “f”string naming.
 - nobu: other languages call it “intern”
-- ko1: true but we already have rb\_intern().
+- ko1: true but we already have rb_intern().
 - ko1: nobody has idea. so that nobu and ko1 will decide it. nobody against exposing this functionality.
 
-## [[Feature #13385]](https://bugs.ruby-lang.org/issues/13385) \[PATCH\] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
+## [[Feature #13385]](https://bugs.ruby-lang.org/issues/13385) [PATCH] Make Resolv::DNS::Name validation similar to host and dig commands (shyouhei)
 
 
 - akr: I can’t say if this is valid until I fully understand the RFC.
-- akira: what about using domain\_name gem?
+- akira: what about using domain_name gem?
 - assign akr.
 
-## [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) \[PATCH\] Module#source\_location (shyouhei)
+## [[Feature #13383]](https://bugs.ruby-lang.org/issues/13383) [PATCH] Module#source_location (shyouhei)
 
 
 - akira: needs?
-- shyouhei: I think source\_locations makes more sense than source\_location.
-- akira: I started to confuse.  Is it useful?  We can already get Method#source\_location.
+- shyouhei: I think source_locations makes more sense than source_location.
+- akira: I started to confuse.  Is it useful?  We can already get Method#source_location.
 
 ## [[Feature #12063]](https://bugs.ruby-lang.org/issues/12063) KeyError#receiver and KeyError#name (shyouhei) status?
 
 
 - matz: I take KeyError#key.
 
-## [[Bug #13397]](https://bugs.ruby-lang.org/issues/13397) #object\_id should not be signed (shyouhei)
+## [[Bug #13397]](https://bugs.ruby-lang.org/issues/13397) #object_id should not be signed (shyouhei)
 
 
-- akr: isn’t it possible to somehow calculate so that we can avoid negative object\_id?  Because pointers are 8 byte aligned, while positive fixnums are of 262 space.
+- akr: isn’t it possible to somehow calculate so that we can avoid negative object_id?  Because pointers are 8 byte aligned, while positive fixnums are of 262 space.
 - nobu: it’s true we can avoid negative numbers on some environment, but not always.
 - reject this specific issue and request for new issue that address the inspect helper.
 
 ## [[Feature #13396]](https://bugs.ruby-lang.org/issues/13396) Net::HTTP has no write timeout (shyouhei)
 
-## [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+## [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv_nonblock but not send_nonblock... can we add it? (shyouhei)
 
 ## [[Feature #13395]](https://bugs.ruby-lang.org/issues/13395) Add a method to check for not nil (shyouhei)
 
@@ -209,7 +209,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Bug #13535]](https://bugs.ruby-lang.org/issues/13535) Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
 
-## [[Feature #13568]](https://bugs.ruby-lang.org/issues/13568) File#path for O\_TMPFILE fds are unmeaning (sorah)
+## [[Feature #13568]](https://bugs.ruby-lang.org/issues/13568) File#path for O_TMPFILE fds are unmeaning (sorah)
 
 ## [[Feature #13563]](https://bugs.ruby-lang.org/issues/13563) Implement Hash#choice method. (shyouhei)
 
@@ -232,7 +232,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Bug #12684]](https://bugs.ruby-lang.org/issues/12684) Delegator#eql? missing
 
-## [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) \[PATCH\] POP3 support timeout for TLS handshake
+## [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) [PATCH] POP3 support timeout for TLS handshake
 
 ## [[Bug #13404]](https://bugs.ruby-lang.org/issues/13404) Hash#any? yields arguments to lambdas with proc semantics
 
@@ -240,11 +240,11 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Bug #13429]](https://bugs.ruby-lang.org/issues/13429) Net::SMTP has no read timeout when connexion over TLS
 
-## [[Bug #13432]](https://bugs.ruby-lang.org/issues/13432) set\_trace\_funcにproc->is\_from\_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
+## [[Bug #13432]](https://bugs.ruby-lang.org/issues/13432) set_trace_funcにproc->is_from_method = TRUEのオブジェクトを渡し、SystemStackErrorを発生させるとRubyVMが停止する
 
 ## [[Bug #13446]](https://bugs.ruby-lang.org/issues/13446) refinements with prepend for module has strange behavior
 
-## [[Bug #13498]](https://bugs.ruby-lang.org/issues/13498) Weakref, Weakmap and define\_finalizer don't work on frozen objects
+## [[Bug #13498]](https://bugs.ruby-lang.org/issues/13498) Weakref, Weakmap and define_finalizer don't work on frozen objects
 
 ## [[Bug #13513]](https://bugs.ruby-lang.org/issues/13513) Resolv::DNS::Message.decode hangs after detecting truncation in UDP messages
 
@@ -252,13 +252,13 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Bug #13515]](https://bugs.ruby-lang.org/issues/13515) Pathname#join doesn't add separator on UNC paths
 
-## [[Bug #13521]](https://bugs.ruby-lang.org/issues/13521) \[PATCH\] Add fallback for DNS resolver registry key on Wine
+## [[Bug #13521]](https://bugs.ruby-lang.org/issues/13521) [PATCH] Add fallback for DNS resolver registry key on Wine
 
-## [[Bug #13537]](https://bugs.ruby-lang.org/issues/13537) ruby crash in rb\_gc\_mark
+## [[Bug #13537]](https://bugs.ruby-lang.org/issues/13537) ruby crash in rb_gc_mark
 
-## [[Bug #13548]](https://bugs.ruby-lang.org/issues/13548) miniruby SEGV while building with non-default CFLAGS (caused by \_\_builtin\_setjmp)
+## [[Bug #13548]](https://bugs.ruby-lang.org/issues/13548) miniruby SEGV while building with non-default CFLAGS (caused by __builtin_setjmp)
 
-## [[Bug #13555]](https://bugs.ruby-lang.org/issues/13555) Disable TestTrace#test\_trace\_stackoverflow
+## [[Bug #13555]](https://bugs.ruby-lang.org/issues/13555) Disable TestTrace#test_trace_stackoverflow
 
 ## [[Bug #13557]](https://bugs.ruby-lang.org/issues/13557) there's no way to pass backtrace locations as a massaged backtrace
 
@@ -278,7 +278,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Bug #13556]](https://bugs.ruby-lang.org/issues/13556) MinGW readline Alt / Meta keys
 
-## [[Bug #13569]](https://bugs.ruby-lang.org/issues/13569) Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+## [[Bug #13569]](https://bugs.ruby-lang.org/issues/13569) Windows - TestRubyOptions#test_search - append to paths instead of replacing
 
 
 ## [[Bug #13564]](https://bugs.ruby-lang.org/issues/13564) Exception message management
@@ -286,15 +286,15 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## From attendees
 
-## [[Bug #12159]](https://bugs.ruby-lang.org/issues/12159) Thread::Backtrace::Location#path returns absolute path for files loaded by require\_relative (ko1)
+## [[Bug #12159]](https://bugs.ruby-lang.org/issues/12159) Thread::Backtrace::Location#path returns absolute path for files loaded by require_relative (ko1)
 
 
-- ko1: I want to add Thread::Backtrace::Location#realpath to deprecate #absplute\_path instead.
+- ko1: I want to add Thread::Backtrace::Location#realpath to deprecate #absplute_path instead.
 - matz: no objection.
 
-## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
+## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) [PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (ko1)
 
-- [[Bug #13576]](https://bugs.ruby-lang.org/issues/13576) File#to\_path shall be deleted (shyouhei)
+- [[Bug #13576]](https://bugs.ruby-lang.org/issues/13576) File#to_path shall be deleted (shyouhei)
 
 - akr: did you try deleting this method?
 - shyouhei: no, but I should.
@@ -304,10 +304,10 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## Write your name and your interest (what do you want to ask and to whom?) please.
 
-## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (normalperson)
+## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) [PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (normalperson)
 
 
-- ko1: programmers transfer execution of fibers by hand.  Eric proposes to introduce “auto”-Fiber which are OK to transfer each other on blocking situations. His implementation is great. rb\_wait\_for\_single\_fd is the ponit of switching. matz wanted this feature, too.
+- ko1: programmers transfer execution of fibers by hand.  Eric proposes to introduce “auto”-Fiber which are OK to transfer each other on blocking situations. His implementation is great. rb_wait_for_single_fd is the ponit of switching. matz wanted this feature, too.
 - shyouhei: can auto Fibers be a subject to transfer or an object?
 - ko1: transfer happens only from an auto fiber to another and nothing else, AFAIK.
 - ko1: This is essentially a re-introduction of Ruby 1.8 threads (without time-tick). I’m concerning about thread difficulties like locking.
@@ -324,7 +324,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 ## [[Feature #12694]](https://bugs.ruby-lang.org/issues/12694) Want a String method to remove heading substr.
 
 
-- (sonots) I implemented with a name String#remove\_prefix. If the name is ok, I want to merge it. Matz, could you decide? There were other candidates such as lchomp, trim\_prefix. I dropped trim\_prefix because trim is used to remove a list of characters rather than a substring in some languages, so I felt trim\_prefix would raise confusion. I dropped lchomp because I just had never heard.
+- (sonots) I implemented with a name String#remove_prefix. If the name is ok, I want to merge it. Matz, could you decide? There were other candidates such as lchomp, trim_prefix. I dropped trim_prefix because trim is used to remove a list of characters rather than a substring in some languages, so I felt trim_prefix would raise confusion. I dropped lchomp because I just had never heard.
 
 - candidates discussed:
 
@@ -336,10 +336,10 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 - NG because PHP behaves differently
 
-- delete\_prefix
+- delete_prefix
 
-- amatsuda: remove\_prefix sounds strange if it doesn’t change the receiver.
+- amatsuda: remove_prefix sounds strange if it doesn’t change the receiver.
 - nobu: facets has lchomp.
 - akr: I don’t want chomp’s complex newline handling for this requested method.
-- ko1: remove\_prefix seems has no downsides.
-- matz: accept delete\_prefix.
+- ko1: remove_prefix seems has no downsides.
+- matz: accept delete_prefix.

--- a/2017/DevMeeting-2017-07-14.md
+++ b/2017/DevMeeting-2017-07-14.md
@@ -188,7 +188,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - nobu: then we should automatically assume text mode when newline: is specified.
 - matz: make it so,
 
-## [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) \[PATCH\] POP3 support timeout for TLS handshake
+## [[Feature #13389]](https://bugs.ruby-lang.org/issues/13389) [PATCH] POP3 support timeout for TLS handshake
 
 
 - hsbt: pop3 has no maintainer.
@@ -214,10 +214,10 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 
 - shyouhei: doc issue?
-- akr: we take negative signal or negative pids.  signal.c:rb\_f\_kill() has special codes for negative signals but not for negative pids.
+- akr: we take negative signal or negative pids.  signal.c:rb_f_kill() has special codes for negative signals but not for negative pids.
 - akr: what happens both signal and pid are negative?
 
-## [[Bug #13521]](https://bugs.ruby-lang.org/issues/13521) \[PATCH\] Add fallback for DNS resolver registry key on Wine
+## [[Bug #13521]](https://bugs.ruby-lang.org/issues/13521) [PATCH] Add fallback for DNS resolver registry key on Wine
 
 
 - nobu: 3rd party issue?
@@ -239,7 +239,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Bug #13556]](https://bugs.ruby-lang.org/issues/13556) MinGW readline Alt / Meta keys
 
-## [[Bug #13569]](https://bugs.ruby-lang.org/issues/13569) Windows - TestRubyOptions#test\_search - append to paths instead of replacing
+## [[Bug #13569]](https://bugs.ruby-lang.org/issues/13569) Windows - TestRubyOptions#test_search - append to paths instead of replacing
 
 ---
 - nobu: I cannot reproduce these problems.
@@ -249,7 +249,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 ## [[Bug #13564]](https://bugs.ruby-lang.org/issues/13564) Exception message management
 
 
-- matz I understand that it breaks encapsulation \_by theory\_, but in practice is it worth, for instance, duplicate every time?
+- matz I understand that it breaks encapsulation _by theory_, but in practice is it worth, for instance, duplicate every time?
 
 ## From attendees
 
@@ -257,14 +257,14 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 
 - should what happen for tainted string?
-- ko1: it seems there is string.c:fstring\_cmp.  Can’t we change this function?
+- ko1: it seems there is string.c:fstring_cmp.  Can’t we change this function?
 
-## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) [PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (shyouhei)
 
 
 - akr: Socket to DB would normally be pooled / shared among threads in normal web applications.  There shall be some locking mechanism to do so.
 
-## [[Feature #13583]](https://bugs.ruby-lang.org/issues/13583) Adding Hash#transform\_keys method (shyouhei)
+## [[Feature #13583]](https://bugs.ruby-lang.org/issues/13583) Adding Hash#transform_keys method (shyouhei)
 
 
 - matz: seems OK.
@@ -277,12 +277,12 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: I think scheme compilers tends to transpile into C.
 - matz: I like this idea itself.
 
-## [[Feature #13676]](https://bugs.ruby-lang.org/issues/13676) to\_s method is not overriden for Set (shyouhei)
+## [[Feature #13676]](https://bugs.ruby-lang.org/issues/13676) to_s method is not overriden for Set (shyouhei)
 
 
 - assign knu
 - shyouhei: what is wanted?
-- akr: seems the intension is to call to\_a internally
+- akr: seems the intension is to call to_a internally
 - knu: is it OK to call inspect?
 - matz: OK.
 
@@ -301,7 +301,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - bugs that are not assigned (shyouhei)
 
 
-## [[Bug #13586]](https://bugs.ruby-lang.org/issues/13586) Ruby hangs when accessing array which is modified in instance\_eval after Coverage.start
+## [[Bug #13586]](https://bugs.ruby-lang.org/issues/13586) Ruby hangs when accessing array which is modified in instance_eval after Coverage.start
 
 
 - assign nobu
@@ -349,7 +349,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 - naruse: doc issue.
 
-## [[Bug #13660]](https://bugs.ruby-lang.org/issues/13660) rb\_str\_hash\_m discards bits from the hash
+## [[Bug #13660]](https://bugs.ruby-lang.org/issues/13660) rb_str_hash_m discards bits from the hash
 
 
 - akr: it’s intentional.
@@ -381,13 +381,13 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - Martin: Okay to me.
 - nobu: nobody disallows to write specs at the first place, do they?
 
-## [[Feature #13665]](https://bugs.ruby-lang.org/issues/13665) Before I added String#delete\_prefix. For symmetry, is it okay to commit String#delete\_suffix? (sonots)
+## [[Feature #13665]](https://bugs.ruby-lang.org/issues/13665) Before I added String#delete_prefix. For symmetry, is it okay to commit String#delete_suffix? (sonots)
 
 
 - shyouhei: should we add it?
 - matz: no objection.
 
-## [[Feature #13743]](https://bugs.ruby-lang.org/issues/13743) Support linking of files opened with O\_TMPFILE (mmasaki)
+## [[Feature #13743]](https://bugs.ruby-lang.org/issues/13743) Support linking of files opened with O_TMPFILE (mmasaki)
 
 
 - nobu: File.link or File#link?

--- a/2017/DevMeeting-2017-08-31.md
+++ b/2017/DevMeeting-2017-08-31.md
@@ -184,7 +184,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 - [https://chouseisan.com/s?h=cbab178ad925432ca81f9a64b2563b95](https://chouseisan.com/s?h=cbab178ad925432ca81f9a64b2563b95)
 
-## Invitation to "mini RubyKaigi" (a\_matsuda)
+## Invitation to "mini RubyKaigi" (a_matsuda)
 
 - 3-6 committers
 
@@ -192,7 +192,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Feature #13396]](https://bugs.ruby-lang.org/issues/13396) Net::HTTP has no write timeout (shyouhei)
 
-## [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv\_nonblock but not send\_nonblock... can we add it? (shyouhei)
+## [[Bug #13407]](https://bugs.ruby-lang.org/issues/13407) We have recv_nonblock but not send_nonblock... can we add it? (shyouhei)
 
 ## [[Feature #13395]](https://bugs.ruby-lang.org/issues/13395) Add a method to check for not nil (shyouhei)
 
@@ -202,7 +202,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Bug #13535]](https://bugs.ruby-lang.org/issues/13535) Installing Ruby2.4.1 on Solaris 10 (shyouhei) response?
 
-## [[Feature #13568]](https://bugs.ruby-lang.org/issues/13568) File#path for O\_TMPFILE fds are unmeaning (sorah)
+## [[Feature #13568]](https://bugs.ruby-lang.org/issues/13568) File#path for O_TMPFILE fds are unmeaning (sorah)
 
 
 - raising exception
@@ -217,13 +217,13 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 - naming issue.
 
-## [[Bug #13438]](https://bugs.ruby-lang.org/issues/13438) Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei)
+## [[Bug #13438]](https://bugs.ruby-lang.org/issues/13438) Fix heap overflow due to configure.in not being updated for HEAP_\* -> HEAP_PAGE_\* variable renaming (shyouhei)
 
 ## [[Misc #12529]](https://bugs.ruby-lang.org/issues/12529) LEGAL file covering all the license information within Ruby (shyouhei)
 
-## [[Feature #13600]](https://bugs.ruby-lang.org/issues/13600) yield\_self should be chainable/composable (shyouhei)
+## [[Feature #13600]](https://bugs.ruby-lang.org/issues/13600) yield_self should be chainable/composable (shyouhei)
 
-## [[Misc #13597]](https://bugs.ruby-lang.org/issues/13597) Does read\_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
+## [[Misc #13597]](https://bugs.ruby-lang.org/issues/13597) Does read_nonblock call remalloc for the buffer if does it just set the size attribute (shyouhei)
 
 ## [[Feature #13606]](https://bugs.ruby-lang.org/issues/13606) Enumerator equality and comparison (shyouhei)
 
@@ -234,15 +234,15 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Feature #13602]](https://bugs.ruby-lang.org/issues/13602) Optimize instance variable access if $VERBOSE is not true when compiling (shyouhei)
 
-## [[Feature #13613]](https://bugs.ruby-lang.org/issues/13613) Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
+## [[Feature #13613]](https://bugs.ruby-lang.org/issues/13613) Prefer that require/require_relative/load to tell us permission error if the target file is unreadable (shyouhei)
 
 ## [[Feature #13620]](https://bugs.ruby-lang.org/issues/13620) Simplifying MRI's build system: always install (shyouhei)
 
-## [[Feature #13630]](https://bugs.ruby-lang.org/issues/13630) :\[\] method should accept block in nice syntax (shyouhei)
+## [[Feature #13630]](https://bugs.ruby-lang.org/issues/13630) :[] method should accept block in nice syntax (shyouhei)
 
 ## [[Feature #13639]](https://bugs.ruby-lang.org/issues/13639) Add "RTMIN" and "RTMAX" to Signal.list (shyouhei)
 
-## [[Feature #11484]](https://bugs.ruby-lang.org/issues/11484) add output offset for readpartial/read\_nonblock/etc (shyouhei)
+## [[Feature #11484]](https://bugs.ruby-lang.org/issues/11484) add output offset for readpartial/read_nonblock/etc (shyouhei)
 
 ## [[Feature #9001]](https://bugs.ruby-lang.org/issues/9001) Please package better standard library (shyouhei)
 
@@ -256,19 +256,19 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Feature #13551]](https://bugs.ruby-lang.org/issues/13551) Add a method to alias class methods (shyouhei)
 
-## [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def\_instance\_delegator nil (shyouhei)
+## [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def_instance_delegator nil (shyouhei)
 
 ## [[Feature #13378]](https://bugs.ruby-lang.org/issues/13378) Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
 
-## [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) [PATCH] Expose rb_fstring and its family to C extensions (shyouhei)
 
 ## [[Feature #13677]](https://bugs.ruby-lang.org/issues/13677) Add more details to error "Name or service not known (SocketError)" (shyouhei)
 
 ## [[Feature #9323]](https://bugs.ruby-lang.org/issues/9323) IO#writev (shyouhei)
 
-## [[Feature #13686]](https://bugs.ruby-lang.org/issues/13686) Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (shyouhei)
+## [[Feature #13686]](https://bugs.ruby-lang.org/issues/13686) Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on_\* (shyouhei)
 
-## [[Feature #13693]](https://bugs.ruby-lang.org/issues/13693) Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
+## [[Feature #13693]](https://bugs.ruby-lang.org/issues/13693) Allow String#to_i and / or Kernel::Integer to parse e-notation (shyouhei)
 
 ## [[Feature #13434]](https://bugs.ruby-lang.org/issues/13434) better method definition in C API (shyouhei)
 
@@ -280,9 +280,9 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Feature #13713]](https://bugs.ruby-lang.org/issues/13713) socketの便利メソッドのdatagramのUNIXSocket用対応 (shyouhei)
 
-## [[Feature #13715]](https://bugs.ruby-lang.org/issues/13715) \[PATCH\] avoid garbage from Symbol#to\_s in interpolation (shyouhei)
+## [[Feature #13715]](https://bugs.ruby-lang.org/issues/13715) [PATCH] avoid garbage from Symbol#to_s in interpolation (shyouhei)
 
-## [[Feature #13719]](https://bugs.ruby-lang.org/issues/13719) \[PATCH\] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
+## [[Feature #13719]](https://bugs.ruby-lang.org/issues/13719) [PATCH] net/http: allow existing socket arg for Net::HTTP.start (shyouhei)
 
 ## [[Feature #13732]](https://bugs.ruby-lang.org/issues/13732) Precise Time.now on Windows (shyouhei)
 
@@ -290,7 +290,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Feature #13625]](https://bugs.ruby-lang.org/issues/13625) BigDecimal short form / shorthand (shyouhei)
 
-## [[Feature #13712]](https://bugs.ruby-lang.org/issues/13712) String#start\_with? with regexp (shyouhei)
+## [[Feature #13712]](https://bugs.ruby-lang.org/issues/13712) String#start_with? with regexp (shyouhei)
 
 - bugs that are not assigned (shyouhei)
 
@@ -301,22 +301,22 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Bug #13700]](https://bugs.ruby-lang.org/issues/13700) Enumerable#sum may not work for Ranges subclasses due to optimization (mrkn)
 
-## [[Bug #13705]](https://bugs.ruby-lang.org/issues/13705) \[PATCH\] \`cfp consistency error' occurs when raising exception in bmethod call event
+## [[Bug #13705]](https://bugs.ruby-lang.org/issues/13705) [PATCH] `cfp consistency error' occurs when raising exception in bmethod call event
 
 ## [[Bug #13716]](https://bugs.ruby-lang.org/issues/13716) Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
 
-## [[Bug #13670]](https://bugs.ruby-lang.org/issues/13670) \[BUG\] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
+## [[Bug #13670]](https://bugs.ruby-lang.org/issues/13670) [BUG] Bus Error at 0xefce7b (armv7l) (ruby 2.3.4p301)
 
 
 ## From attendees
 
-## [[Feature #13780]](https://bugs.ruby-lang.org/issues/13780) String#each\_grapheme (naruse)
+## [[Feature #13780]](https://bugs.ruby-lang.org/issues/13780) String#each_grapheme (naruse)
 
 
-- matz: the unit is grapheme cluster. so the name should be each\_grapheme\_cluster.
+- matz: the unit is grapheme cluster. so the name should be each_grapheme_cluster.
 
 
-## [[Misc #13704]](https://bugs.ruby-lang.org/issues/13704) \[PATCH\] Exclude Changelog files from documentation. (hsbt)
+## [[Misc #13704]](https://bugs.ruby-lang.org/issues/13704) [PATCH] Exclude Changelog files from documentation. (hsbt)
 
 ## [[Feature #12733]](https://bugs.ruby-lang.org/issues/12733) Bundle bundler to ruby core (hsbt)
 
@@ -342,9 +342,9 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Feature #13767]](https://bugs.ruby-lang.org/issues/13767) add something like python's buffer protocol to share memory between different narray like classes (shyouhei)
 
-## [[Feature #13777]](https://bugs.ruby-lang.org/issues/13777) Array#delete\_all (shyouhei)
+## [[Feature #13777]](https://bugs.ruby-lang.org/issues/13777) Array#delete_all (shyouhei)
 
-## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) [PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (shyouhei)
 
 ## [[Feature #13784]](https://bugs.ruby-lang.org/issues/13784) Add Enumerable#filter as an alias of Enumerable#select (shyouhei)
 
@@ -384,13 +384,13 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Bug #13746]](https://bugs.ruby-lang.org/issues/13746) windows-pr gemのRuby 2.4 32bit版でのSEGV
 
-## [[Bug #13758]](https://bugs.ruby-lang.org/issues/13758) TestRubyOptions#test\_segv\_setproctitle segfaults on AARCH64
+## [[Bug #13758]](https://bugs.ruby-lang.org/issues/13758) TestRubyOptions#test_segv_setproctitle segfaults on AARCH64
 
 ## [[Bug #13716]](https://bugs.ruby-lang.org/issues/13716) Unexpected or undocumented (or maybe both) behaviour when mixing String#scan with named captures
 
 ## [[Bug #13691]](https://bugs.ruby-lang.org/issues/13691) Word- and symbol array literals not valid where regular array is
 
-## [[Bug #13769]](https://bugs.ruby-lang.org/issues/13769) IPAddr#ipv4\_compat incorrect behavior
+## [[Bug #13769]](https://bugs.ruby-lang.org/issues/13769) IPAddr#ipv4_compat incorrect behavior
 
 ## [[Bug #13768]](https://bugs.ruby-lang.org/issues/13768) SIGCHLD and Thread dead-lock problem
 
@@ -398,11 +398,11 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## [[Bug #13774]](https://bugs.ruby-lang.org/issues/13774) for methods defined from procs, the binding of the resulting bound method proc does not have access to the original proc's closure environment
 
-## [[Bug #13748]](https://bugs.ruby-lang.org/issues/13748) \[PATCH\] Fix mul overflow detection for LLP64 arch.
+## [[Bug #13748]](https://bugs.ruby-lang.org/issues/13748) [PATCH] Fix mul overflow detection for LLP64 arch.
 
 ## [[Bug #13781]](https://bugs.ruby-lang.org/issues/13781) Should the safe navigation operator invoke nil?
 
-## [[Bug #13795]](https://bugs.ruby-lang.org/issues/13795) Hash#select return type does not match Hash#find\_all
+## [[Bug #13795]](https://bugs.ruby-lang.org/issues/13795) Hash#select return type does not match Hash#find_all
 
 ## [[Bug #13811]](https://bugs.ruby-lang.org/issues/13811) Ruby 2.4.1 fails to compile inside qemu armhf - signal 11 (Segmentation fault)
 
@@ -411,7 +411,7 @@ We couldn’t investigate it because there is not enough reproduction instructio
 
 ## [[Bug #13818]](https://bugs.ruby-lang.org/issues/13818) Licence issue with use of Onigmo rather than Oniguruma library files
 
-## [[Bug #13827]](https://bugs.ruby-lang.org/issues/13827) Improve performance of Base64.urlsafe\_encode64
+## [[Bug #13827]](https://bugs.ruby-lang.org/issues/13827) Improve performance of Base64.urlsafe_encode64
 
 ## [[Bug #13829]](https://bugs.ruby-lang.org/issues/13829) NUL char in $0
 
@@ -419,7 +419,7 @@ We couldn’t investigate it because there is not enough reproduction instructio
 
 ## [[Bug #13835]](https://bugs.ruby-lang.org/issues/13835) Using 'open-uri' with 'tempfile' causes an exception
 
-## [[Bug #13757]](https://bugs.ruby-lang.org/issues/13757) TestBacktrace#test\_caller\_lev segaults on PPC
+## [[Bug #13757]](https://bugs.ruby-lang.org/issues/13757) TestBacktrace#test_caller_lev segaults on PPC
 
 ## [[Bug #13167]](https://bugs.ruby-lang.org/issues/13167) Dir.glob is 25x slower since Ruby 2.2
 
@@ -428,7 +428,7 @@ We couldn’t investigate it because there is not enough reproduction instructio
 
 ## From non-attendees
 
-## [[Feature #13686]](https://bugs.ruby-lang.org/issues/13686) Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on\_\* (aycabta)
+## [[Feature #13686]](https://bugs.ruby-lang.org/issues/13686) Add states of scanner to tokens from Ripper.lex and Ripper::Filter#on_\* (aycabta)
 
 
 ## Write your name and your interest (what do you want to ask and to whom?) please.

--- a/2017/DevMeeting-2017-09-25.md
+++ b/2017/DevMeeting-2017-09-25.md
@@ -162,8 +162,8 @@ Date: 2017/09/25 (Mon)
 Time: 14:00- 18:00 (JST)
 Place: Speee, Inc.
 Sign-up: [https://ruby.connpass.com/event/67822/](https://ruby.connpass.com/event/67822/)
-log edit: [https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9\_TkMayQ6\_s/edit](https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9_TkMayQ6_s/edit)
-log: [https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9\_TkMayQ6\_s/pub](https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9_TkMayQ6_s/pub)
+log edit: [https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9_TkMayQ6_s/edit](https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9_TkMayQ6_s/edit)
+log: [https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9_TkMayQ6_s/pub](https://docs.google.com/document/d/1lkipHlUzcSSse01EFGvlABuCmY7WwXun9_TkMayQ6_s/pub)
 Attendees: matz (Yukihiro Matsumoto), nobu (Nobuyoshi Nakada), ko1 (Koichi Sasada, partially), naruse (Yui Naruse), akr (Akira Tanaka), shyouhei (Shyouhei Urabe), mrkn (Kenta Murata), mame (Yusuke Endoh), knu (Akinori MUSHA), duerst (Martin Dürst), yuki (Yuki Nishijima) (add your name here if you would like to appear)
 Language: mostly Japanese (sorry for non native Japanese speakers)
 
@@ -196,7 +196,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 - naruse: I’ll implement this.
 
-## [[Bug #13438]](https://bugs.ruby-lang.org/issues/13438) Fix heap overflow due to configure.in not being updated for HEAP\_\* -> HEAP\_PAGE\_\* variable renaming (shyouhei) Sorry, what was the conclusion of it?
+## [[Bug #13438]](https://bugs.ruby-lang.org/issues/13438) Fix heap overflow due to configure.in not being updated for HEAP_\* -> HEAP_PAGE_\* variable renaming (shyouhei) Sorry, what was the conclusion of it?
 
 
 - mrkn: I remember we should not support old OpenBSD.
@@ -217,11 +217,11 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 - ko1: is it worth for a 5-6% speedup?
 - mame: this should affect optcarrot...
 
-## [[Feature #13613]](https://bugs.ruby-lang.org/issues/13613) Prefer that require/require\_relative/load to tell us permission error if the target file is unreadable (shyouhei)
+## [[Feature #13613]](https://bugs.ruby-lang.org/issues/13613) Prefer that require/require_relative/load to tell us permission error if the target file is unreadable (shyouhei)
 
 
 - akr: we should define errors that are “fatal” and those aren’t.  For instance, ENOENT is not fatal but EPERM is.
-- shyouhei: it sounds reasonable for someone want to know when there \_are\_ some nasty files.
+- shyouhei: it sounds reasonable for someone want to know when there _are_ some nasty files.
 - mame: should we raise exceptions for errors other than ENOENT? or to warn only?
 
 ## [[Feature #13620]](https://bugs.ruby-lang.org/issues/13620) Simplifying MRI's build system: always install (shyouhei)
@@ -229,20 +229,20 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 - the thread is going on.
 
-## [[Feature #13630]](https://bugs.ruby-lang.org/issues/13630) :\[\] method should accept block in nice syntax (shyouhei) OK to close?
+## [[Feature #13630]](https://bugs.ruby-lang.org/issues/13630) :[] method should accept block in nice syntax (shyouhei) OK to close?
 
 
 - matz: I think it should be accepted.
 - nobu: mruby doesn’t work this way, BTW.
 - shyouhei: OK, lets close.
 
-- [[Feature #11484]](https://bugs.ruby-lang.org/issues/11484) add output offset for readpartial/read\_nonblock/etc (shyouhei)
+- [[Feature #11484]](https://bugs.ruby-lang.org/issues/11484) add output offset for readpartial/read_nonblock/etc (shyouhei)
 
 - akr: sounds OK to me.
 - shyouhei: seems nobody is against the feature itself but the API?
 - akr: keyword argument sounds reasobable.
-- matz: off\_out doesn’t charm me.
-- nobu: what about buffer\_offset?
+- matz: off_out doesn’t charm me.
+- nobu: what about buffer_offset?
 - knu: seems IO.write has optional 3rd argument, offset, which is used to seek the file.
 
 ## [[Feature #9001]](https://bugs.ruby-lang.org/issues/9001) Please package better standard library (shyouhe)
@@ -306,12 +306,12 @@ puts "tomatoe".vegetables
 - shyouhei: ah, I want this feature.
 - matz: I prefer opening singleton class.
 
-## [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def\_instance\_delegator nil (shyouhei)
+## [[Feature #13332]](https://bugs.ruby-lang.org/issues/13332) Forwardable#def_instance_delegator nil (shyouhei)
 
 
 - nobu: I don’t think this is much meaningful.
 - matz: I fell it’s over-engineering.
-- knu: ActiveSupport::Delegate also doesn’t support this comples feature (but only allow\_nil)
+- knu: ActiveSupport::Delegate also doesn’t support this comples feature (but only allow_nil)
 - matz: I’d like to hear use cases.
 
 ## [[Feature #13378]](https://bugs.ruby-lang.org/issues/13378) Eliminate 4 of 8 syscalls when requiring file by absolute path (shyouhei)
@@ -319,7 +319,7 @@ puts "tomatoe".vegetables
 
 - nobu: I’m handlig this. WIP.
 
-## [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) \[PATCH\] Expose rb\_fstring and its family to C extensions (shyouhei)
+## [[Feature #13381]](https://bugs.ruby-lang.org/issues/13381) [PATCH] Expose rb_fstring and its family to C extensions (shyouhei)
 
 
 - matz: postpone because ko1 is absent.
@@ -327,7 +327,7 @@ puts "tomatoe".vegetables
 ## [[Feature #13677]](https://bugs.ruby-lang.org/issues/13677) Add more details to error "Name or service not known (SocketError)" (shyouhei)
 
 
-- akr: we currenly only show the return value of gai\_strerror(). Seems OK to extend though.
+- akr: we currenly only show the return value of gai_strerror(). Seems OK to extend though.
 - akr: patch is welcomed.
 
 ## [[Feature #9323]](https://bugs.ruby-lang.org/issues/9323) IO#writev (shyouhei)
@@ -337,17 +337,17 @@ puts "tomatoe".vegetables
 - mame: I want to know how this speeds things up.
 - knu: maybe atomic write is the point.
 
-## [[Feature #13693]](https://bugs.ruby-lang.org/issues/13693) Allow String#to\_i and / or Kernel::Integer to parse e-notation (shyouhei)
+## [[Feature #13693]](https://bugs.ruby-lang.org/issues/13693) Allow String#to_i and / or Kernel::Integer to parse e-notation (shyouhei)
 
 
 - mame: haha
 - duerst: 1e+3 doesn’t sound like a integer.
 - nobu: should we accept minus?
 - akr: yes because 10e-1 shall be OK according to this request.
-- mrkn: backwards compatibility is to huge in #to\_i
-- shyouhei: so should we recommend using #to\_r, then round?
+- mrkn: backwards compatibility is to huge in #to_i
+- shyouhei: so should we recommend using #to_r, then round?
 - mrkn: yes.
-- mrkn: it seems the behaviour of #to\_i comes with atoi().
+- mrkn: it seems the behaviour of #to_i comes with atoi().
 
 ## [[Feature #13434]](https://bugs.ruby-lang.org/issues/13434) better method definition in C API (shyouhei)
 
@@ -371,7 +371,7 @@ puts "tomatoe".vegetables
 - mame: what about the feature itself?
 - matz: think we need more use case.
 
-## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (shyouhei)
+## [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) [PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (shyouhei)
 
 
 - matz: async { File.read }
@@ -385,7 +385,7 @@ puts "tomatoe".vegetables
 
 - ko1: it’s technically impossible.
 
-## [[Bug #13931]](https://bugs.ruby-lang.org/issues/13931) correct install\_name of libruby on macOS (libruby.2.5.0.dylib -> libruby.2.5.dylib) (naruse)
+## [[Bug #13931]](https://bugs.ruby-lang.org/issues/13931) correct install_name of libruby on macOS (libruby.2.5.0.dylib -> libruby.2.5.dylib) (naruse)
 
 
 - nobu: compatibility version shall be, and is, “2.4.0” ATM.  But we had bugs before.  I don’t want to change the AS-IS behaviour.
@@ -399,12 +399,12 @@ puts "tomatoe".vegetables
 - mame: we don’t optimize Comparable#clamp for literals, because no practical usage can be thought for such thing. NEWS shall be consulted.
 - naruse: I’ll respond as such. nobu will merge the pull request.
 
-## [[Feature #13893]](https://bugs.ruby-lang.org/issues/13893) Add Fiber#\[\] and Fiber#\[\]= and restore Thread#\[\] and Thread#\[\]= to their original behavior (shyouhei)
+## [[Feature #13893]](https://bugs.ruby-lang.org/issues/13893) Add Fiber#[] and Fiber#[]= and restore Thread#[] and Thread#[]= to their original behavior (shyouhei)
 
 
 - akr: This is clear, but too late.
 
-## [[Feature #10344]](https://bugs.ruby-lang.org/issues/10344) \[PATCH\] Implement Fiber#raise (shyouhei)
+## [[Feature #10344]](https://bugs.ruby-lang.org/issues/10344) [PATCH] Implement Fiber#raise (shyouhei)
 
 
 - ko1: if we allow Fiber#raise, auto fiber shall introduce weired behaviour.
@@ -419,7 +419,7 @@ puts "tomatoe".vegetables
 - matz: or with in Python
 - matz: I don’t want to add new keywords.
 - nobu: I now think it should be done using a library, not by the language.
-- matz: what about introducing ensure\_mod, just like rescue\_mod?
+- matz: what about introducing ensure_mod, just like rescue_mod?
 - nobu: should that expose ensure’s scope?
 - knu: foo rescue bar ensure baz sounds like baz would be executed immediately at the line.
 - akr: I’d like to propose non-nesting block:
@@ -452,14 +452,14 @@ puts "tomatoe".vegetables
 - knu: .of sounds NG…
 - akr: what about optional argument that describes the unit of second argument?
     Time.at(123, 456, :nanosecond)
-- matz: \`Time.at(100000, 123, :nsec)\`? \`Time.at(100000, 123,:msec)\`? \`Time.at(100000, nsec: 123)\`?
+- matz: `Time.at(100000, 123, :nsec)`? `Time.at(100000, 123,:msec)`? `Time.at(100000, nsec: 123)`?
 - ko1: This seems to be the first kind of API
-- akr: No, we already have CLOCK\_GETTIME
+- akr: No, we already have CLOCK_GETTIME
 - ko1: what to do about Time.at(1, msec: 234, nsec: 567)
 - naruse: I think no practical usage are there for specifying both msec and nsec.
 - matz: OK, accepted.  But specifying nil shall raise exceptions.
 
-## [[Bug #13887]](https://bugs.ruby-lang.org/issues/13887) test/ruby/test\_io.rb may get stuck with FIBER\_USE\_NATIVE=0 on Linux
+## [[Bug #13887]](https://bugs.ruby-lang.org/issues/13887) test/ruby/test_io.rb may get stuck with FIBER_USE_NATIVE=0 on Linux
 
 
 - ko1: this is a bug that should be fixed. I’ll do.

--- a/2018/DevMeeting-2018-01-24.md
+++ b/2018/DevMeeting-2018-01-24.md
@@ -127,7 +127,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 
 ## Sign-up: [https://ruby.connpass.com/event/73509/](https://ruby.connpass.com/event/73509/)
 
-## log edit: [https://docs.google.com/document/d/1XbUbch8\_eTqh21FOwj9a\_X-ZyJyCBjxkq8rWwfpf5BM/edit](https://docs.google.com/document/d/1XbUbch8_eTqh21FOwj9a_X-ZyJyCBjxkq8rWwfpf5BM/edit)
+## log edit: [https://docs.google.com/document/d/1XbUbch8_eTqh21FOwj9a_X-ZyJyCBjxkq8rWwfpf5BM/edit](https://docs.google.com/document/d/1XbUbch8_eTqh21FOwj9a_X-ZyJyCBjxkq8rWwfpf5BM/edit)
 
 ## log: TBD
 
@@ -162,22 +162,22 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 
 ## From attendees
 
-## [[Feature #14223]](https://bugs.ruby-lang.org/issues/14223) Enable #to\_proc by Refinements at &hoge (nobu)
+## [[Feature #14223]](https://bugs.ruby-lang.org/issues/14223) Enable #to_proc by Refinements at &hoge (nobu)
 
 
 - Matz: LGTM.
 
-## [[Feature #14371]](https://bugs.ruby-lang.org/issues/14371) New option "recursive: true" for Hash#transform\_keys! (nobu)
+## [[Feature #14371]](https://bugs.ruby-lang.org/issues/14371) New option "recursive: true" for Hash#transform_keys! (nobu)
 
 
-- Mrkn: This is deep\_stringify\_keys!
+- Mrkn: This is deep_stringify_keys!
 - Shyouhei: Understand the needs.
 - Mame: Should this be called recursive: true ?
 - Mrkn: This method has some assumption on the receiver’s structure. E.g. JSON
 - Knu: This method changes values as well as keys, which seems wrong.
 - Matz: This particular API seems NG to me.
 
-## \[Bug #14380\] Expected transform\_keys! to work just as transform\_keys, but it doesn't (mame)
+## \[Bug #14380\] Expected transform_keys! to work just as transform_keys, but it doesn't (mame)
 
 
 - Shyouhei: This behaviour was inherited from ActiveSupport.
@@ -205,7 +205,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Mrkn: But he doesn’t have the repo access bit, nor gem release right.
 - Mame: He’s active on twitter etc.  You should ask his current status.
 
-## [[Feature #4831]](https://bugs.ruby-lang.org/issues/4831) Integer#prime\_factors (mrkn)
+## [[Feature #4831]](https://bugs.ruby-lang.org/issues/4831) Integer#prime_factors (mrkn)
 
 
 - Mrkn: name?
@@ -219,8 +219,8 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Nobu: is this request to raise error when spawn fails, or when the spawned process fails?
 - Mrkn: I don’t like the RuntimeError.
 - K0kubun: RuntimeError is from Rake.
-- Mrkn: I see similarity for discussion on Integer(). \[ruby-core:77171\] \[Feature#12732\]
-- Akr: There are \`exception: true\`
+- Mrkn: I see similarity for discussion on Integer(). [ruby-core:77171] [Feature#12732]
+- Akr: There are `exception: true`
 
 ## [[Bug #14353]](https://bugs.ruby-lang.org/issues/14353) $SAFE should stay at least thread-local for compatibility (ko1)
 
@@ -248,7 +248,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 
 ## From non-attendees
 
-## [[Feature #14382]](https://bugs.ruby-lang.org/issues/14382) Make public access of a private constant call const\_missing (jeremyevans0)
+## [[Feature #14382]](https://bugs.ruby-lang.org/issues/14382) Make public access of a private constant call const_missing (jeremyevans0)
 
 
 - Nobu: sounds like a bug to me
@@ -265,10 +265,10 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Naruse: as a release management, 2.6 is good timing to warn because it has good benefit for paying compatibility cost.
 - Mame: warn this?
 - Akr: warning, if any, should not be annoying this case because it should / would happen on parsing.
-- Mame: should we also deprecate def \`; end; self.\` ? If so, warning on parsing is dangerous.
+- Mame: should we also deprecate def `; end; self.` ? If so, warning on parsing is dangerous.
 - Matz: I think we don’t necessarily warn this as soon as 2.6.
 
-## [[Feature #13969]](https://bugs.ruby-lang.org/issues/13969) Dir#each\_child (znz)
+## [[Feature #13969]](https://bugs.ruby-lang.org/issues/13969) Dir#each_child (znz)
 
 
 - Matz: OK.

--- a/2018/DevMeeting-2018-02-20.md
+++ b/2018/DevMeeting-2018-02-20.md
@@ -124,7 +124,7 @@ Please add your favorite ticket numbers you want to ask to discuss.
 
 ## Sign-up: [https://ruby.connpass.com/event/73509/](https://ruby.connpass.com/event/73509/)
 
-## log edit: [https://docs.google.com/document/d/1XbUbch8\_eTqh21FOwj9a\_X-ZyJyCBjxkq8rWwfpf5BM/edit](https://docs.google.com/document/d/1XbUbch8_eTqh21FOwj9a_X-ZyJyCBjxkq8rWwfpf5BM/edit)
+## log edit: [https://docs.google.com/document/d/1XbUbch8_eTqh21FOwj9a_X-ZyJyCBjxkq8rWwfpf5BM/edit](https://docs.google.com/document/d/1XbUbch8_eTqh21FOwj9a_X-ZyJyCBjxkq8rWwfpf5BM/edit)
 
 ## log: TBD
 
@@ -163,22 +163,22 @@ Next Developper Meetings
 
 ## From attendees
 
-## [[Feature #14223]](https://bugs.ruby-lang.org/issues/14223) Enable #to\_proc by Refinements at &hoge (nobu)
+## [[Feature #14223]](https://bugs.ruby-lang.org/issues/14223) Enable #to_proc by Refinements at &hoge (nobu)
 
 
 - Matz: LGTM.
 
-## [[Feature #14371]](https://bugs.ruby-lang.org/issues/14371) New option "recursive: true" for Hash#transform\_keys! (nobu)
+## [[Feature #14371]](https://bugs.ruby-lang.org/issues/14371) New option "recursive: true" for Hash#transform_keys! (nobu)
 
 
-- Mrkn: This is deep\_stringify\_keys!
+- Mrkn: This is deep_stringify_keys!
 - Shyouhei: Understand the needs.
 - Mame: Should this be called recursive: true ?
 - Mrkn: This method has some assumption on the receiver’s structure. E.g. JSON
 - Knu: This method changes values as well as keys, which seems wrong.
 - Matz: This particular API seems NG to me.
 
-## \[Bug #14380\] Expected transform\_keys! to work just as transform\_keys, but it doesn't (mame)
+## \[Bug #14380\] Expected transform_keys! to work just as transform_keys, but it doesn't (mame)
 
 
 - Shyouhei: This behaviour was inherited from ActiveSupport.
@@ -206,7 +206,7 @@ Next Developper Meetings
 - Mrkn: But he doesn’t have the repo access bit, nor gem release right.
 - Mame: He’s active on twitter etc.  You should ask his current status.
 
-## [[Feature #4831]](https://bugs.ruby-lang.org/issues/4831) Integer#prime\_factors (mrkn)
+## [[Feature #4831]](https://bugs.ruby-lang.org/issues/4831) Integer#prime_factors (mrkn)
 
 
 - Mrkn: name?
@@ -220,8 +220,8 @@ Next Developper Meetings
 - Nobu: is this request to raise error when spawn fails, or when the spawned process fails?
 - Mrkn: I don’t like the RuntimeError.
 - K0kubun: RuntimeError is from Rake.
-- Mrkn: I see similarity for discussion on Integer(). \[ruby-core:77171\] \[Feature#12732\]
-- Akr: There are \`exception: true\`
+- Mrkn: I see similarity for discussion on Integer(). [ruby-core:77171] [Feature#12732]
+- Akr: There are `exception: true`
 
 ## [[Bug #14353]](https://bugs.ruby-lang.org/issues/14353) $SAFE should stay at least thread-local for compatibility (ko1)
 
@@ -249,7 +249,7 @@ Next Developper Meetings
 
 ## From non-attendees
 
-## [[Feature #14382]](https://bugs.ruby-lang.org/issues/14382) Make public access of a private constant call const\_missing (jeremyevans0)
+## [[Feature #14382]](https://bugs.ruby-lang.org/issues/14382) Make public access of a private constant call const_missing (jeremyevans0)
 
 
 - Nobu: sounds like a bug to me
@@ -266,10 +266,10 @@ Next Developper Meetings
 - Naruse: as a release management, 2.6 is good timing to warn because it has good benefit for paying compatibility cost.
 - Mame: warn this?
 - Akr: warning, if any, should not be annoying this case because it should / would happen on parsing.
-- Mame: should we also deprecate def \`; end; self.\` ? If so, warning on parsing is dangerous.
+- Mame: should we also deprecate def `; end; self.` ? If so, warning on parsing is dangerous.
 - Matz: I think we don’t necessarily warn this as soon as 2.6.
 
-## [[Feature #13969]](https://bugs.ruby-lang.org/issues/13969) Dir#each\_child (znz)
+## [[Feature #13969]](https://bugs.ruby-lang.org/issues/13969) Dir#each_child (znz)
 
 
 - Matz: OK.

--- a/2018/DevMeeting-2018-03-15.md
+++ b/2018/DevMeeting-2018-03-15.md
@@ -138,25 +138,25 @@ Maintainers starting Apr 2018:
 - Resolved
 - Mrkn will file the conclusion.
 
-- [[Feature #14476]](https://bugs.ruby-lang.org/issues/14476) Adding same\_all? for checking whether all items in an Array are same (mrkn)
+- [[Feature #14476]](https://bugs.ruby-lang.org/issues/14476) Adding same_all? for checking whether all items in an Array are same (mrkn)
 
-- Definition of “same”? -> \`\==\`, for mrkn’s case
-- Empty array? -> true, \[\].all?{} #=> true
-- same\_all? -> bad name: unnatural English
-- all\_same? Or all\_equal? -> natural, but it seems to use Object#equal? (assert\_same uses Object#equal?)
+- Definition of “same”? -> `\==`, for mrkn’s case
+- Empty array? -> true, [].all?{} #=> true
+- same_all? -> bad name: unnatural English
+- all_same? Or all_equal? -> natural, but it seems to use Object#equal? (assert_same uses Object#equal?)
 - uniform? -> “uniform array” means an array contains same type values
 - constant? -> easy to misunderstand
-- uniform\_values? -> verbose
+- uniform_values? -> verbose
 - Usage examples:
 
-- ary.all\_equal?
-- ary.all\_equal?{|e| e.foo}
-- ary.all\_same?
-- ary.all\_same?{|e| e.foo}
+- ary.all_equal?
+- ary.all_equal?{|e| e.foo}
+- ary.all_same?
+- ary.all_same?{|e| e.foo}
 - ary.uniform?
 - ary.uniform?{|e| e.foo}
-- ary.uniform\_values?
-- ary.uniform\_values?{|e| e.foo}
+- ary.uniform_values?
+- ary.uniform_values?{|e| e.foo}
 
 - [[Feature #14362]](https://bugs.ruby-lang.org/issues/14362) use BigDecimal instead of Float by default (mrkn)
 
@@ -205,14 +205,14 @@ p 1.step(by: 2)         #=> (1.step(by:2))
 - Will be SyntaxError in 2.6-preview2
 - All of begin/do/def (experimental)
 
-- [[Feature #14594]](https://bugs.ruby-lang.org/issues/14594) Rethink yield\_self's name
+- [[Feature #14594]](https://bugs.ruby-lang.org/issues/14594) Rethink yield_self's name
 
 - “then”?
 - (1) Possible to use this method name by other libraries (like promise)
 - (2) No built-in methods like this …
 - Comitters objected the suggestion but matz accepted it
 
-- [[Feature #14324]](https://bugs.ruby-lang.org/issues/14324) Should Exception#full\_message include escape sequences?
+- [[Feature #14324]](https://bugs.ruby-lang.org/issues/14324) Should Exception#full_message include escape sequences?
 
 - Keyword arguments
 
@@ -221,7 +221,7 @@ p 1.step(by: 2)         #=> (1.step(by:2))
 
 - [[Feature #12745]](https://bugs.ruby-lang.org/issues/12745) String#(g)sub(!) should pass a MatchData to the block, not a String
 
-- akr: how about gsubm, \`m\` means MatchData
+- akr: how about gsubm, `m` means MatchData
 
 ### From non-attendees
 
@@ -290,7 +290,7 @@ B.show
 
 - Matz approved NameError
 
-- \[Bugs [#14380](https://bugs.ruby-lang.org/issues/14380)\] Change Hash#transform\_keys! and break compatibility with Ruby 2.5 and ActiveSupport, or not?
+- \[Bugs [#14380](https://bugs.ruby-lang.org/issues/14380)\] Change Hash#transform_keys! and break compatibility with Ruby 2.5 and ActiveSupport, or not?
 
 - It’s considered bug. amatsuda says ActiveSupport will follow Ruby 2.6.
 

--- a/2018/DevMeeting-2018-04-19.md
+++ b/2018/DevMeeting-2018-04-19.md
@@ -85,13 +85,13 @@ wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Ja
 
 ### From attendees
 
-[[Bug #14345]](https://bugs.ruby-lang.org/issues/14345) http\_proxy setting should respect both parent domain and subdomain (hsbt)
+[[Bug #14345]](https://bugs.ruby-lang.org/issues/14345) http_proxy setting should respect both parent domain and subdomain (hsbt)
 
 [[Feature #14559]](https://bugs.ruby-lang.org/issues/14559) ENV.slice (hsbt)
 
 - Matz: OK.
 
-[[Feature #14643]](https://bugs.ruby-lang.org/issues/14643) Remove problematic separator '\\0' of Dir.glob and Dir.\[\] (usa)
+[[Feature #14643]](https://bugs.ruby-lang.org/issues/14643) Remove problematic separator '\\0' of Dir.glob and Dir.[] (usa)
 
 - Usa: we can pass arrays to the pattern.  No need to use \\0.
 - Matz: makes sense.
@@ -126,7 +126,7 @@ wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Ja
 
 - Matz: sounds like an implementation detail.
 - Ko1: it’s too large a patch to implement this as a new VM instruction.
-- Naruse: when I tested opt\_to\_s with @k0kubun the speedup was marginal/not that much.
+- Naruse: when I tested opt_to_s with @k0kubun the speedup was marginal/not that much.
 
 [[Feature #6670]](https://bugs.ruby-lang.org/issues/6670) str.chars.last should be possible (mame)
 
@@ -146,7 +146,7 @@ wiki: [https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20180419Ja
 
 - Naruse: I’ll take care.  Let me make this a doc issue.
 
-\[Feature #14594\] Rethink yield\_self's name (matz)
+\[Feature #14594\] Rethink yield_self's name (matz)
 
 - Matz: I can live with #then.
 

--- a/2018/DevMeeting-2018-05-17.md
+++ b/2018/DevMeeting-2018-05-17.md
@@ -147,7 +147,7 @@ logs
 
 - [[Feature #14724]](https://bugs.ruby-lang.org/issues/14724) chains of inequations (mrkn)
 
-- This new syntax can also reduce the duplicated evaluations of common terms, such as timeval.tv\_sec in the descriptiohn of the proposal.
+- This new syntax can also reduce the duplicated evaluations of common terms, such as timeval.tv_sec in the descriptiohn of the proposal.
 - Same issue as above. See above.
 
 - Object#then (Usa)
@@ -185,7 +185,7 @@ Functional programming: (zverok)
 - 1-year-old proposal. Matz: "I am for adding syntax sugar for method reference. But I don't like proposed syntax (e.g. \->). Any other idea?"
 - (reviewed comment #21)
 - Preference by the attendees is .:
-- Matz: \`.:\` is better than \`->\`
+- Matz: `.:` is better than `->`
 - Mame: there is a patch cf #12125 [https://bugs.ruby-lang.org/issues/12125](https://bugs.ruby-lang.org/issues/12125)
 
 - [[Feature #11161]](https://bugs.ruby-lang.org/issues/11161) Proc/Method#rcurry working like curry but in reverse order
@@ -194,7 +194,7 @@ Functional programming: (zverok)
 - Mame: I don’t think reverse currying works for variadic methods
 - Akr: the “real-life” example is adding keyword arguments, which is not what currying is talking about
 
-- [[Feature #14390]](https://bugs.ruby-lang.org/issues/14390) UnboundMethod#to\_proc
+- [[Feature #14390]](https://bugs.ruby-lang.org/issues/14390) UnboundMethod#to_proc
 
 - What is the expected behaviour here?
 
@@ -218,7 +218,7 @@ Docs (probably not to discuss on development meeting, but I am not sure where I 
 - Method: [https://bugs.ruby-lang.org/issues/14483](https://bugs.ruby-lang.org/issues/14483)
 - Proc: [https://bugs.ruby-lang.org/issues/14610](https://bugs.ruby-lang.org/issues/14610)
 - MatchData: [https://bugs.ruby-lang.org/issues/14450](https://bugs.ruby-lang.org/issues/14450)
-- yield\_self: [https://bugs.ruby-lang.org/issues/14436](https://bugs.ruby-lang.org/issues/14436)
+- yield_self: [https://bugs.ruby-lang.org/issues/14436](https://bugs.ruby-lang.org/issues/14436)
 
 - Naruse: This meeting is not for documents. Just assign to docs member group.
 
@@ -226,7 +226,7 @@ Docs (probably not to discuss on development meeting, but I am not sure where I 
 
 - Shyouhei: what to do with String this case?
 - Akr: the simplest is to only concern the both ends.
-- Usa: Hash has \`>\` and \`<\`
+- Usa: Hash has `>` and `<`
 - Mame: use case not clear.
 
 - [[Feature #14097]](https://bugs.ruby-lang.org/issues/14097) Add union and difference to Array ( ana06)
@@ -243,4 +243,4 @@ Docs (probably not to discuss on development meeting, but I am not sure where I 
 
 - [[Misc #14760]](https://bugs.ruby-lang.org/issues/14760) cross-thread IO#close semantics (normal)
 
-- Ko1: I made it theoretically possible to unblock IO#select. However there is a difficult problem for  IO#copy\_stream.
+- Ko1: I made it theoretically possible to unblock IO#select. However there is a difficult problem for  IO#copy_stream.

--- a/2018/DevMeeting-2018-07-18.md
+++ b/2018/DevMeeting-2018-07-18.md
@@ -131,23 +131,23 @@ Place: MoneyForward HQ (Tokyo, Japan)
 
 - pattern matching
 - Matz: positive for the proposal itself, though we need to discuss many details
-- Matz: Pin var\_ should be changed
+- Matz: Pin var_ should be changed
 - Matz: one-liner is slightly negative
 - Matz: guard must be able to write in pattern
-- Akr: & pattern is needed: \[self\] + values can be avoided by a pattern: \[A, 1, 1\] => A & \[1, 1\]
-- ko1:  want to write \[\] in pattern instead of ()
+- Akr: & pattern is needed: [self] + values can be avoided by a pattern: [A, 1, 1] => A & [1, 1]
+- ko1:  want to write [] in pattern instead of ()
 - Mame: NoMatchingError is needed?
 - Usa: is it a good idea to call deconstruct implicitly? is it better to write deconstruct explicitly?
 - Mame: the result of deconstruct must be cached
 - Tarui: cant distinguish between Array and Struct
 
-case \[1, 2, 3\]
+case [1, 2, 3]
 in a, 2 => b, c
  p a, b, cl
 end
 
-case \[1, 2, 3\]
-in \[a, 2 => b, c\]
+case [1, 2, 3]
+in [a, 2 => b, c]
  p a, b, c
 end
 
@@ -167,7 +167,7 @@ In Maybe(nil)
 In Maybe(foo)
 End
 
-- opt\_to\_s (nobu)
+- opt_to_s (nobu)
 
 - Naruse: Is it fast?
 - Nobu: not measured yet.
@@ -178,7 +178,7 @@ End
 - [[Feature #14111]](https://bugs.ruby-lang.org/issues/14111) ArgumentErrorが発生した時メソッドのプロトタイプをメッセージに含む (esjee)
 
 - Suggestion: include method parameters when generating an ArgumentError message. Nobu's patch in the issue provides functionality to make writing a ruby gem to provide this functionality possible.
-- \`method\_name\` is true method name, not \`callee\`.
+- `method_name` is true method name, not `callee`.
 - current implementation by nobu returns callee, so, change the implement to return true name.  after then, discuss about the necessity of callee.
 
 - [[Bug #14878]](https://bugs.ruby-lang.org/issues/14878) Add command line argument to deactivate JIT (k0kubun)
@@ -188,7 +188,7 @@ End
 
 - [[Feature #12306]](https://bugs.ruby-lang.org/issues/12306) Implement String #blank? #present? and improve #strip and family to handle unicode (sam.saffron)
 
-- blank? Is not the best name, but acceptable (space\_only? or something might be better)
+- blank? Is not the best name, but acceptable (space_only? or something might be better)
 - present? Is not acceptable at all
 - matz will accept the feature itself of blank?, but hope another good name
 - TBW
@@ -197,7 +197,7 @@ End
 
 - some steps towards better pattern matching
 
-- [[Feature #14914]](https://bugs.ruby-lang.org/issues/14914) Add BasicObject#instance\_exec\_with\_block (jeremyevans0)
+- [[Feature #14914]](https://bugs.ruby-lang.org/issues/14914) Add BasicObject#instance_exec_with_block (jeremyevans0)
 
 - Real use case, please
 
@@ -211,11 +211,11 @@ End
 
 Carry over:
 
-- [[Bug #14887]](https://bugs.ruby-lang.org/issues/14887) Array#delete\_if does not use #delete (shyouhei)
+- [[Bug #14887]](https://bugs.ruby-lang.org/issues/14887) Array#delete_if does not use #delete (shyouhei)
 
 - Is it by design, or a bug?
 
-- [[Feature #13050]](https://bugs.ruby-lang.org/issues/13050) Readline: expose rl\_completion\_quote\_character variable (nobu)
+- [[Feature #13050]](https://bugs.ruby-lang.org/issues/13050) Readline: expose rl_completion_quote_character variable (nobu)
 - [[Feature #14850]](https://bugs.ruby-lang.org/issues/14850) Add official API for setting timezone on Time (nobu)
 - [[Feature #14869]](https://bugs.ruby-lang.org/issues/14869) Proposal to add Hash#=== (nobu)
 - [[Feature #14877]](https://bugs.ruby-lang.org/issues/14877) Calculate age in Date class (nobu)

--- a/2018/DevMeeting-2018-08-09.md
+++ b/2018/DevMeeting-2018-08-09.md
@@ -101,26 +101,26 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 ## Carry-over from previous meeting(s)
 
-- [[Bug #14887]](https://bugs.ruby-lang.org/issues/14887) Array#delete\_if does not use #delete (shyouhei)
+- [[Bug #14887]](https://bugs.ruby-lang.org/issues/14887) Array#delete_if does not use #delete (shyouhei)
 
 - Is it by design, or a bug?
 - Matz: delete is memory inefficient.
-- Mame: if you can override #delete, why not also #delete\_if.
+- Mame: if you can override #delete, why not also #delete_if.
 
-- [[Feature #13050]](https://bugs.ruby-lang.org/issues/13050) Readline: expose rl\_completion\_quote\_character variable (nobu)
+- [[Feature #13050]](https://bugs.ruby-lang.org/issues/13050) Readline: expose rl_completion_quote_character variable (nobu)
 
 - Go!!!
 
 ## From Attendees
 
-- [[Feature #5446]](https://bugs.ruby-lang.org/issues/5446) at\_fork callback API (eregon) Can we get approval for introducing this? It is solving a real-world issue, in a more reliable way than the various hacks in most Ruby servers.
+- [[Feature #5446]](https://bugs.ruby-lang.org/issues/5446) at_fork callback API (eregon) Can we get approval for introducing this? It is solving a real-world issue, in a more reliable way than the various hacks in most Ruby servers.
 
-- Mrkn: I wanted to use this in pycall to call PyOS\_AfterFork\_Child, and so on from C-layer, but I noticed that I can use pthread\_atfork directly.
+- Mrkn: I wanted to use this in pycall to call PyOS_AfterFork_Child, and so on from C-layer, but I noticed that I can use pthread_atfork directly.
 - Naruse: Ruby’s fork is unsafe operation. Application programmers should understand the fact and carefully handle related operations (for example freeing resources).
-- Akr: I guess at\_fork hook would be problematic with multi-thread and/or multi-guild.  But making it Ruby’s standard feature impress this feature usable universally including multi-thread/guild. So, I’m negative for this proposal.
+- Akr: I guess at_fork hook would be problematic with multi-thread and/or multi-guild.  But making it Ruby’s standard feature impress this feature usable universally including multi-thread/guild. So, I’m negative for this proposal.
 - usa: Furthermore, I consider that fork must be destroyed.
 
-- [[Feature #11258]](https://bugs.ruby-lang.org/issues/11258) add 'x' mode character for O\_EXCL (kazu)
+- [[Feature #11258]](https://bugs.ruby-lang.org/issues/11258) add 'x' mode character for O_EXCL (kazu)
 
 - Matz accepted already.
 
@@ -139,7 +139,7 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 - [[Feature #14869]](https://bugs.ruby-lang.org/issues/14869) Proposal to add Hash#=== (nobu)
 
-- After \[Feature #14912\]
+- After [Feature #14912]
 
 - [[Feature #14877]](https://bugs.ruby-lang.org/issues/14877) Calculate age in Date class (nobu)
 
@@ -149,7 +149,7 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 - Matz: percent literal...
 
-- [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) \[PATCH\] auto fiber schedule for rb\_wait\_for\_single\_fd and rb\_waitpid (ko1)
+- [[Feature #13618]](https://bugs.ruby-lang.org/issues/13618) [PATCH] auto fiber schedule for rb_wait_for_single_fd and rb_waitpid (ko1)
 
 - Naming.
 
@@ -174,12 +174,12 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
 
 - Closed already
 
-- [[Feature #11076]](https://bugs.ruby-lang.org/issues/11076) Enumerable method count\_by (baweaver)
-    As mentioned in the discussion, Nobu was kind enough to update this to work with current master for Ruby: [https://github.com/ruby/ruby/compare/trunk...nobu:feature/11076-Enumerable%23count\_by](https://github.com/ruby/ruby/compare/trunk...nobu:feature/11076-Enumerable%23count_by)
+- [[Feature #11076]](https://bugs.ruby-lang.org/issues/11076) Enumerable method count_by (baweaver)
+    As mentioned in the discussion, Nobu was kind enough to update this to work with current master for Ruby: [https://github.com/ruby/ruby/compare/trunk...nobu:feature/11076-Enumerable%23count_by](https://github.com/ruby/ruby/compare/trunk...nobu:feature/11076-Enumerable%23count_by)
     As the code is already written I believe it would be an ideal target for 2.6 as a quick win on an often requested feature.
 
-- Matz: I thought #count\_by would be something different.
-- Mame: There is #count. #count\_by is very different from that.
+- Matz: I thought #count_by would be something different.
+- Mame: There is #count. #count_by is very different from that.
 - K-tsj: Also, #count takes a block.
 - Matz: I’m not against the feature itself.  Also, do we need a block-less counterpart?
 - Naruse: It looks similar to [Presto’s histogram function](https://prestodb.io/docs/current/functions/aggregate.html#histogram)
@@ -202,14 +202,14 @@ Please comment your favorite ticket numbers you want to ask to discuss with your
     This to say I would second the inclusion of the first two items as they relate to the third and fourth. It would give Ruby an exceptional amount of power.
 - Matz: we should discuss these after pattern match is introduced.
 
-- [[Feature #14759]](https://bugs.ruby-lang.org/issues/14759) \[PATCH\] set M\_ARENA\_MAX for glibc malloc (sam.saffron)
+- [[Feature #14759]](https://bugs.ruby-lang.org/issues/14759) [PATCH] set M_ARENA_MAX for glibc malloc (sam.saffron)
     I would also very much like to see it backported 2.4 and 2.5. It is of enormous value to the ecosystem
 
 - Usa: The decision should be made by Linux port maintainer
 - Naruse: up to kosaki.
 - Mame: Once kosaki said “If we merge this, we should decide when we remove this”.
 
-- [[Feature #14944]](https://bugs.ruby-lang.org/issues/14944) Support optional inherit argument for Module#method\_defined? (jeremyevans0)
+- [[Feature #14944]](https://bugs.ruby-lang.org/issues/14944) Support optional inherit argument for Module#method_defined? (jeremyevans0)
 
 - Usa: I want this too.
 - Mame: why?

--- a/2018/DevMeeting-2018-09-13.md
+++ b/2018/DevMeeting-2018-09-13.md
@@ -88,7 +88,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 - I'd like to introduce a new kind of coverage to record whether each line is executed or not. It provides less but still useful information compared to the traditional line coverage, and the measurement is quite faster.
 - shyouhei: clear is not atomic, isn’t it?
-- mame: oh, yes.  maybe I should add clear: true option to peek\_result.
+- mame: oh, yes.  maybe I should add clear: true option to peek_result.
 - all: let’s go
 
 - [[Feature #8661]](https://bugs.ruby-lang.org/issues/8661) Add option to print backtrace in reverse order(stack frames first & error last)
@@ -96,7 +96,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - The current backtrace order is really annoying, and I'm not still used; is there any chance to revert?
 - ???: How about using pager?
 
-- [[Feature #14609]](https://bugs.ruby-lang.org/issues/14609) \`Kernel#p\` without args shows the receiver (ko1)
+- [[Feature #14609]](https://bugs.ruby-lang.org/issues/14609) `Kernel#p` without args shows the receiver (ko1)
 
 - I feel this feature is very useful and some people say :+1: so let discuss about this feature.
 - everyone except mame/ko1: not good

--- a/2018/DevMeeting-2018-10-10.md
+++ b/2018/DevMeeting-2018-10-10.md
@@ -96,7 +96,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 ## About 2.6 timeframe
 
 - Nobu’s task (show causes in backtrace) is blocker of preview3.
-- mswin with MSVC14+ (only 14?) doesn’t work with Windows 10 October 2018 Update (version 1809) because of ucrtbase.dll’s internal \_\_pioinfo structure.
+- mswin with MSVC14+ (only 14?) doesn’t work with Windows 10 October 2018 Update (version 1809) because of ucrtbase.dll’s internal __pioinfo structure.
 
 ## Carry-over from previous meeting(s)
 
@@ -132,7 +132,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - hsbt: Efforts ongoing.
 - (details omitted from the log)
 
-- [[Misc #14632]](https://bugs.ruby-lang.org/issues/14632) \[ANN\] git.ruby-lang.org (hsbt)
+- [[Misc #14632]](https://bugs.ruby-lang.org/issues/14632) [ANN] git.ruby-lang.org (hsbt)
 
 - hsbt: I want to switch to git in 20 Oct.
 - usa: what happens?
@@ -141,7 +141,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - mame: Any restriction on git?
 - hsbt: push --force shall be forbidden.
 
-- [[Feature #14609]](https://bugs.ruby-lang.org/issues/14609) \`Kernel#p\` without args shows the receiver (ko1)
+- [[Feature #14609]](https://bugs.ruby-lang.org/issues/14609) `Kernel#p` without args shows the receiver (ko1)
 
 - It will be useful.
 
@@ -159,7 +159,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 - What happen? on: obj.send(:p, \*args)
 
-- It feels strange: p(\*\[\]) #=> nil
+- It feels strange: p(\*[]) #=> nil
 - It should be fancy to detect by eyes (.p is easy to hide) -> different name
 
 - knu: What if Object#display returned self? It does not emit a trailing LF.
@@ -192,19 +192,19 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - shyouhei: This one conflicts with [#14609](https://bugs.ruby-lang.org/issues/14609)
 - mame: Does it really conflict with that? Does anyone bother inspecting STDERR?
 - taru: Matz wants tapp for the other ticket.
-- duerst: I propose #warn\_p.
+- duerst: I propose #warn_p.
 - matz: I understand the needs for this one, but…
 - usa: Honestly I want to have #p for all IOs
 - naruse: Yes, like for logging.
 - mame: Doesn’t it make people leave such debug outputs here and there?
 - akr: What about introducing it with a longer name than #p
-- usa: like #putp (\`p\` means %p)
+- usa: like #putp (`p` means %p)
 - matz: OK, feature-wise I accept. For name…?
-- ko1: “IO#puts\_inspect” ?
+- ko1: “IO#puts_inspect” ?
 - akr: I think STDERR.p is acceptable but IO#p is too short.
 - mame: same feeling.
 
-## [[Feature #11505]](https://bugs.ruby-lang.org/issues/11505) Module#=== should call #kind\_of? on the object rather than rb\_obj\_is\_kind\_of which only searches the ancestor hierarchy (rafaelfranca)
+## [[Feature #11505]](https://bugs.ruby-lang.org/issues/11505) Module#=== should call #kind_of? on the object rather than rb_obj_is_kind_of which only searches the ancestor hierarchy (rafaelfranca)
 
 
 - This would allow patterns as Decorator and Proxy to work with case statements.
@@ -218,7 +218,7 @@ class Module
 
  def === other
 
- other.kind\_of?(self)
+ other.kind_of?(self)
 
  end
 
@@ -226,7 +226,7 @@ end
 
 class ArrayLike
 
- def kind\_of? other
+ def kind_of? other
 
  if other == Array
 
@@ -267,7 +267,7 @@ end
 - matz: I don’t like Enumerable#chain naming.
 - ko1: Is this method destructive?
 - akr: How can it be destructive?
-- ko1: \`Enumerator.chain( e1, e2, ... )\` is considerable, but should be discussed in the different ticket.
+- ko1: `Enumerator.chain( e1, e2, ... )` is considerable, but should be discussed in the different ticket.
 - matz: + is acceptable but maybe difficult to method chain.
 - usa: e0.+(e1, e2, ...).bar.baz.. might suffice.
 - matz: maybe.

--- a/2018/DevMeeting-2018-11-22.md
+++ b/2018/DevMeeting-2018-11-22.md
@@ -135,7 +135,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Matz: why not Enumerable#chain ?
 - Knu: definitely agreed!
 
-## \[[Bug #14127](https://bugs.ruby-lang.org/issues/14127)\] generating UTF-16LE encoded file without BOM (nobu)
+## [[Bug #14127](https://bugs.ruby-lang.org/issues/14127)] generating UTF-16LE encoded file without BOM (nobu)
 
 
 - Although this is not a bug of csv.rb, I'd suggest to enable "bom|" flag when writing instead. [https://github.com/nobu/ruby/tree/bug/14127-bom-header](https://github.com/nobu/ruby/tree/bug/14127-bom-header)
@@ -147,7 +147,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Knu: We need a concrete specification first as to when a BOM is written.
 - Ko1: file a new ticket for this.
 
-## [[Feature #15230]](https://bugs.ruby-lang.org/issues/15230) RubyVM.resolve\_feature\_path (mame)
+## [[Feature #15230]](https://bugs.ruby-lang.org/issues/15230) RubyVM.resolve_feature_path (mame)
 
 
 - I'd like this feature to investigate what will be loaded by require(feature).
@@ -285,27 +285,27 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Usa: for 3x3?
 - Matz: may not make it 3x faster.
 
-## [[Feature #15327]](https://bugs.ruby-lang.org/issues/15327) Proposal: Enable refinements to #respond\_to? (osyo)
+## [[Feature #15327]](https://bugs.ruby-lang.org/issues/15327) Proposal: Enable refinements to #respond_to? (osyo)
 
 
 - Matz: Mmm.
-- Ko1: when respond\_to says false, we can send that method anyways?
+- Ko1: when respond_to says false, we can send that method anyways?
 - Usa: yes.
-- Knu: there are implicit and explicit respond\_to. Is it for explicit one?
+- Knu: there are implicit and explicit respond_to. Is it for explicit one?
 - Usa: yes.
-- Matz: respond\_to does not interact with refinements right now is/was intentional because refinements are file-scope; it should be immediately obvious what method is callable or not at looking at the source code.
-- Ko1: what about respond\_to\_missing?
-- Matz: redefining respond\_to\_missing at a refinements should be against local rebinding.
+- Matz: respond_to does not interact with refinements right now is/was intentional because refinements are file-scope; it should be immediately obvious what method is callable or not at looking at the source code.
+- Ko1: what about respond_to_missing?
+- Matz: redefining respond_to_missing at a refinements should be against local rebinding.
 - Shyouhei: but I think we can undef a method inside of a refinement.
 - (everybody started thinking...)
 - Ko1: OK, let’s not think about it for a while.
 
-## [[Feature #15326]](https://bugs.ruby-lang.org/issues/15326) Proposal: Enable refinements to #public\_send (osyo)
+## [[Feature #15326]](https://bugs.ruby-lang.org/issues/15326) Proposal: Enable refinements to #public_send (osyo)
 
 
 - Matz: this one makes sense. Accepted.
 
-## [[Feature #15114]](https://bugs.ruby-lang.org/issues/15114) Symbol#to\_proc does not work with refinements? (osyo)
+## [[Feature #15114]](https://bugs.ruby-lang.org/issues/15114) Symbol#to_proc does not work with refinements? (osyo)
 
 
 - I want to more refinements!
@@ -313,13 +313,13 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - Matz: sounds like a bug?
 - assign nobu
 
-## [[Feature #15330]](https://bugs.ruby-lang.org/issues/15330) Proposal: autoload\_relative (marcandre)
+## [[Feature #15330]](https://bugs.ruby-lang.org/issues/15330) Proposal: autoload_relative (marcandre)
 
 
 - This feature is actually more useful than autoload and should be added to 2.6
 
 - Matz: why people love autoload, why…?
 - Naruse: What is new in this issue is not why, but how much people love autoloads.
-- Ko1: Marc-Andre recently changed requires in stdlib to require\_relative.  I guess it is natural for him to think about autoloads next.
-- Shyouhei: why not make a new method called autoload\_relative, which is an alias of require\_relative? :trollface:
+- Ko1: Marc-Andre recently changed requires in stdlib to require_relative.  I guess it is natural for him to think about autoloads next.
+- Shyouhei: why not make a new method called autoload_relative, which is an alias of require_relative? :trollface:
 - Knu: It is understandable to me that this may cover most popular use cases of autoload.

--- a/2018/DevMeeting-2018-12-12.md
+++ b/2018/DevMeeting-2018-12-12.md
@@ -104,8 +104,8 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - [[Feature #15287]](https://bugs.ruby-lang.org/issues/15287) New TracePoint events to support loading features (ko1)
 
 - Ruby 2.6
-- I already introduced script\_compiled TracePoint event. We need to decide related methods.
-- Matz: remove “compiled\_” prefix.
+- I already introduced script_compiled TracePoint event. We need to decide related methods.
+- Matz: remove “compiled_” prefix.
 
 - Should hash separation be prohibited? (mame)
 
@@ -113,7 +113,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 def foo(h = {}, \*\*kw)
 
- p \[h, kw\]
+ p [h, kw]
 
 end
 
@@ -123,7 +123,7 @@ foo("str" => 1, :sym => 2)
 - Akr: open3.rb has problem
     % ./ruby -ropen3 -e 'p Open3.capture2("echo foo", :in => IO::NULL, 3 => IO::NULL)'
     Traceback (most recent call last):
-    \-e:1:in \`<main>': non-symbol key in keyword arguments: 3 (ArgumentError)
+    \-e:1:in `<main>': non-symbol key in keyword arguments: 3 (ArgumentError)
 - Akr: open3.rb will be changed to avoid \*\*.  r66352
 
 
@@ -135,7 +135,7 @@ foo("str" => 1, :sym => 2)
 
 ## Non-attendees
 
-- [[Feature #15230]](https://bugs.ruby-lang.org/issues/15230) RubyVM.resolve\_feature\_path
+- [[Feature #15230]](https://bugs.ruby-lang.org/issues/15230) RubyVM.resolve_feature_path
 
 - 2.6 issue
 - Mame: no fix on 2.6. Consider on next version.
@@ -151,19 +151,19 @@ foo("str" => 1, :sym => 2)
 - 2.7 or later
 - Matz: OK, but wait for 2.7.
 
-- [[Feature #15373]](https://bugs.ruby-lang.org/issues/15373) Proposal: Enable refinements to #method and #instance\_method
+- [[Feature #15373]](https://bugs.ruby-lang.org/issues/15373) Proposal: Enable refinements to #method and #instance_method
 
 - 2.7 or later
 - Matz: ok to introduce.
 
-- [[Feature #15374]](https://bugs.ruby-lang.org/issues/15374) Proposal: Enable refinements to #method\_missing
+- [[Feature #15374]](https://bugs.ruby-lang.org/issues/15374) Proposal: Enable refinements to #method_missing
 
 - 2.7 or later
 - Matz: let me think about it for a while.
 
 - [[Feature #15007]](https://bugs.ruby-lang.org/issues/15007) Proposal: Introduce support for cold function attributes (clang and GCC)
 
-- reduced scope PR [https://github.com/ruby/ruby/pull/2005](https://github.com/ruby/ruby/pull/2005) (rb\_memerror, rb\_bug, rb\_warn)
+- reduced scope PR [https://github.com/ruby/ruby/pull/2005](https://github.com/ruby/ruby/pull/2005) (rb_memerror, rb_bug, rb_warn)
 - Already  merged.
 
 - [[Bug #15394]](https://bugs.ruby-lang.org/issues/15394) Ruby adds unexpected HTTP header value when using symbol key

--- a/2019/DevMeeting-2019-01-10.md
+++ b/2019/DevMeeting-2019-01-10.md
@@ -80,12 +80,12 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## From Attendees
 
-- [[Feature #6012]](https://bugs.ruby-lang.org/issues/6012) Proc#source\_location (ko1)
+- [[Feature #6012]](https://bugs.ruby-lang.org/issues/6012) Proc#source_location (ko1)
 
 - nobu: this breaks compatibility
 - ko1: how about specifying the new behaviour by some optional parameter?
 - matz: we don’t have to take care of old behavior in this case
-- mame: pry is using source\_location#last
+- mame: pry is using source_location#last
 - naruse: pry will be pleasured in this change, I guess :)
 - ko1: I’m against to break compatibility
 - usa: if you really concern to keep compatibility, you should propose this feature as new method.
@@ -98,23 +98,23 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 - Special variable for block parameter
 
-- $\_
+- $_
 - @1, @2, @3
-- Ko1: Which \`@1\` mean \`{|x|\` or \`{|x, |\`
-- Znz: \`@0\` means \`{|x|\`
-- Akr: ary.map { .to\_i }
+- Ko1: Which `@1` mean `{|x|` or `{|x, |`
+- Znz: `@0` means `{|x|`
+- Akr: ary.map { .to_i }
 - Knu: … as in Lua
 
 - Mark for a method which doesn’t receive a proc
 
 - matz: I’m planning to introduce a new syntax to specify that the method does not accept any blocks.  proposals?
-- \`&nil\`
-- \`&!\`
-- \`!&\`
-- \`&void\`
-- Matz: Ok, \`&nil\`.
+- `&nil`
+- `&!`
+- `!&`
+- `&void`
+- Matz: Ok, `&nil`.
 - Ko1: Objection.  Many pull-reqs “added &nil” will be opened
-- Ko1: I have been thinking of making Ruby automatically detect if a method actually takes a block even by checking if it uses a block argument or it has a \`yield\` keyword in it.  To achieve this, I want to ban \`yield\` from within \`eval\`, and blockless call of proc/lambda/Proc.new etc.  I believe that is the way to go.  Please warn for “proc” and “Proc.new” without block as obsolete.
+- Ko1: I have been thinking of making Ruby automatically detect if a method actually takes a block even by checking if it uses a block argument or it has a `yield` keyword in it.  To achieve this, I want to ban `yield` from within `eval`, and blockless call of proc/lambda/Proc.new etc.  I believe that is the way to go.  Please warn for “proc” and “Proc.new” without block as obsolete.
 - Matz: accepted.
 - Akr: “lambda without block” has been already warned since 2003 (ruby-1.8.0), How about changing it to an exception?
 - Matz: accepted.
@@ -123,7 +123,7 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 - Can we prohibit (1.. ..1) and (1..1)..1 as a SyntaxError?
 - matz: ok, prohibit
-- usa: please add test cases into test\_syntax.rb
+- usa: please add test cases into test_syntax.rb
 
 - [[Feature #14799]](https://bugs.ruby-lang.org/issues/14799) Startless range (aycabta)
 
@@ -133,9 +133,9 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 - What is the expected / desired way to fix this?
 
-- [[Bug #7300]](https://bugs.ruby-lang.org/issues/7300) Hash#\[\] の挙動が 1.9.3 と異なっている (mame)
+- [[Bug #7300]](https://bugs.ruby-lang.org/issues/7300) Hash#[] の挙動が 1.9.3 と異なっている (mame)
 
-- I think we can remove the compatibility layer for 1.9: Hash\[\[nil\]\] #=> {}
+- I think we can remove the compatibility layer for 1.9: Hash[[nil]] #=> {}
 
 - [[Misc #15347]](https://bugs.ruby-lang.org/issues/15347) Require C99 (k0kubun)
 - [[Feature #15445]](https://bugs.ruby-lang.org/issues/15445) Reject '.123' in Float() method (mrkn)
@@ -152,9 +152,9 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 ## Non-attendees
 
-- [[Feature #14444]](https://bugs.ruby-lang.org/issues/14444) MatchData: alias for #\[\]
+- [[Feature #14444]](https://bugs.ruby-lang.org/issues/14444) MatchData: alias for #[]
 
-- Naruse: \`next\_page = response.dig('meta', 'pagination', 'next')&.slice(/&page=(\\d+)/, 1)\` is better
+- Naruse: `next_page = response.dig('meta', 'pagination', 'next')&.slice(/&page=(\\d+)/, 1)` is better
 
 - [[Feature #14784]](https://bugs.ruby-lang.org/issues/14784) Comparable#clamp with a range
 
@@ -170,17 +170,17 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 - [[Bug #15428]](https://bugs.ruby-lang.org/issues/15428) Refactor Proc#>> and #<< (it regards the same problem as [#15483](https://bugs.ruby-lang.org/issues/15483) above, but approaches it from a different point of view)
 
 - Mame: Use a block.  You then want syntactic sugar for passing an argument, and then for partial application, blah blah blah.
-- knu: We should not add fancy new features around procs and symbols if the real problem is that block syntax is not good enough, like \`|x|\` is always necessary. (See above for the default block parameter syntax)
+- knu: We should not add fancy new features around procs and symbols if the real problem is that block syntax is not good enough, like `|x|` is always necessary. (See above for the default block parameter syntax)
 - Matz: raise an error when the argument does not respond to :call
 
 - [[Misc #15486]](https://bugs.ruby-lang.org/issues/15486) Default gems README.md
 
 - [[Misc #15487]](https://bugs.ruby-lang.org/issues/15487) Clarify default gems maintenance policy
-- [[Feature #15373]](https://bugs.ruby-lang.org/issues/15373) Proposal: Enable refinements to #method and #instance\_method
+- [[Feature #15373]](https://bugs.ruby-lang.org/issues/15373) Proposal: Enable refinements to #method and #instance_method
 
 - matz: go ahead
 
-- [[Feature #15374]](https://bugs.ruby-lang.org/issues/15374) Proposal: Enable refinements to #method\_missing
+- [[Feature #15374]](https://bugs.ruby-lang.org/issues/15374) Proposal: Enable refinements to #method_missing
 
 - matz: wait a month
 
@@ -188,21 +188,21 @@ I don't guarantee to put tickets in agenda if the comment violate the format (be
 
 - History:
 
-- 2006: r10235 removes command from aref\_args.
-- 2007: r13821 removes warning from call\_args.
+- 2006: r10235 removes command from aref_args.
+- 2007: r13821 removes warning from call_args.
 
 - \*: Should we emit a warning against both cases?
 - knu: There's so much existing code out there written as follows:
 
 - expect(command arg).to eq(value)
 - f.(Math.sqrt 2)
-- f\[Math.sqrt 2\]
+- f[Math.sqrt 2]
 
-- [[Bug #2250]](https://bugs.ruby-lang.org/issues/2250) IO::for\_fd() objects' finalization dangerously closes underlying fds (eregon)
+- [[Bug #2250]](https://bugs.ruby-lang.org/issues/2250) IO::for_fd() objects' finalization dangerously closes underlying fds (eregon)
 
 - The current behavior is dangerous and has caused many spurious test/spec failures which are hard to find and debug. I plan to submit a patch, but I'd like opinions regarding compatibility.
 
-- [[Bug #15488]](https://bugs.ruby-lang.org/issues/15488) const\_defined?("File::NULL") の挙動
+- [[Bug #15488]](https://bugs.ruby-lang.org/issues/15488) const_defined?("File::NULL") の挙動
 
 - What is the expected behavior?
 - matz: ok, try to return “true” in this case. if we find something wrong, will give up.

--- a/2019/DevMeeting-2019-02-07.md
+++ b/2019/DevMeeting-2019-02-07.md
@@ -96,10 +96,10 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 
 ## Non-attendees
 
-- [[Feature #6470]](https://bugs.ruby-lang.org/issues/6470) Make attr\_accessor return the list of generated method (eregon)
+- [[Feature #6470]](https://bugs.ruby-lang.org/issues/6470) Make attr_accessor return the list of generated method (eregon)
 
 - What’s volatile?  No one understand.
-- Matz: if volatile is needed, it would be better to define volatile\_attr\_reader etc.
+- Matz: if volatile is needed, it would be better to define volatile_attr_reader etc.
 
 - [[Bug #14353]](https://bugs.ruby-lang.org/issues/14353) $SAFE should stay at least thread-local for compatibility (eregon)
 
@@ -115,7 +115,7 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 
 - [[Feature #14344]](https://bugs.ruby-lang.org/issues/14344) refine at class level (kddeisz)
 
-- Shorter refinement syntax proposed based on common use cases. Proposed either refine\_class or using blocks for shorthand. What do you think?
+- Shorter refinement syntax proposed based on common use cases. Proposed either refine_class or using blocks for shorthand. What do you think?
 - Matz: I understand the needs, but I don’t like the style.  Please propose other styles.
 
 - [[Feature #14680]](https://bugs.ruby-lang.org/issues/14680) Adding +@ and -@ to hash and array (kddeisz)
@@ -143,13 +143,13 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 - The feature is done (the title is old, it will be implemented in String) but blocked on picking a method name. I would like to ask for opinions so this can move forward.
 -  ???
 
-- [[Feature #15331]](https://bugs.ruby-lang.org/issues/15331) \[PATCH\] Faster hashing for short string literals
+- [[Feature #15331]](https://bugs.ruby-lang.org/issues/15331) [PATCH] Faster hashing for short string literals
 
 - Looking for feedback on this patch.
 - Nobu: I tested, but cannot confirm the speed up
 - Matz: Umm.
 
-- [[Feature #15374]](https://bugs.ruby-lang.org/issues/15374) Proposal: Enable refinements to #method\_missing
+- [[Feature #15374]](https://bugs.ruby-lang.org/issues/15374) Proposal: Enable refinements to #method_missing
 
 - waited one month.
 - Matz: will reject.
@@ -159,7 +159,7 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 - I feel this feature is very useful and some people say :+1: so let discuss about this feature.
 - Need to discuss when we have ko1.  He left, so discuss it at the next meeting.
 
-- [[Feature #15588]](https://bugs.ruby-lang.org/issues/15588) String#each\_chunk and #chunks
+- [[Feature #15588]](https://bugs.ruby-lang.org/issues/15588) String#each_chunk and #chunks
 
 - Looking for feedback on this patch.
 - Matz: use case.
@@ -184,21 +184,21 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 
 -  [[Feature #4475]](https://bugs.ruby-lang.org/issues/4475) default variable name for parameter (aycabta)
 
-- In [#15483](https://bugs.ruby-lang.org/issues/15483), matz said "I feel the expression ary.map(&(:to\_i << :chr)) is far less readable than ary.map{|x|x.to\_i.chr}.", and "And this can lead to the default block parameter like it."
-- nobu is wriing a patch for \`@1\`. so, let’s try it.
+- In [#15483](https://bugs.ruby-lang.org/issues/15483), matz said "I feel the expression ary.map(&(:to_i << :chr)) is far less readable than ary.map{|x|x.to_i.chr}.", and "And this can lead to the default block parameter like it."
+- nobu is wriing a patch for `@1`. so, let’s try it.
 
 - [[Feature #5632]](https://bugs.ruby-lang.org/issues/5632) Attempt to open included class shades it instead. (mame)
 
 - Matz: sorry, it was not mame’s task. reject it.
 
-- [[Feature #11076]](https://bugs.ruby-lang.org/issues/11076) Enumerable method count\_by
+- [[Feature #11076]](https://bugs.ruby-lang.org/issues/11076) Enumerable method count_by
 
-- Matz: ok, introduce \`tally\`.
+- Matz: ok, introduce `tally`.
 
 - [[Feature #15573]](https://bugs.ruby-lang.org/issues/15573) Permit zero step in Numeric#step and Range#step
 
-\>> (10 .. 0).step(-1).to\_a
+\>> (10 .. 0).step(-1).to_a
 
-\=> \[10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0\]
+\=> [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
- (0 .. 0).step(0).to\_a loops infinitely
+ (0 .. 0).step(0).to_a loops infinitely

--- a/2019/DevMeeting-2019-03-11.md
+++ b/2019/DevMeeting-2019-03-11.md
@@ -73,12 +73,12 @@ We don't guarantee to put tickets in agenda if the comment violate the format (b
 - 2.6.3 (Apr)
 - 2.7.0-preview1u89
 
-- waiting introducing \`@1\`. maybe at RubyKaigi
+- waiting introducing `@1`. maybe at RubyKaigi
 
 - [https://bugs.ruby-lang.org/issues/4475](https://bugs.ruby-lang.org/issues/4475)
-- matz: I deny \`@0\`, and also deny assignment to \`@1\`
+- matz: I deny `@0`, and also deny assignment to `@1`
 
-- \[\[1,2,3\]\].each {|a,| p a }
+- [[1,2,3]].each {|a,| p a }
 - →→ [https://hackmd.io/eb38KJgKQEeGEgsbSACUWg](https://hackmd.io/eb38KJgKQEeGEgsbSACUWg)
 
 ## Check security tickets (confidencial)
@@ -109,15 +109,15 @@ done
 
 - usa: nagachika-san is planning to release in this month.
 
-- [[Feature #15323]](https://bugs.ruby-lang.org/issues/15323) Proposal: Add Enumerable#filter\_map
+- [[Feature #15323]](https://bugs.ruby-lang.org/issues/15323) Proposal: Add Enumerable#filter_map
 
-- naruse: Sequel uses \`select\_filter\` as another meaning
-- usa: also need \`select\_map\` as alias?
-- matz: so, \`select\_collect\`? :)
+- naruse: Sequel uses `select_filter` as another meaning
+- usa: also need `select_map` as alias?
+- matz: so, `select_collect`? :)
 - mame: is lazy not enough?
 - mame: if this method is accepted, other methods with map will be also requested.
-- matz: filter\_map is not simply combination of filter and map.  so mame’s concern is needless fears.
-- matz: ok, accepted \`filter\_map\`.
+- matz: filter_map is not simply combination of filter and map.  so mame’s concern is needless fears.
+- matz: ok, accepted `filter_map`.
 
 - [[Feature #14145]](https://bugs.ruby-lang.org/issues/14145) Proposal: Better Method#inspect
 
@@ -133,19 +133,19 @@ done
 
 - [[Feature #15653]](https://bugs.ruby-lang.org/issues/15653) Proposal: Add Time#floor
 
-- naruse: isn’t it \`trunc\`?  see SQL.
+- naruse: isn’t it `trunc`?  see SQL.
 - akr: truncate means rounding to zero.  conceptually, zero is the first time, but we often assume the zero time as UNIX epoch.
 - naruse: I see.
-- mrkn, knu: There’s a typical use case in test code in Rails.  Sub-second fragment often gets lost through serialization/deserialization for DB and we often do Time.at(time.to\_i) in test code as a workaround.
+- mrkn, knu: There’s a typical use case in test code in Rails.  Sub-second fragment often gets lost through serialization/deserialization for DB and we often do Time.at(time.to_i) in test code as a workaround.
 - matz: ok, accepted.
 
 ## From Attendees
 
 - [[Misc #15615]](https://bugs.ruby-lang.org/issues/15615) File.birthtimeがLinux環境で有効なファイル作成時刻を得られなかった場合の挙動について
 
-- should raises \`NotImplementedError\` both \`File.birthtime\` and \`File::Stat#birthtime\` if birthtime is not available.
-- akr: \`respond\_to?\` should always return \`true\`.
-- akr: we also have to implement \`birthtime\` to \`Pathname\`, don’t it?
+- should raises `NotImplementedError` both `File.birthtime` and `File::Stat#birthtime` if birthtime is not available.
+- akr: `respond_to?` should always return `true`.
+- akr: we also have to implement `birthtime` to `Pathname`, don’t it?
 - usa: yes
 
 - [[Feature #15195]](https://bugs.ruby-lang.org/issues/15195) How to deal with new Japanese era
@@ -162,22 +162,22 @@ done
 
 - akr: IMO, these are bugs.  I propose that autoload should use one global lock instead of locks per constants.
 
-- [[Feature #15618]](https://bugs.ruby-lang.org/issues/15618) Implement Enumerator::Yielder#to\_proc
+- [[Feature #15618]](https://bugs.ruby-lang.org/issues/15618) Implement Enumerator::Yielder#to_proc
 
 - matz: ok, accepted.
 
 - [[Feature #15553]](https://bugs.ruby-lang.org/issues/15553) Addrinfo.getaddrinfo supports timeout
 
 - akr: this implementation is not acceptable, but the feature is ok.
-- glass\_saga: I see.  BTW, is using Resolv acceptable?
+- glass_saga: I see.  BTW, is using Resolv acceptable?
 - akr: yes.
 - Even if it doesn’t support getaddrinfo with timeout (non glibc), it should ignore because we want to use the same code on macOS and Linux.
 
-- [[Bug #15652]](https://bugs.ruby-lang.org/issues/15652) Profiler\_\_ is not working correctly (ruby 2.6)
+- [[Bug #15652]](https://bugs.ruby-lang.org/issues/15652) Profiler__ is not working correctly (ruby 2.6)
 
 - usa, naruse: kill it
 
-- [[Feature #15626]](https://bugs.ruby-lang.org/issues/15626) Manual Compaction for MRI’s GC (\`GC.compact\`)
+- [[Feature #15626]](https://bugs.ruby-lang.org/issues/15626) Manual Compaction for MRI’s GC (`GC.compact`)
 
 - matz: current status?
 - ko1: I think this is mergeable.  But one incompatibility exists.   if an C extension keeps pointers without mark (expecting to mark via Ruby code), GC cannot change the pointers.

--- a/2019/DevMeeting-2019-04-21.md
+++ b/2019/DevMeeting-2019-04-21.md
@@ -73,7 +73,7 @@ Place: Fukuoka Ruby Content Industry Promotion Center (Fukuoka, Japan)
 
 ### Agenda
 
-- 13:30-14:00 (1) keyword arguments progress report \[[#14183](https://bugs.ruby-lang.org/issues/14183)\] (mame)
+- 13:30-14:00 (1) keyword arguments progress report [[#14183](https://bugs.ruby-lang.org/issues/14183)] (mame)
 
 - Mame: Presentation of problems and issues. Testing of strict implementation shows many incompatibilities.
 - Jeremy Evans: More compatible proposal, same as mame, but backwards compatible for methods that don’t accept keyword arguments.
@@ -95,7 +95,7 @@ Place: Fukuoka Ruby Content Industry Promotion Center (Fukuoka, Japan)
 
 - Agreed it’s very complex logic to handle them (eregon)
 
-- 14:00-14:30 (2) static checking progress report \[#?????\] (mame)
+- 14:00-14:30 (2) static checking progress report [#?????] (mame)
 
 - Mame: Add side-car file for type annotations (.rbi)
 
@@ -116,11 +116,11 @@ Place: Fukuoka Ruby Content Industry Promotion Center (Fukuoka, Japan)
 
 - Can you handle “Integer | String”
 
-- Mame: Yes it’s possible \[demo from slides\].
+- Mame: Yes it’s possible [demo from slides].
 
 - How should we use type profiler?
 
-- Mame: By using type profiler you can find more errors than testing alone \[e.g. typo in untested branch\].
+- Mame: By using type profiler you can find more errors than testing alone [e.g. typo in untested branch].
 
 - Can we test refinements? What other limitations are there?
 
@@ -128,7 +128,7 @@ Place: Fukuoka Ruby Content Industry Promotion Center (Fukuoka, Japan)
 
 - What about anonymous classes and e.g., Struct subclasses? (eregon)
 
-- 14:30-15:00 (3) pattern matching \[[#14912](https://bugs.ruby-lang.org/issues/14912)\] (k\_tsj)
+- 14:30-15:00 (3) pattern matching [[#14912](https://bugs.ruby-lang.org/issues/14912)] (k_tsj)
 
 - Kazuki: Presentation of general idea and implementation.
 
@@ -157,7 +157,7 @@ Place: Fukuoka Ruby Content Industry Promotion Center (Fukuoka, Japan)
 - The names are manually defined right now but perhaps it can be defined by “comment” in C source code.
 
 - Eregon: If we have more of the core written in Ruby, we can share more of it between implementations.
-- Eregon: a nice improvement over current \_\_foo methods in prelude.rb :)
+- Eregon: a nice improvement over current __foo methods in prelude.rb :)
 - Do we need to be concerned about MRI specific code being used in an unorthodox way?
 
 - Koichi: We can add a warning comment at the top of the file?
@@ -178,12 +178,12 @@ Place: Fukuoka Ruby Content Industry Promotion Center (Fukuoka, Japan)
 - Matz: It is not for the VM implementation but for the users.
 
 - 16:30-17:00 break
-- 17:00-18:00 (6) RubyVM \[[#15752](https://bugs.ruby-lang.org/issues/15752)\] + numbered parameters \[[#15708](https://bugs.ruby-lang.org/issues/15708)\] (eregon)
+- 17:00-18:00 (6) RubyVM [[#15752](https://bugs.ruby-lang.org/issues/15752)] + numbered parameters [[#15708](https://bugs.ruby-lang.org/issues/15708)] (eregon)
 
 - Presentation about RubyVM namespace issues. How to handle experimental features.
 - Many new methods are implemented directly. What should go under proposed “ExperimentalFeatures”?
 
-- Where should we put \`RubyVM.resolve\_feature\_path(path)\`?
+- Where should we put `RubyVM.resolve_feature_path(path)`?
 
 - Should a.map{|e| e.sum} behave the same as a.map{@1.sum}?
 

--- a/2019/DevMeeting-2019-05-22.md
+++ b/2019/DevMeeting-2019-05-22.md
@@ -88,38 +88,38 @@ Nothing.
 
 ## Topics
 
-- [\[Misc #14632\]](https://bugs.ruby-lang.org/issues/14632) [git.ruby-lang.org](http://git.ruby-lang.org/) (k0kubun)
+- [[Misc #14632]](https://bugs.ruby-lang.org/issues/14632) [git.ruby-lang.org](http://git.ruby-lang.org/) (k0kubun)
 
-- RUBY\_REVISION should be full-length hash value
+- RUBY_REVISION should be full-length hash value
 
-- [\[Bug #15745\]](https://bugs.ruby-lang.org/issues/15745) There is no symmetry in the beginless range and the endless range using Range#inspect (koic)(1..).inspect      #=> "1.."
+- [[Bug #15745]](https://bugs.ruby-lang.org/issues/15745) There is no symmetry in the beginless range and the endless range using Range#inspect (koic)(1..).inspect      #=> "1.."
 - (..5).inspect      #=> "..5"
 - (nil..nil).inspect #=> "nil..nil"
 
-- [\[Feature #14915\]](https://bugs.ruby-lang.org/issues/14915) Deprecate String#crypt (jeremyevans0)
+- [[Feature #14915]](https://bugs.ruby-lang.org/issues/14915) Deprecate String#crypt (jeremyevans0)
 
 - There are a few committers against the removal. They will reply into the ticket.
 - Jeremy Evans committer? -> “Go ahead” by matz ([https://bugs.ruby-lang.org/issues/15853#change-78060](https://bugs.ruby-lang.org/issues/15853#change-78060), [https://bugs.ruby-lang.org/issues/15839#change-78087](https://bugs.ruby-lang.org/issues/15839#change-78087))
 
-- [\[Feature #15765\]](https://bugs.ruby-lang.org/issues/15765) \[PATCH\] Module#name without global constant search (alanwu)
+- [[Feature #15765]](https://bugs.ruby-lang.org/issues/15765) [PATCH] Module#name without global constant search (alanwu)
 
 - Matz: leaf to nobu.
 - Nobu: Will check and merge.
 
-- [\[Feature #15772\]](https://bugs.ruby-lang.org/issues/15772) Proposal: Add Time#ceil (osyo)
+- [[Feature #15772]](https://bugs.ruby-lang.org/issues/15772) Proposal: Add Time#ceil (osyo)
 
 - Shyouhei: Use case?
 - Matz: Okay!
 
-- [\[Feature #13645\]](https://bugs.ruby-lang.org/issues/13645) Syntactic sugar for indexing when using the safe navigation operator (osyo)
+- [[Feature #13645]](https://bugs.ruby-lang.org/issues/13645) Syntactic sugar for indexing when using the safe navigation operator (osyo)
 
 - Matz: the use case looks artificial. Reject once.
 
-- [\[Misc #15802\]](https://bugs.ruby-lang.org/issues/15802) \[PATCH\] Reduce the minimum string buffer size from 127 to 63 bytes (methodmissing)
+- [[Misc #15802]](https://bugs.ruby-lang.org/issues/15802) [PATCH] Reduce the minimum string buffer size from 127 to 63 bytes (methodmissing)
 
 - ko1 will check.
 
-- [\[Feature #14736\]](https://bugs.ruby-lang.org/issues/14736) Thread selector for flexible cooperative fiber based concurrency (ioquatix)
+- [[Feature #14736]](https://bugs.ruby-lang.org/issues/14736) Thread selector for flexible cooperative fiber based concurrency (ioquatix)
 
 - (ko1, nobu, and matz talks)
 - Matz: I’m worry about the performance, it would be difficult to accept the patch as is. I’m not positive to add a hook to IO because it will bring a big overhead when buffered. I prefer auto-fiber to using traditional IOs with a hook.
@@ -127,44 +127,44 @@ Nothing.
 - Matz: Will reject.
 - Ko1: I’m unsure what design is best, but I think eregon wrote [a good comment](https://bugs.ruby-lang.org/issues/14736#change-77879). It would be good that the proposal is much simpler than autofiber.
 
-- [\[Feature #15323\]](https://bugs.ruby-lang.org/issues/15323) \[PATCH\] Proposal: Add Enumerable#filter\_map (greggzst)
+- [[Feature #15323]](https://bugs.ruby-lang.org/issues/15323) [PATCH] Proposal: Add Enumerable#filter_map (greggzst)
 
 - Matz will reply.
 
-- [\[Misc #15843\]](https://bugs.ruby-lang.org/issues/15843) Make “trunk” a symbolic-ref of “master” on [git.ruby-lang.org](http://git.ruby-lang.org/) (k0kubun)
+- [[Misc #15843]](https://bugs.ruby-lang.org/issues/15843) Make “trunk” a symbolic-ref of “master” on [git.ruby-lang.org](http://git.ruby-lang.org/) (k0kubun)
 
 - Go ahead?
 - Nobu: Why “master” is primary and “trunk” is secondary.
 - Akr: “Out of scope (for a short term)” is a trap! “accept” may mean accept for long term?
 
-- [\[Feature #15778\]](https://bugs.ruby-lang.org/issues/15778) Expose an API to pry-open the stack frames in Ruby (eregon)
+- [[Feature #15778]](https://bugs.ruby-lang.org/issues/15778) Expose an API to pry-open the stack frames in Ruby (eregon)
 
-- Ko1: I hate Binding.of\_caller.
+- Ko1: I hate Binding.of_caller.
 - Shyouhei: How about requiring require "something" to communicate “should only be used for debugging”?
 
-- [\[Bug #7300\]](https://bugs.ruby-lang.org/issues/7300) Hash#\[\] の挙動が 1.9.3 と異なっている (hsbt)
+- [[Bug #7300]](https://bugs.ruby-lang.org/issues/7300) Hash#[] の挙動が 1.9.3 と異なっている (hsbt)
 
 - Mame: I’d like to merge it.
 
-- [\[Feature #14844\]](https://bugs.ruby-lang.org/issues/14844) Future of RubyVM::AST?
+- [[Feature #14844]](https://bugs.ruby-lang.org/issues/14844) Future of RubyVM::AST?
 
 - What can we do about this? The current situation is confusing for everyone, the API sounds “blessed” by being in core but it’s actually experimental and unstable. Can we document it as clearly as possible when this API should be used? Could we improve the API so it’s less fragile to parser changes and could be reasonably implemented on other Ruby implementations?
 - “Add a document to warn the result of this API may (easily) change in future”
 
-- [\[Feature #15863\]](https://bugs.ruby-lang.org/issues/15863) Add Hash#slice! and ENV.slice!(bogdanvlviv)
-- [\[Feature #15831\]](https://bugs.ruby-lang.org/issues/15831) Add Array#extract, Hash#extract, and ENV.extract (bogdanvlviv)
+- [[Feature #15863]](https://bugs.ruby-lang.org/issues/15863) Add Hash#slice! and ENV.slice!(bogdanvlviv)
+- [[Feature #15831]](https://bugs.ruby-lang.org/issues/15831) Add Array#extract, Hash#extract, and ENV.extract (bogdanvlviv)
 
 - Matz: negative. (Sorry I missed to log)
 
-- [\[Feature #15864\]](https://bugs.ruby-lang.org/issues/15864) Proposal: Add methods to determine if it is an infinite range
+- [[Feature #15864]](https://bugs.ruby-lang.org/issues/15864) Proposal: Add methods to determine if it is an infinite range
     (osyo)
 
 - Matz: negative.
 
-- [\[Feature #15865\]](https://bugs.ruby-lang.org/issues/15865) <expr> in <pattern> expression (mame)
+- [[Feature #15865]](https://bugs.ruby-lang.org/issues/15865) <expr> in <pattern> expression (mame)
 
 - Matz: positive.
 
-- [\[Feature #15281\]](https://bugs.ruby-lang.org/issues/15281) Speed up Set#intersect with size check. (tenderlove)
+- [[Feature #15281]](https://bugs.ruby-lang.org/issues/15281) Speed up Set#intersect with size check. (tenderlove)
 
 - Knu will check.

--- a/2020/DevMeeting-2020-02-27.md
+++ b/2020/DevMeeting-2020-02-27.md
@@ -201,7 +201,7 @@ bar.case? # => false
 shyouhei: Want to see actual use cases
 nobu: no-argument case should raise an exception
 mame: I like the feature, though its name is very arguable
-akr: code search of ‘\]\.include\?’ finds many example
+akr: code search of ‘]\.include\?’ finds many example
 Discussion:
 matz: I understand the idea and it is a bit helpful, but don’t understand how useful it is
 mame: I like the word order like in?

--- a/2021/DevelopersMeeting20210216Japan.md
+++ b/2021/DevelopersMeeting20210216Japan.md
@@ -416,7 +416,7 @@ s = Set[1, 2] # works without require
 ```
 
 ```shell
-ko1@aluminium:~$ gem-codesearch '\bSet\[' | wc -l
+ko1@aluminium:~$ gem-codesearch '\bSet[' | wc -l
 8464
 
 $ gem-codesearch '\bSet\.new' | wc -l

--- a/2024/DevMeeting-2024-01-17.md
+++ b/2024/DevMeeting-2024-01-17.md
@@ -368,7 +368,7 @@ NameError: name 'foo' is not defined
 ```
 
 ```
-$ git grep "\`.+'"
+$ git grep "`.+'"
 spec/ruby/core/exception/backtrace_spec.rb:46:      line.should =~ /^.+:\d+:in `[^`]+'$/
 ```
 


### PR DESCRIPTION
When meeting logs were exported from Google Docs to Markdown, several characters were unnecessarily escaped with backslashes.

**Escaped underscores** (539 instances across 49 files):
- Method names: `to\_s` → `to_s`, `each\_char` → `each_char`
- C identifiers: `\_\_FILE\_\_` → `__FILE__`, `rb\_cFixnum` → `rb_cFixnum`

**Escaped backticks** (83 instances across 28 files):
- Inline code: `` \`foo\` `` → `` `foo` ``

**Escaped brackets in code/text context** (63 instances across 22 files):
- Array literals: `\[1, 2, 3\]` → `[1, 2, 3]`
- Method calls: `hash\[key\]` → `hash[key]`
- Tags: `\[PATCH\]` → `[PATCH]`, `\[ANN\]` → `[ANN]`

Note: Escaped brackets in ticket references (e.g. `\[Feature ...\]`) are intentionally left unchanged for a separate cleanup.

53 files changed spanning 2013-2022.

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.