### PR TITLE
Remove Redmine paragraph anchors from headings (2013-2016)

### DIFF
--- a/2013/DevMeeting-2013-12-05.md
+++ b/2013/DevMeeting-2013-12-05.md
@@ -80,11 +80,11 @@ Although we didn't have a video recording from the meeting on Friday, werecorded
 
 Below I have summarized the meetings for each day and organized them intoagenda items. Each agenda item should have an associated ticket on our [bugtracker](http://bugs.ruby-lang.org/) that you can follow for more information.I will be updating these tickets with our conclusion shortly!
 
-## 2013-12-05[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#2013-12-05)
+## 2013-12-05
 
 Last Thursday several ruby-core committers, including Matz, met to discuss thefuture of Ruby. Here's the summary by topic:
 
-### 2.1.0 Release Schedule[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#210-Release-Schedule)
+### 2.1.0 Release Schedule
 
 [Version 27 on bug tracker](http://bugs.ruby-lang.org/versions/27)
 
@@ -94,14 +94,14 @@ Last Thursday several ruby-core committers, including Matz, met to discuss thefu
 - All bug fixes must be approved by the release manager ([@nalsh](https://twitter.com/nalsh))
 - 2.1.0 will be released on christmas 2013 (2013-12-25)
 
-### 2.1.0 Maintainer[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#210-Maintainer)
+### 2.1.0 Maintainer
 
 [misc. #9215](http://bugs.ruby-lang.org/issues/9215)
 
 - Undecided
 - [@nalsh](https://twitter.com/nalsh) will maintain 2.1.0 for 2 months after release
 
-### Semantic Versioning[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Semantic-Versioning)
+### Semantic Versioning
 
 [misc. #8835](http://bugs.ruby-lang.org/issues/8835)
 
@@ -115,7 +115,7 @@ To summarize:
 - We accept proposal of [@hsbt](https://twitter.com/hsbt)
 - The following proposal will begin with 2.1.0
 
-#### Version Schema `ruby-{MAJOR}.{MINOR}.{TEENY}`[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Version-Schema-ruby-MAJORMINORTEENY)
+#### Version Schema `ruby-{MAJOR}.{MINOR}.{TEENY}`
 
 - `MAJOR`: increased when incompatible change which can't be released in MINOR
 - "MAJOR is for party", reserved for special events
@@ -127,7 +127,7 @@ To summarize:
 
 Matz and other attendees were concerned about `TEENY >= 10`.
 
-#### Branches[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Branches)
+#### Branches
 
 We will maintain the following branches:
 
@@ -136,13 +136,13 @@ We will maintain the following branches:
 - `ruby_{MAJOR}_{MINOR}` across `TEENY` releases
 - tags will be used for each release
 
-#### API Compatibility[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#API-Compatibility)
+#### API Compatibility
 
 - Removing API is an incompatible change
 - such as (`STDIO_READ_DATA_PENDING`, etc.) must wait for 2.2.0
 - an incompatible change must increase `MINOR`
 
-#### ABI Compatibility[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#ABI-Compatibility)
+#### ABI Compatibility
 
 - Scheme of `{MAJOR}.{MINOR}.0`
 - Keep ABI compatibility with same `MINOR` release, so `TEENY` is fixed at 0
@@ -153,11 +153,11 @@ We are concerned with changes required for existing tools, such as:
 - svn
 - backport / merger
 
-#### Documentation[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Documentation)
+#### Documentation
 
 We need to announce our plans for removing patch level semantics, in order touse `{MAJOR}.{MINOR}.{TEENY}`.
 
-### Maintenance Policy for 1.8.7 and 1.9.2[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Maintenance-Policy-for-187-and-192)
+### Maintenance Policy for 1.8.7 and 1.9.2
 
 [misc. #9216](http://bugs.ruby-lang.org/issues/9216)
 
@@ -175,7 +175,7 @@ We were given permission from Matz to release backport versions of Ruby forsecur
 
 We made an important decision on this policy on Friday, please read the summaryfor that day in the next major section.
 
-### Maintenance Policy for 1.9.3[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Maintenance-Policy-for-193)
+### Maintenance Policy for 1.9.3
 
 [misc. #9217](http://bugs.ruby-lang.org/issues/9217)
 
@@ -183,7 +183,7 @@ We made an important decision on this policy on Friday, please read the summaryf
 - It will receive security fixes until March 2014
 - Additional 3 month security maintenance period may be supported by [@unak](https://twitter.com/unak)
 
-### Maintenance Policy for Future Versions of Ruby[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Maintenance-Policy-for-Future-Versions-of-Ruby)
+### Maintenance Policy for Future Versions of Ruby
 
 [misc. #9215](http://bugs.ruby-lang.org/issues/9215)
 
@@ -194,7 +194,7 @@ We want to encourage a more routine process to improve user expectation andexper
 
 It's encouraged that each release manager decide on a roadmap for theirversion, although an absolute schedule and maintenance plan is difficult.
 
-### Policy Announcements[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Policy-Announcements)
+### Policy Announcements
 
 [misc. #9219](http://bugs.ruby-lang.org/issues/9219)
 
@@ -204,7 +204,7 @@ We will offer a conclusive policy document for all versions during the announceo
 
 I will publish this document shortly!
 
-### Maintainer Appointment and Discharge[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Maintainer-Appointment-and-Discharge)
+### Maintainer Appointment and Discharge
 
 [misc. #9218](http://bugs.ruby-lang.org/issues/9218)
 
@@ -232,7 +232,7 @@ for 2.0.0.
 
 It was suggested that [@unak](https://twitter.com/unak) may begin maintenance of2.0.0 in March 2014.
 
-### GC Merits and Documentation[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#GC-Merits-and-Documentation)
+### GC Merits and Documentation
 
 [misc. #8962](http://bugs.ruby-lang.org/issues/8962)
 
@@ -250,7 +250,7 @@ Koichi adds, "its ok to be shady".
 
 I will help with authoring this document.
 
-### Error Hiding[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Error-Hiding)
+### Error Hiding
 
 [Feature #7688](http://bugs.ruby-lang.org/issues/7688)
 
@@ -260,7 +260,7 @@ We discussed this ticket, and concluded the following statements:
 - Matz is undecided on the best way to improve performance
 - Okay to experiment after 2.1.0 is released
 
-### Various other discussion and events during Thursday[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Various-other-discussion-and-events-during-Thursday)
+### Various other discussion and events during Thursday
 
 After watching the video I wrote a [roughsummary](https://gist.github.com/zzak/7821769), since most of thediscussion was in English. The following other events took place during themeeting:
 

--- a/2013/DevMeeting-2013-12-06.md
+++ b/2013/DevMeeting-2013-12-06.md
@@ -54,11 +54,11 @@ Please follow the [[DevelopersMeetingIRCGuidelines]] for irc
 
 # Summary
 
-## 2013-12-06[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#2013-12-06)
+## 2013-12-06
 
 On Friday, several committers met to discuss the events that took place duringthe previous meeting. We made important decisions on the maintenance policy forbackport versions and commercial support.
 
-### Branch Schema for Semantic Versioning `ruby_MAJOR_MINOR`[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Branch-Schema-for-Semantic-Versioning-ruby_MAJOR_MINOR)
+### Branch Schema for Semantic Versioning `ruby_MAJOR_MINOR`
 
 [misc. #8835](http://bugs.ruby-lang.org/issues/8835)
 
@@ -72,7 +72,7 @@ The previous solution was to create a new branch (`ruby_1_8_6`) and beginmaintai
 
 We are concerned because security versions may occur more frequently betweenMINOR branch changes.
 
-#### SemVer[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#SemVer)
+#### SemVer
 
 After reviewing the discussion from the previous meeting we discussed theconcern of `TEENY >= 10`.
 
@@ -81,11 +81,11 @@ After reviewing the discussion from the previous meeting we discussed theconcern
 - The version number can be anything that acts like String
 - We will postpone this situation
 
-#### Tooling support[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Tooling-support)
+#### Tooling support
 
 Most maintainers use tools from trunk, so they need to remain compatible withbackport branches. Any change in this policy should be documented.
 
-### Maintenance Policy for 1.8.7 and 1.9.2[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Maintenance-Policy-for-187-and-192-2)
+### Maintenance Policy for 1.8.7 and 1.9.2
 
 [misc. #9216](http://bugs.ruby-lang.org/issues/9216)
 
@@ -99,7 +99,7 @@ Reason being, we don't want any new tickets, as an official release will resulti
 
 We need to write documentation for upgrading to supported versions, this isstrongly needed regardless of any policy changes.
 
-### Maintenance Policy for 1.9.3[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Maintenance-Policy-for-193-2)
+### Maintenance Policy for 1.9.3
 
 [misc. #9217](http://bugs.ruby-lang.org/issues/9217)
 
@@ -107,18 +107,18 @@ We strongly agree on one major point:
 
 - An official announcement on this issue is critical
 
-### Maintenance Policy for Future Versions of Ruby[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Maintenance-Policy-for-Future-Versions-of-Ruby-2)
+### Maintenance Policy for Future Versions of Ruby
 
 [misc. #9215](http://bugs.ruby-lang.org/issues/9215)
 
 We had an extended conversation about the maintenance policy of all Rubyversions.
 
-#### Priority[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Priority)
+#### Priority
 
 - Security fixes become priority
 - Its maintainer's decision for priority of bug fix and security fix
 
-#### Duration[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Duration)
+#### Duration
 
 We decided the following conclusion:
 
@@ -137,7 +137,7 @@ Our maintenance period should be:
 
 Our goal is to avoid a sudden death.
 
-#### On commercial support[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#On-commercial-support)
+#### On commercial support
 
 [@ayumin](https://twitter.com/ayumin) offered the following statement:
 
@@ -150,7 +150,7 @@ It's the responsibility of the business party involved to maintain backwardscomp
 
 We should encourage commercial support for EOL rubies, such documentation wouldbe beneficial.
 
-### Wrap-up[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingDecember2013Japan#Wrap-up)
+### Wrap-up
 
 That about wraps up the summary of both meetings, thank you to everyone who could attend!
 

--- a/2014/DevMeeting-2014-05-17.md
+++ b/2014/DevMeeting-2014-05-17.md
@@ -224,71 +224,71 @@ pLinux が何なのかよくわからないので RubyCI のサーバー名を�
 
 # Summary
 
-## Attendance[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Attendance)
+## Attendance
 
 - in person: sora_h, shyouhei, akr, naruse, ko1, hsbt, tarui
 - online: matz, n0kada
 
-## \[Feature [#9772](https://bugs.ruby-lang.org/issues/9772 "Feature: IO#statfs and File::Statfs (Rejected)")\] IO#statfs and File::Statfs[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9772-IOstatfs-and-FileStatfs)
+## \[Feature [#9772](https://bugs.ruby-lang.org/issues/9772 "Feature: IO#statfs and File::Statfs (Rejected)")\] IO#statfs and File::Statfs
 
 not accepted. A gem should be made first.
 
-## \[Feature [#9647](https://bugs.ruby-lang.org/issues/9647 "Feature: File::Stat#birthtimeの追加 (Closed)")\] File::Stat#birthtime[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9647-FileStatbirthtime)
+## \[Feature [#9647](https://bugs.ruby-lang.org/issues/9647 "Feature: File::Stat#birthtimeの追加 (Closed)")\] File::Stat#birthtime
 
 accepted
 
-## \[Feature [#9816](https://bugs.ruby-lang.org/issues/9816 "Feature: 文字列内の数字を数値として比較するメソッド (Assigned)")\] 文字列内の数字を数値として比較するメソッド[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9816-%E6%96%87%E5%AD%97%E5%88%97%E5%86%85%E3%81%AE%E6%95%B0%E5%AD%97%E3%82%92%E6%95%B0%E5%80%A4%E3%81%A8%E3%81%97%E3%81%A6%E6%AF%94%E8%BC%83%E3%81%99%E3%82%8B%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89)
+## \[Feature [#9816](https://bugs.ruby-lang.org/issues/9816 "Feature: 文字列内の数字を数値として比較するメソッド (Assigned)")\] 文字列内の数字を数値として比較するメソッド
 
 This feature is about comparing characters as numbers, like for Gem versions. For instance, 11 > 9 #=> true
 
 - still need more discussion
 - also need a good name
 
-## date[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#date)
+## date
 
 going separate it into a bundled gem
 
-## \[Feature [#9513](https://bugs.ruby-lang.org/issues/9513 "Feature: Hide Rational internal (Closed)")\] Hide Rational internal (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9513-Hide-Rational-internal-akr)
+## \[Feature [#9513](https://bugs.ruby-lang.org/issues/9513 "Feature: Hide Rational internal (Closed)")\] Hide Rational internal (akr)
 
 accepted
 
-## \[Feature [#9826](https://bugs.ruby-lang.org/issues/9826 "Feature: Enumerable#slice_between (Closed)")\] Enumerable#slice_between (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9826-Enumerableslice_between-akr)
+## \[Feature [#9826](https://bugs.ruby-lang.org/issues/9826 "Feature: Enumerable#slice_between (Closed)")\] Enumerable#slice_between (akr)
 
 Matz likes the idea, but it needs a better name. There is already Array#slice.
 
-## \[Feature [#9071](https://bugs.ruby-lang.org/issues/9071 "Feature: Enumerable#slice_after (Closed)")\] Enumerable#slice_after (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9071-Enumerableslice_after-akr)
+## \[Feature [#9071](https://bugs.ruby-lang.org/issues/9071 "Feature: Enumerable#slice_after (Closed)")\] Enumerable#slice_after (akr)
 
 accepted
 
-## \[Feature [#9770](https://bugs.ruby-lang.org/issues/9770 "Feature: Etc.uname (Closed)")\] Etc.uname (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9770-Etcuname-akr)
+## \[Feature [#9770](https://bugs.ruby-lang.org/issues/9770 "Feature: Etc.uname (Closed)")\] Etc.uname (akr)
 
 accepted
 
-## \[Feature [#9842](https://bugs.ruby-lang.org/issues/9842 "Feature: system configuration variables (sysconf(), confstr(), pathconf() and fpathconf()) (Closed)")\] system configuration variables (sysconf(), confstr(), pathconf() and fpathconf()) (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9842-system-configuration-variables-sysconf-confstr-pathconf-and-fpathconf-akr)
+## \[Feature [#9842](https://bugs.ruby-lang.org/issues/9842 "Feature: system configuration variables (sysconf(), confstr(), pathconf() and fpathconf()) (Closed)")\] system configuration variables (sysconf(), confstr(), pathconf() and fpathconf()) (akr)
 
 accepted
 
-## \[Feature [#9834](https://bugs.ruby-lang.org/issues/9834 "Feature: Float#{next_float,prev_float} (Closed)")\] Float#{next_float,prev_float} (akr)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9834-Floatnext_floatprev_float-akr)
+## \[Feature [#9834](https://bugs.ruby-lang.org/issues/9834 "Feature: Float#{next_float,prev_float} (Closed)")\] Float#{next_float,prev_float} (akr)
 
 accepted
 
-## \[Feature [#9632](https://bugs.ruby-lang.org/issues/9632 "Feature: [PATCH 0/2] speedup IO#close with linked-list from ccan (Closed)")\] [offtopic] remove doxygen?[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9632-offtopic-remove-doxygen)
+## \[Feature [#9632](https://bugs.ruby-lang.org/issues/9632 "Feature: [PATCH 0/2] speedup IO#close with linked-list from ccan (Closed)")\] [offtopic] remove doxygen?
 
 dropping support for doxygen
 
-## \[Feature [#9711](https://bugs.ruby-lang.org/issues/9711 "Feature: Remove test-unit and minitest from stdlib. (Closed)")\] Remove test-unit and minitest from stdlib. Can I remove test-unit? /cc sora_h (hsbt)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Feature-9711-Remove-test-unit-and-minitest-from-stdlib-Can-I-remove-test-unit-cc-sora_h-hsbt)
+## \[Feature [#9711](https://bugs.ruby-lang.org/issues/9711 "Feature: Remove test-unit and minitest from stdlib. (Closed)")\] Remove test-unit and minitest from stdlib. Can I remove test-unit? /cc sora_h (hsbt)
 
 continuing to discuss about bundling test libraries test-unit/minitest.
 
-## remove rubyforge url(hsbt)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#remove-rubyforge-urlhsbt)
+## remove rubyforge url(hsbt)
 
 accepted
 
-## give up callcc (tarui)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#give-up-callcc-tarui)
+## give up callcc (tarui)
 
 accepted: going to fade out callcc support
 
-## Hash#comprized? (hone02)[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Hashcomprized-hone02)
+## Hash#comprized? (hone02)
 
 [http://olivierlacan.com/posts/proposal-for-a-better-ruby-hash-include/](http://olivierlacan.com/posts/proposal-for-a-better-ruby-hash-include/)
 
@@ -296,11 +296,11 @@ accepted: going to fade out callcc support
 - unclear what the usecase is
 - continue to discuss on redmine
 
-## [ANN] chkbuildXXX.hsbt.org[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#ANN-chkbuildXXXhsbtorg)
+## [ANN] chkbuildXXX.hsbt.org
 
 Using Ruby Association's funds, 4 machines have been prepared for chkbuild. chkbuild is the Ruby CI platform powering [http://rubyci.org](http://rubyci.org/). We also want something besides Intel like running ARM on top of QEMU.
 
-## Next Meetings[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeetingSummary20140517Japan#Next-Meetings)
+## Next Meetings
 
 - 6/18, 18:30 JST: discussing [Feature [#9711](https://bugs.ruby-lang.org/issues/9711 "Feature: Remove test-unit and minitest from stdlib. (Closed)")], [doorkeeper](http://cruby.doorkeeper.jp/events/11795?utm_campaign=event_11795_7773&utm_medium=email&utm_source=not_replied_message)
 - 7/26: big features for 2.2

--- a/2016/DevMeeting-2016-08-09.md
+++ b/2016/DevMeeting-2016-08-09.md
@@ -100,7 +100,7 @@ Write your name and your interest (what do you want to ask and to whom?) please.
 - when 7 Sept., 14:00 〜
 - At @tagomoris house?
 
-## Doorkeeperhq account upgrade[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20160809Japan#Doorkeeperhq-account-upgrade)
+## Doorkeeperhq account upgrade
 
 We need a paypal account to connect to cruby.doorkeeper.jp (shyouhei)
 


### PR DESCRIPTION
When meeting logs were exported from Redmine wiki pages, each heading retained a paragraph anchor link (`[¶](wiki-url)`) used for in-page navigation on the wiki. These are rendering artifacts that serve no purpose in the markdown files.

Removes 47 anchors across 4 files.

**Example:**
```
## Attendance[¶](https://bugs.ruby-lang.org/projects/ruby/wiki/...)
```
→
```
## Attendance
```

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.