### PR TITLE
Add links to unlinked ticket references in headings (2013-2021)

### DIFF
--- a/2013/DevMeeting-2013-07-12.md
+++ b/2013/DevMeeting-2013-07-12.md
@@ -371,7 +371,7 @@ ADD ITEMS HERE (with redmine links)
 16:33 drbrain: I believe the next topic is up to
       tenderlove</pre>
 
-### Non-blocking reads without exceptions. Feature #5138
+### [[Feature #5138]](https://bugs.ruby-lang.org/issues/5138) Non-blocking reads without exceptions.
 
 <pre>16:33 drbrain: non blocking reads without exceptions.
 16:33 tenderlove: yay

--- a/2015/DevMeeting-2015-05-14.md
+++ b/2015/DevMeeting-2015-05-14.md
@@ -217,7 +217,7 @@ Nobu: Impement Range specializes String and try it.
 
 New syntax proposals
 
-# Feature #11141:  new syntax suggestion for abbreviate definition on block parameters in order
+# [[Feature #11141]](https://bugs.ruby-lang.org/issues/11141)  new syntax suggestion for abbreviate definition on block parameters in order
 [https://bugs.ruby-lang.org/issues/11141](https://bugs.ruby-lang.org/issues/11141)
 
 Matz: negative
@@ -272,7 +272,7 @@ Which is favorite?
 
 Next action: ko1 will add discussion into 11141.
 
-# Feature #11105: ES6-like hash literals
+# [[Feature #11105]](https://bugs.ruby-lang.org/issues/11105) ES6-like hash literals
 [https://bugs.ruby-lang.org/issues/11105#change-52447](https://bugs.ruby-lang.org/issues/11105#change-52447)
 
 Problem 1: It seems “Set”

--- a/2015/DevMeeting-2015-06-12.md
+++ b/2015/DevMeeting-2015-06-12.md
@@ -121,7 +121,7 @@ matz: approved (Hash#fetch_values).
 
 Action: Matz will reply. Nobu will merge it.
 
-## \[Feature #9108\] Hash sub-selections
+## [[Feature #9108]](https://bugs.ruby-lang.org/issues/9108) Hash sub-selections
 
 Action: Matz will reply.
 
@@ -129,13 +129,13 @@ Action: Matz will reply.
 
 Action: continue to discuss how to implement (nobu)
 
-## \[Feature #11215\] pack/unpack for (u)intptr_t
+## [[Feature #11215]](https://bugs.ruby-lang.org/issues/11215) pack/unpack for (u)intptr_t
 
 Action: Matz will approve it.
 
-## \[Feature #10769\] Negative counterpart to Enumerable#slice_when
+## [[Feature #10769]](https://bugs.ruby-lang.org/issues/10769) Negative counterpart to Enumerable#slice_when
 
-## \[Feature #11253\] rb_io_modestr_oflags for Ruby API
+## [[Feature #11253]](https://bugs.ruby-lang.org/issues/11253) rb_io_modestr_oflags for Ruby API
 
 matz: add keyword argument “flags”, which is OR-ed with 2nd argument mode.
 

--- a/2016/DevMeeting-2016-05-17.md
+++ b/2016/DevMeeting-2016-05-17.md
@@ -241,7 +241,7 @@ Milestones
 - Duerst: oniguruma has updates.
 - naruse: I hadn’t know Oniguruma is on GitHub now [https://github.com/kkos/oniguruma](https://github.com/kkos/oniguruma). I’ll check it.
 
-## \[Bug #12368\] default encoding of Integer#chr
+## [[Bug #12368]](https://bugs.ruby-lang.org/issues/12368) default encoding of Integer#chr
 
 - As usa says script encoding doesn’t exist run time.
 - defaults to utf-8?

--- a/2016/DevMeeting-2016-06-13.md
+++ b/2016/DevMeeting-2016-06-13.md
@@ -142,7 +142,7 @@ nobu: this patch requires some tests, and fixes.
 
 - see https://bugs.ruby-lang.org/projects/ruby/wiki/DeveloperHowto
 
-## \[Feature #12247\] accept multiple arguments at Array#delete
+## [[Feature #12247]](https://bugs.ruby-lang.org/issues/12247) accept multiple arguments at Array#delete
 
 What’s happen?
 
@@ -173,7 +173,7 @@ Assigned to Minero Aoki.
 
 Assigned to shugo.
 
-## \[Feature #12086\] using: option for instance_eval etc.
+## [[Feature #12086]](https://bugs.ruby-lang.org/issues/12086) using: option for instance_eval etc.
 
 Motivation is replace self and using context.
 

--- a/2017/DevMeeting-2017-07-14.md
+++ b/2017/DevMeeting-2017-07-14.md
@@ -253,7 +253,7 @@ Language: mostly Japanese (sorry for non native Japanese speakers)
 
 ## From attendees
 
-## \[Bug #13737\] "can't modify frozen String" when installing bundled gems (ko1)
+## [[Bug #13737]](https://bugs.ruby-lang.org/issues/13737) "can't modify frozen String" when installing bundled gems (ko1)
 
 
 - should what happen for tainted string?

--- a/2018/DevMeeting-2018-01-24.md
+++ b/2018/DevMeeting-2018-01-24.md
@@ -177,7 +177,7 @@ Do we have to support such old toolchains? For instance, is it unable for us to 
 - Knu: This method changes values as well as keys, which seems wrong.
 - Matz: This particular API seems NG to me.
 
-## \[Bug #14380\] Expected transform_keys! to work just as transform_keys, but it doesn't (mame)
+## [[Bug #14380]](https://bugs.ruby-lang.org/issues/14380) Expected transform_keys! to work just as transform_keys, but it doesn't (mame)
 
 
 - Shyouhei: This behaviour was inherited from ActiveSupport.

--- a/2018/DevMeeting-2018-02-20.md
+++ b/2018/DevMeeting-2018-02-20.md
@@ -178,7 +178,7 @@ Next Developper Meetings
 - Knu: This method changes values as well as keys, which seems wrong.
 - Matz: This particular API seems NG to me.
 
-## \[Bug #14380\] Expected transform_keys! to work just as transform_keys, but it doesn't (mame)
+## [[Bug #14380]](https://bugs.ruby-lang.org/issues/14380) Expected transform_keys! to work just as transform_keys, but it doesn't (mame)
 
 
 - Shyouhei: This behaviour was inherited from ActiveSupport.

--- a/2021/DevelopersMeeting20210521Japan.md
+++ b/2021/DevelopersMeeting20210521Japan.md
@@ -475,7 +475,7 @@ Conclusion:
 https://github.com/ruby/dev-meeting-log/blob/master/DevelopersMeeting20210416Japan.md
 
 
-### [Bug #16983] RubyVM::AbstractSyntaxTree.of(method) returns meaningless node if the method is defined in eval (jeremyevans0)
+### [[Bug #16983]](https://bugs.ruby-lang.org/issues/16983) RubyVM::AbstractSyntaxTree.of(method) returns meaningless node if the method is defined in eval (jeremyevans0)
 
 * ko1: Will do.
 


### PR DESCRIPTION
Several meeting log headings referenced Redmine tickets by number without linking to them. This adds links to `bugs.ruby-lang.org` for 14 ticket headings across 9 files, using the standard `[[Type #NNN]](url)` format.

Examples of changes:
- `## \[Bug #12368\] default encoding...` → `## [[Bug #12368]](https://bugs.ruby-lang.org/issues/12368) default encoding...`
- `# Feature #11141: new syntax...` → `# [[Feature #11141]](https://bugs.ruby-lang.org/issues/11141) new syntax...`
- `### Non-blocking reads... Feature #5138` → `### [[Feature #5138]](https://bugs.ruby-lang.org/issues/5138) Non-blocking reads...`

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.