### PR TITLE
Replace HTML entities with literal characters (2008-2013)

### DIFF
--- a/2008/DevMeeting-2008-09-22.md
+++ b/2008/DevMeeting-2008-09-22.md
@@ -19,19 +19,19 @@ tags: Ruby, ruby-dev-meeting
 
 # Agenda
 
-* ABI fixの前に<code>struct RArray</code>の埋め込みはやらないのか? (yugui) -&gt; 公開したくない構造体を別のファイルにする
-* <kbd>include/ruby/</kbd>から<kbd>node.h</kbd>を移動させたい (yugui) -&gt; ripper 問題がなければいいのでは
-* class of class of class is <kbd>Class</kbd>は仕様かバグか? (yugui) -&gt; yugui さんががんばる
-* DelegateClass#class を1.8仕様にするか否かの結論を (unak) -&gt; 1.8 に戻す，その他のメソッドについては未定
-* Regexp#to_s を Regexp#inspect の alias に (nurse) -&gt; rejected by akr
-* Method#parameters, Proc#parameters (ko1) -&gt; rejected (wait for named parameter)
-* Method#source_location -&gt; nobu matter
-* Encoding::default_internal (Michael Selig, ruby-core:18774) -&gt; pending (今週中)
-* 凍結の範囲はどこまでか (添付ライブラリも含まれるか (rubygems のアップグレードは間に合うのか (mame) [RubyKaigi2008 で新しい文字コード変換の追加が含まれないのは matz の見解でした] -&gt; 含まれる．ただし，事前に悲鳴をあげれば 10 月まで待つ
+* ABI fixの前に<code>struct RArray</code>の埋め込みはやらないのか? (yugui) -> 公開したくない構造体を別のファイルにする
+* <kbd>include/ruby/</kbd>から<kbd>node.h</kbd>を移動させたい (yugui) -> ripper 問題がなければいいのでは
+* class of class of class is <kbd>Class</kbd>は仕様かバグか? (yugui) -> yugui さんががんばる
+* DelegateClass#class を1.8仕様にするか否かの結論を (unak) -> 1.8 に戻す，その他のメソッドについては未定
+* Regexp#to_s を Regexp#inspect の alias に (nurse) -> rejected by akr
+* Method#parameters, Proc#parameters (ko1) -> rejected (wait for named parameter)
+* Method#source_location -> nobu matter
+* Encoding::default_internal (Michael Selig, ruby-core:18774) -> pending (今週中)
+* 凍結の範囲はどこまでか (添付ライブラリも含まれるか (rubygems のアップグレードは間に合うのか (mame) [RubyKaigi2008 で新しい文字コード変換の追加が含まれないのは matz の見解でした] -> 含まれる．ただし，事前に悲鳴をあげれば 10 月まで待つ
 * 文字コード変換あたりの名前の整理 (duerst, matz, ruby-dev:36389): 結論: 現在のままでよい (matz ruby-dev:36420)
-* lib/1.9 or lib/1.9.1 ? -&gt; suffix を付ければいいのではという案
-* binread -&gt; 入れる
-* Hash#eachの順序 =&gt; 公式にRuby 1.9 featureとして認定
-* inspect の Encoding -&gt; external encoding と同じならそのまま，それ以外はバイナリ
-* tempdir, tmpfile どちらかに対応したい -&gt; tmp に統一?
+* lib/1.9 or lib/1.9.1 ? -> suffix を付ければいいのではという案
+* binread -> 入れる
+* Hash#eachの順序 => 公式にRuby 1.9 featureとして認定
+* inspect の Encoding -> external encoding と同じならそのまま，それ以外はバイナリ
+* tempdir, tmpfile どちらかに対応したい -> tmp に統一?
 * ticket の Feature な issue を一応全部見直した．

--- a/2008/DevMeeting-2008-10-16.md
+++ b/2008/DevMeeting-2008-10-16.md
@@ -22,7 +22,7 @@ tags: Ruby, ruby-dev-meeting
 
 # Agenda
 
-Please write your name at the end of your topics such as -&gt; (ko1).
+Please write your name at the end of your topics such as -> (ko1).
 
 * ABI fix (ko1)
 * What default_internal caused?

--- a/2009/DevMeeting-2009-06-22.md
+++ b/2009/DevMeeting-2009-06-22.md
@@ -26,7 +26,7 @@ tags: Ruby, ruby-dev-meeting
 * 今開発中の機能を確認 (yugui)
   * → クリスマスに1.9.2を出せそうかどうか (yugui)
 
-Please write your name at the end of your topics such as -&gt; (ko1).
+Please write your name at the end of your topics such as -> (ko1).
 
 # Log
 

--- a/2009/DevMeeting-2009-07-16.md
+++ b/2009/DevMeeting-2009-07-16.md
@@ -25,14 +25,14 @@ tags: Ruby, ruby-dev-meeting
 
 # Agenda
 
-Please write your name at the end of your topics such as -&gt; (ko1).
+Please write your name at the end of your topics such as -> (ko1).
 
 * [[ruby-core:24113]] (shyouhei)
   * なんか頑張る
 * [[ruby-dev:30954]] (nobu)
   * 中田さんがメンテナだったら，trunk に突っ込んでいいよ
 * [[ruby-dev:38785]] (shugo)
-  * to_a -&gt; to_ary (ko1)
+  * to_a -> to_ary (ko1)
 * [[tracing]] (rocky)
   * Note: I won't be at this meeting, but I am hoping that ko1 will lead the discussion.
   * なんか頑張る

--- a/2009/DevMeeting-2009-10-13.md
+++ b/2009/DevMeeting-2009-10-13.md
@@ -35,7 +35,7 @@ tags: Ruby, ruby-dev-meeting
   * either way, rubyspec will probably be a bottleneck
 * everyone should run rubyspec more often, and report any problems found (problems with ruby or rubspec are welcome)
 
-### The next preview &amp; feature freeze
+### The next preview & feature freeze
 
 * release preview 2 around end of October (motion passed)
 * Aim for December feature freeze  (motion passed)

--- a/2010/DevMeeting-2010-08-27.md
+++ b/2010/DevMeeting-2010-08-27.md
@@ -34,7 +34,7 @@ tags: Ruby, ruby-dev-meeting
 
 If you need a bento (lunch), please write it.  Expense will be collected.
 
-'''Bento order deadline is 8/24''' &lt;- Order is closed.  We prepare 17 bentos (RubyKaigi staffs have own bento).
+'''Bento order deadline is 8/24''' <- Order is closed.  We prepare 17 bentos (RubyKaigi staffs have own bento).
 
 # Agenda
 
@@ -44,7 +44,7 @@ If you need a bento (lunch), please write it.  Expense will be collected.
     * No deadline, no code
   * Features
     * classbox?
-    * MVM &lt;- impossible
+    * MVM <- impossible
     * debug features
     * keyword argument (2.0?)
     * tuning (ko1)
@@ -66,7 +66,7 @@ If you need a bento (lunch), please write it.  Expense will be collected.
     * traits
     * keyword arguments
     * compatibility?
-    * -&gt; matz: 100% compatible
+    * -> matz: 100% compatible
       * crap
   * yugui: 1.9 should include 2.0 features, gradually
   * yugui: 1.9 branch should not be made
@@ -80,9 +80,9 @@ If you need a bento (lunch), please write it.  Expense will be collected.
   * akr: Should 1.8.8 include 1.9.2 methods which 1.9.1 doesn't have?
   * knu: We can ignore 1.9.1.
   * knu: NEWS document is really important.
-  * akr: How to maintain NEWS file? -&gt; flush
+  * akr: How to maintain NEWS file? -> flush
 * The license of Ruby (by naruse)
-  * naruse: GPL3 incompatible. OK: BSD -&gt; Ruby, NG: Ruby -&gt; BSD
+  * naruse: GPL3 incompatible. OK: BSD -> Ruby, NG: Ruby -> BSD
   * naruse: How about to change license Ruby's and BSD?
   * ..some lawyers discussion...
   * matz: i'm thinking to change only GPL2 or later.  However, not enough consideration.  plus BSD seems OK.  We need more law knowledge.
@@ -113,9 +113,9 @@ If you need a bento (lunch), please write it.  Expense will be collected.
 * Specification of dynamic loading (see [ruby-dev:41774]) and Virtual File System Interface (if we have some time (low priority), by nagai)
 * Bug ticket squash (everyone)
 * #3675
-  * String#prepend =&gt; OK
-  * String#append, String#&gt;&gt; =&gt; pending
-  * Array#prepend, Array#append =&gt; pending
+  * String#prepend => OK
+  * String#append, String#>> => pending
+  * Array#prepend, Array#append => pending
 * proposal for Standard C API
   * based on Rubinius's
   * will be porting 1.9.

--- a/2013/DevMeeting-2013-01-15.md
+++ b/2013/DevMeeting-2013-01-15.md
@@ -7,7 +7,7 @@ tags: Ruby, ruby-dev-meeting
 
 This meeting will be held on [2013-01-15 at 15:00 Pacific Time](http://timeanddate.com/worldclock/meetingdetails.html?year=2013&month=1&day=15&hour=23&min=0&sec=0&p1=234&p2=248&p3=48&p4=64/) at irc://chat.freenode.net/#ruby-implementers.
 
-EN &lt;=&gt; JA translations will be done on demand in #ruby-ja on ircnet
+EN <=> JA translations will be done on demand in #ruby-ja on ircnet
 
 ## Attendees
 

--- a/2013/DevMeeting-2013-02-15.md
+++ b/2013/DevMeeting-2013-02-15.md
@@ -9,7 +9,7 @@ tags: Ruby, ruby-dev-meeting
 
 This meeting will be held on [2013-02-15 at 15:00 Pacific Time](http://www.timeanddate.com/worldclock/meetingdetails.html?year=2013&month=2&day=15&hour=23&min=0&sec=0&p1=234&p2=248&p3=48&p4=64)) at ((<URL:irc://chat.freenode.net/#ruby-implementers).
 
-EN &lt;=&gt; JA translations will be done on demand in #ruby-ja on ircnet
+EN <=> JA translations will be done on demand in #ruby-ja on ircnet
 
 ## Attendees
 
@@ -59,7 +59,7 @@ EN &lt;=&gt; JA translations will be done on demand in #ruby-ja on ircnet
 We'll keep this meeting to one hour long.
 
 * Introduction (tenderlove)
-* Ruby 2 versioning scheme, like 1.x (no number &gt; 9)? Will 2.0.10 or 2.10.0 be allowed?
+* Ruby 2 versioning scheme, like 1.x (no number > 9)? Will 2.0.10 or 2.10.0 be allowed?
   * new version number of trunk (2.0.1dev or 2.1.0dev?)
 * [Ruby Symbol issues](https://bugs.ruby-lang.org/issues/7839) (tenderlove)
 * Should <kbd>YAML.load</kbd> be the safe version by default? (marcandre)

--- a/2013/DevMeeting-2013-02-23.md
+++ b/2013/DevMeeting-2013-02-23.md
@@ -133,7 +133,7 @@ mame-san presented summary of Ruby 2.0.0.
 
 ## After Ruby 2.0.0
 
-* Who manage? -&gt; mame (matz's approved)
+* Who manage? -> mame (matz's approved)
 
 ### Version number
 

--- a/2013/DevMeeting-2013-07-12.md
+++ b/2013/DevMeeting-2013-07-12.md
@@ -7,7 +7,7 @@ tags: Ruby, ruby-dev-meeting
 
 This meeting will be held on [2013-07-12 at 23:00 UTC](http://everytimezone.com/#2013-7-12,660,6bj) at irc://chat.freenode.net/#ruby-implementers.
 
-EN &lt;=&gt; JA translations will be done on demand in #ruby-ja on ircnet
+EN <=> JA translations will be done on demand in #ruby-ja on ircnet
 
 ## Attendees
 

--- a/2013/DevMeeting-2013-08-09.md
+++ b/2013/DevMeeting-2013-08-09.md
@@ -7,7 +7,7 @@ tags: Ruby, ruby-dev-meeting
 
 This meeting will be held on [2013-08-09 at 23:00 UTC](http://everytimezone.com/#2013-9-9,660,6bj) at irc://chat.freenode.net/#ruby-implementers.
 
-EN &lt;=&gt; JA translations will be done on demand in #ruby-ja on ircnet
+EN <=> JA translations will be done on demand in #ruby-ja on ircnet
 
 ## Attendees
 

--- a/2013/DevMeeting-2013-09-20.md
+++ b/2013/DevMeeting-2013-09-20.md
@@ -9,7 +9,7 @@ tags: Ruby, ruby-dev-meeting
 
 This meeting will be held on [2013-09-20 at 23:00 UTC](http://everytimezone.com/#2013-9-20,660,6bj) at irc://chat.freenode.net/#ruby-implementers.
 
-EN &lt;=&gt; JA translations will be done on demand in #ruby-ja on ircnet
+EN <=> JA translations will be done on demand in #ruby-ja on ircnet
 
 ## Attendees
 

--- a/2013/DevMeeting-2013-12-05.md
+++ b/2013/DevMeeting-2013-12-05.md
@@ -40,7 +40,7 @@ tags: Ruby, ruby-dev-meeting
 
 * 2.1 roadmap and schedule
 * 2.1.0 branch maintainer
-* &gt;= 2.1 maintenance policy #9215
+* \>= 2.1 maintenance policy #9215
 * Versioning Policy after Ruby 2.1
   * #8835
   * http://d.hatena.ne.jp/nurse/20131111#1384136384


### PR DESCRIPTION
Meeting logs from early years contained HTML entities instead of literal characters, likely from Redmine wiki export:

- `-&gt;` → `->`
- `=&gt;` → `=>`
- `&lt;=&gt;` → `<=>`
- `&amp;` → `&`

35 replacements across 13 files spanning 2008-2013.

One case (`* >= 2.1`) is escaped as `* \>= 2.1` to prevent markdown blockquote parsing. One intentional instance in 2020 (showing XML encoding output `"&lt;&gt;"`) is left unchanged.

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.