### PR TITLE
Replace raw HTML tags with markdown equivalents (2008-2013)

### DIFF
--- a/2008/DevMeeting-2008-09-22.md
+++ b/2008/DevMeeting-2008-09-22.md
@@ -19,9 +19,9 @@ tags: Ruby, ruby-dev-meeting
 
 # Agenda
 
-* ABI fixの前に<code>struct RArray</code>の埋め込みはやらないのか? (yugui) -> 公開したくない構造体を別のファイルにする
-* <kbd>include/ruby/</kbd>から<kbd>node.h</kbd>を移動させたい (yugui) -> ripper 問題がなければいいのでは
-* class of class of class is <kbd>Class</kbd>は仕様かバグか? (yugui) -> yugui さんががんばる
+* ABI fixの前に`struct RArray`の埋め込みはやらないのか? (yugui) -> 公開したくない構造体を別のファイルにする
+* `include/ruby/`から`node.h`を移動させたい (yugui) -> ripper 問題がなければいいのでは
+* class of class of class is `Class`は仕様かバグか? (yugui) -> yugui さんががんばる
 * DelegateClass#class を1.8仕様にするか否かの結論を (unak) -> 1.8 に戻す，その他のメソッドについては未定
 * Regexp#to_s を Regexp#inspect の alias に (nurse) -> rejected by akr
 * Method#parameters, Proc#parameters (ko1) -> rejected (wait for named parameter)

--- a/2012/DevMeeting-2012-12-10.md
+++ b/2012/DevMeeting-2012-12-10.md
@@ -104,16 +104,15 @@ We'll keep this meeting to one hour long.
 
 * Rigid process is not great
 * Having an executable spec that can be gradually translated to RubySpec is good
-* "And I want to make sure as long as I live on this mortal
-  <pre>state, you need my approval before adding something as official
-  Ruby" -- matz</pre>
+* "And I want to make sure as long as I live on this mortal state, you need my approval before adding something as official Ruby" -- matz
 * We should try having more meetings among implementers
 * Maybe we should maintain a flag to identify official "Ruby" features?
 * Matz wants to remain dictator, but still have participation from implemeters.
 
 ## IRC Log
 
-<pre>[15:00:27] @ drbrain set topic "Introduction"
+```
+[15:00:27] @ drbrain set topic "Introduction"
 [15:00:32] <drbrain> It's meeting time
 [15:00:34] <lrz> headius: hi!
 [15:00:43] <headius> lrz: hello! ltns!
@@ -754,4 +753,5 @@ We'll keep this meeting to one hour long.
 [16:24:59] <dbussink> drbrain: thanks for moderating :)
 [16:24:59] <drbrain> brixen: I will post meeting logs to the wiki...
 [16:25:02] <headius> maybe tenderlove could summarize in a ruby-core email
-[16:25:08] @ drbrain set topic "last meeting: http://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20121210"</pre>
+[16:25:08] @ drbrain set topic "last meeting: http://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20121210"
+```

--- a/2013/DevMeeting-2013-01-15.md
+++ b/2013/DevMeeting-2013-01-15.md
@@ -72,7 +72,7 @@ We'll keep this meeting to one hour long.
 ### Conclusion
 
 * Wiki and tests are updated with latest spec
-  <pre>https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/RefinementsSpec</pre>
+  https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/RefinementsSpec
 * The goal for "non-experimental" status is by Ruby 2.1
 
 ### Open Questions
@@ -117,7 +117,7 @@ More than just "isolated" binding is desired
 ## Open Floor
 
 * New "Common Ruby" project
-  <pre>https://bugs.ruby-lang.org/projects/common-ruby</pre>
+  https://bugs.ruby-lang.org/projects/common-ruby
   * Should we actively put new features there?
   * We need to publicize it as "where new language features go"
 * Issue #7564 needs review from matz
@@ -125,7 +125,8 @@ More than just "isolated" binding is desired
 
 ## IRC Log
 
-<pre>15:00 ferrous26: tenderlove: you did?
+```
+15:00 ferrous26: tenderlove: you did?
 15:01 tenderlove: I did!
 15:01 drbrain: If you don't have voice and are a ruby
       implementer please /msg me or tenderlove
@@ -732,4 +733,5 @@ More than just "isolated" binding is desired
       meeting on weekend
 15:59 tenderlove: seems good
 15:59 drbrain: ok
-15:59 drbrain: this meeting is now closed</pre>
+15:59 drbrain: this meeting is now closed
+```

--- a/2013/DevMeeting-2013-02-15.md
+++ b/2013/DevMeeting-2013-02-15.md
@@ -62,17 +62,18 @@ We'll keep this meeting to one hour long.
 * Ruby 2 versioning scheme, like 1.x (no number > 9)? Will 2.0.10 or 2.10.0 be allowed?
   * new version number of trunk (2.0.1dev or 2.1.0dev?)
 * [Ruby Symbol issues](https://bugs.ruby-lang.org/issues/7839) (tenderlove)
-* Should <kbd>YAML.load</kbd> be the safe version by default? (marcandre)
+* Should `YAML.load` be the safe version by default? (marcandre)
 * [Digest::HMAC? Abandon it or make it non-experimental?](https://github.com/ruby/ruby/blob/eb4ae6bc542cdec0ade408c2f5ddfebba227d30f/ext/digest/lib/digest/hmac.rb#L13) (emboss)
 * [Get impressions on how to implement "erasing a password from memory"](https://bugs.ruby-lang.org/issues/5741) (emboss)
-* <kbd>prepend</kbd> and ancestors, instance_method, etc... (#7836, #7842, #7844)
+* `prepend` and ancestors, instance_method, etc... (#7836, #7842, #7844)
 * invite security ML members, especially non-MRI implementers
 * Open Floor
 * Wrap Up
 
 ## IRC Log
 
-<pre>15:06 zenspider: ok. we start... tenderlove ... intro
+```
+15:06 zenspider: ok. we start... tenderlove ... intro
       please
 15:06 enebo: agreed
 15:06 tenderlove: okay
@@ -647,11 +648,12 @@ We'll keep this meeting to one hour long.
 16:06 _ko1: zenspider: thanks
 16:06 zenspider: thanks everyone
 16:07 marcandre: thanks
-16:07 mame0: thanks</pre>
-
+16:07 mame0: thanks
+```
 ## Post Meeting Discussion
 
-<pre>16:07 _ko1: matz_: do you think about next version number? /
+```
+16:07 _ko1: matz_: do you think about next version number? /
       release date?
 16:07 matz_: Even though in Ruby "!" means "dangerous", bang
       methods in standard library uses it to show side
@@ -777,4 +779,5 @@ We'll keep this meeting to one hour long.
 16:48 matz_: I have leave (in reality)
 16:48 matz_: I leave my xchat logged in
 16:49 _ko1: thanks matz
-16:50 mame0: thank you!</pre>
+16:50 mame0: thank you!
+```

--- a/2013/DevMeeting-2013-07-12.md
+++ b/2013/DevMeeting-2013-07-12.md
@@ -66,7 +66,8 @@ ADD ITEMS HERE (with redmine links)
 
 ## IRC Log
 
-<pre>16:05 tenderlove: I'll start.
+```
+16:05 tenderlove: I'll start.
 16:05 drbrain: I think we have done this enough that I don't
       need to watch time
 16:05 tenderlove: I have to apologize for a couple things
@@ -79,11 +80,12 @@ ADD ITEMS HERE (with redmine links)
       schedule since he is doing the 2.1 management
 16:06 tenderlove: so next time I think it would be nice if we
       can get naruse to join
-16:06 tenderlove: anyway</pre>
-
+16:06 tenderlove: anyway
+```
 ### Documentation hosted on ruby-lang.org (zzak)
 
-<pre>16:06 tenderlove: zzak: your turn!
+```
+16:06 tenderlove: zzak: your turn!
 16:06 tenderlove: ruby-lang.org docs
 16:06 mame3: thank you for arranging the meeting!
 16:06 zzak: thank you
@@ -173,11 +175,12 @@ ADD ITEMS HERE (with redmine links)
       feedback
 16:15 drbrain: tenderlove: yes, I suppose zzak should file
       it
-16:15 zzak: can do</pre>
-
+16:15 zzak: can do
+```
 ### Separating "documentation only commits"
 
-<pre>16:16 drbrain: on to "documentation commits" then
+```
+16:16 drbrain: on to "documentation commits" then
 16:16 zzak: re: doc commits, i was going to ask about using a
       separate repo for doc only commits, eg
       http://github.com/documenting-ruby/ruby which will be
@@ -275,11 +278,12 @@ ADD ITEMS HERE (with redmine links)
       around this
 16:25 enebo: :)
 16:25 tenderlove: enebo: /zombocom/
-16:25 tenderlove: zzak: sounds good</pre>
-
+16:25 tenderlove: zzak: sounds good
+```
 ### Internationalized Documentation
 
-<pre>16:25 drbrain: ok, shall we move on to "internationalized
+```
+16:25 drbrain: ok, shall we move on to "internationalized
       documentation"?
 16:25 zzak: ok
 16:26 zzak: so i want to add support for embedded
@@ -369,11 +373,12 @@ ADD ITEMS HERE (with redmine links)
 16:33 zzak: that's it for me, thank you so much for your time
       everyone <3<3<3
 16:33 drbrain: I believe the next topic is up to
-      tenderlove</pre>
-
+      tenderlove
+```
 ### [[Feature #5138]](https://bugs.ruby-lang.org/issues/5138) Non-blocking reads without exceptions.
 
-<pre>16:33 drbrain: non blocking reads without exceptions.
+```
+16:33 drbrain: non blocking reads without exceptions.
 16:33 tenderlove: yay
 16:33 tenderlove: yes
 16:33 drbrain: https://bugs.ruby-lang.org/issues/5138
@@ -514,11 +519,12 @@ ADD ITEMS HERE (with redmine links)
 16:44 drbrain: since knu is not here we should move on to
       zenspider
 16:44 mame3: akr might have an opinion... but I cannot
-      remember right now</pre>
-
+      remember right now
+```
 ### minitest and test/unit relationship
 
-<pre>16:44 drbrain: minitest 4.7.x and test/unit
+```
+16:44 drbrain: minitest 4.7.x and test/unit
 16:44 tenderlove: mame3: I will ask him :-)
 16:45 drbrain: akr_ is here but idle
 16:45 zenspider: can we wake him?
@@ -647,11 +653,12 @@ ADD ITEMS HERE (with redmine links)
 17:01 zenspider: mame3: using gems in stdlib has been
       propesed 20 times. afaik, it has been approved but
       nobody has made it work to approval
-17:01 akr_: Not proposal, though.</pre>
-
+17:01 akr_: Not proposal, though.
+```
 ### Official Ruby FAQ
 
-<pre>17:01 zzak: re: knu "official ruby FAQ"
+```
+17:01 zzak: re: knu "official ruby FAQ"
       https://twitter.com/knu/status/350245444259033088
 17:01 tenderlove: zenspider: no, he means to rebundle
       test/unit
@@ -693,11 +700,12 @@ ADD ITEMS HERE (with redmine links)
       about the "1.9.1 directory" is actually a good thing to
       put in a FAQ
 17:06 zzak: ok, i will import this and work on revising and
-      updating to current behavior</pre>
-
+      updating to current behavior
+```
 ### Ruby developer meeting
 
-<pre>17:06 tenderlove: I guess there is a dev meeting on the 27th
+```
+17:06 tenderlove: I guess there is a dev meeting on the 27th
       JST?
 17:06 zzak: just call me tenderdoclove
 17:07 yorickpeterse: zzak: if you need any help just ping,
@@ -728,4 +736,5 @@ ADD ITEMS HERE (with redmine links)
 17:09 tenderlove: headius: thanks!
 17:09 zzak: headius: thank you
 17:09 headius has left ()
-17:09 tenderlove: official time is over</pre>
+17:09 tenderlove: official time is over
+```

--- a/2013/DevMeeting-2013-08-09.md
+++ b/2013/DevMeeting-2013-08-09.md
@@ -51,12 +51,14 @@ We'll keep this meeting to one hour long.
 
 ## IRC Log
 
-<pre>17:04 tenderlove: here's the wiki:
-      https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20130809</pre>
-
+```
+17:04 tenderlove: here's the wiki:
+      https://bugs.ruby-lang.org/projects/ruby/wiki/DevelopersMeeting20130809
+```
 ### Frozen string syntax (#8579)
 
-<pre>17:04 drbrain: I guess we start with "frozen string syntax"
+```
+17:04 drbrain: I guess we start with "frozen string syntax"
       from charliesome
 17:04 tenderlove: yep
 17:04 drbrain: if anyone else needs voice please /msg
@@ -159,11 +161,12 @@ We'll keep this meeting to one hour long.
 17:24 matz: so if no better idea comes, I will accept
       them
 17:24 tenderlove: heh, okay
-17:24 charliesome: :)</pre>
-
+17:24 charliesome: :)
+```
 ### Hash#+ (#6225)
 
-<pre>17:24 tenderlove: Hash#+
+```
+17:24 tenderlove: Hash#+
 17:25 tenderlove: I think that was charliesome too?
 17:25 charliesome: it was me on behalf of zzak
 17:25 matz: why not use Hash#merge ?
@@ -182,11 +185,12 @@ We'll keep this meeting to one hour long.
 17:29 charliesome: Should we move on?
 17:29 matz: I still concern about merge is not a mere
       addition
-17:30 drbrain: ok</pre>
-
+17:30 drbrain: ok
+```
 ### Deprecate :: for method calls (#8377)
 
-<pre>17:30 drbrain: next is "deprecate :: for method calls" like o
+```
+17:30 drbrain: next is "deprecate :: for method calls" like o
       = Object::new
 17:30 tenderlove: we should have the original reporter submit
       a slide for decision
@@ -238,11 +242,12 @@ We'll keep this meeting to one hour long.
       For example, test-all passes without test changes or
       not?
 17:37 matz: I declare rejection over removing :: for method
-      calls</pre>
-
+      calls
+```
 ### Process.clock_gettime (#8658) (tenderlove)
 
-<pre>17:38 drbrain: the last topic is "Process.clock_gettime" by
+```
+17:38 drbrain: the last topic is "Process.clock_gettime" by
       tenderlove
 17:38 tenderlove: huh
 17:38 tenderlove: I think I already discussed this with
@@ -296,4 +301,5 @@ We'll keep this meeting to one hour long.
       Maybe I can help somehow
 17:48 matz: so other implementation of Ruby may not provide
       it
-17:49 drbrain: that is the end of the agenda</pre>
+17:49 drbrain: that is the end of the agenda
+```


### PR DESCRIPTION
Several early meeting logs used raw HTML tags instead of markdown, from Redmine wiki exports:

- `<pre>...</pre>` blocks → markdown code fences (`` ``` ``)
- `<code>...</code>` and `<kbd>...</kbd>` → backtick inline code (`` `...` ``)

6 files changed spanning 2008-2013. One file (2020) with intentional HTML tables is left unchanged.

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.