### PR TITLE
Fix severely broken markdown link in 2016-12-21 meeting log

### DIFF
--- a/2016/DevMeeting-2016-12-21.md
+++ b/2016/DevMeeting-2016-12-21.md
@@ -303,6 +303,6 @@ Issues
 
 - [[Feature #5481]](https://bugs.ruby-lang.org/issues/5481) [https://bugs.ruby-lang.org/issues/5481](https://bugs.ruby-lang.org/issues/5481)
 
-- \[Bug [#12998](https://bugs.ruby-lang.org/issues/12998)[\] paragraph mode inconsistency between](https://bugs.ruby-lang.org/issues/5481) [IO#each_line](https://bugs.ruby-lang.org/issues/5481) [and](https://bugs.ruby-lang.org/issues/5481) [String#each_line](https://bugs.ruby-lang.org/issues/5481)[(nobu)](https://bugs.ruby-lang.org/issues/5481)
+- [[Bug #12998]](https://bugs.ruby-lang.org/issues/12998) paragraph mode inconsistency between `IO#each_line` and `String#each_line` (nobu)
 
 - akr: String#each_line should be fixed in 2.5.


### PR DESCRIPTION
A Google Docs export artifact caused every word in a Bug #12998 reference to become a separate markdown link, each pointing to the wrong issue (#5481 instead of #12998):

**Before:**
```
- \[Bug [#12998](url)[\] paragraph mode inconsistency between](wrong-url) [IO#each_line](wrong-url) [and](wrong-url) [String#each_line](wrong-url)[(nobu)](wrong-url)
```

**After:**
```
- [[Bug #12998]](https://bugs.ruby-lang.org/issues/12998) paragraph mode inconsistency between `IO#each_line` and `String#each_line` (nobu)
```

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.