### PR TITLE
Fix unfenced code examples with escaped # and - at line start

### DIFF
--- a/2014/DevMeeting-2014-07-26.md
+++ b/2014/DevMeeting-2014-07-26.md
@@ -97,7 +97,7 @@ approval.
 
 super: ambiguous which is calling method or getting method object of super.
 
-\-> “super_method”
+-> “super_method”
 
 # [[Feature #10095]](https://bugs.ruby-lang.org/issues/10095) Object#as
 

--- a/2014/DevMeeting-2014-09-04.md
+++ b/2014/DevMeeting-2014-09-04.md
@@ -97,11 +97,11 @@ Preview 1 (9/13 freeze)
 
 Need to apply:
 
-\- Incremental GC
+- Incremental GC
 
-\- RubyGems / Rake / RDoc
+- RubyGems / Rake / RDoc
 
-\- vfork
+- vfork
 
 Preview 2 (11/?)
 

--- a/2015/DevMeeting-2015-08-20.md
+++ b/2015/DevMeeting-2015-08-20.md
@@ -73,37 +73,39 @@ Attendee: akr, ayumin, hsbt, ko1, matz, naruse, nobu, kosaki, usa, yuki, amatsud
 
 - More succinct message.  Delete two empty line and indent.
 
+```
 % ruby -rdid_you_mean -e '
 class C
- def bar
- end
+ def bar
+ end
 end
 C.new.baz
 '
-\-e:6:in `<main>': undefined method `baz' for #<C:0x007f790863e880> (NoMethodError)
+-e:6:in `<main>': undefined method `baz' for #<C:0x007f790863e880> (NoMethodError)
 
-   Did you mean? #bar
+   Did you mean? #bar
 
-zsh: exit 1     /home/akr/alias/ruby -rdid_you_mean -e
+zsh: exit 1     /home/akr/alias/ruby -rdid_you_mean -e
 
 % ocaml
-       OCaml version 4.01.0
+       OCaml version 4.01.0
 
-\# let bar = 1;;
+# let bar = 1;;
 val bar : int = 1
-\# baz;;
+# baz;;
 Error: Unbound value baz
 Did you mean bar?
-\# let bas = 2;;
+# let bas = 2;;
 val bas : int = 2
-\# baz;;
+# baz;;
 Error: Unbound value baz
 Did you mean bas or bar?
-\# let bat = 3;;
+# let bat = 3;;
 val bat : int = 3
-\# baz;;
+# baz;;
 Error: Unbound value baz
 Did you mean bas, bat or bar?
+```
 
 #
 

--- a/2015/DevMeeting-2015-11-09.md
+++ b/2015/DevMeeting-2015-11-09.md
@@ -93,29 +93,26 @@ Attendees: matz, nobu, hsbt, akr, naruse, sorah, yuki, ko1
 
 ## [[Feature #4840]](https://bugs.ruby-lang.org/issues/4840) Allow returning from require
 
-\### Before
+```ruby
+### Before
 
 unless cond
-
  class C
-
  end
-
 end
 
-\# … or …
+# … or …
 
 class C
-
 end unless cond
 
-\### After
+### After
 
 return if cond
 
 class C
-
 end
+```
 
 - pros
 
@@ -150,63 +147,48 @@ end
 
 ### Discussed use cases, examples
 
-\# OK
+```ruby
+# OK
 
 if xxx
-
  return
-
 end
 
 while xxx
-
  return
-
 end
 
 begin
-
  raise
-
 rescue
-
  return
-
 ensure
-
  return
-
 end
 
-\# NG
+# NG
 
 1.times{
-
  return
-
 }
 
 Class.new do
-
  return
-
 end
 
 pr = Proc.new{
-
  return
-
 }
 
 def foo
-
  return
-
 end
+```
 
 ## [[Feature #9098]](https://bugs.ruby-lang.org/issues/9098) Indent heredoc against the left margin by default when "indented closing identifier" is turned on.
 
-\# 2 spaces
+```ruby
+# 2 spaces
 
  str =<<~EOS
 
@@ -215,6 +197,7 @@ end
  EOS
 
 #=>”\\nhello\\n”
+```
 
 Matz: acecptable, but there could be a problem if hard tabs and spaces are both used in one heredoc.
 

--- a/2016/DevMeeting-2016-02-16.md
+++ b/2016/DevMeeting-2016-02-16.md
@@ -171,15 +171,17 @@ matz: It should raise TypeError.
 
 ## Allow kwargs to return/next/break
 
+```
 $ ruby -e 'def foo;return :a=>1; end'
 
 $ ruby -e 'def foo;return a: 1; end'
 
-\-e:1: syntax error, unexpected ':', expecting keyword_end
+-e:1: syntax error, unexpected ':', expecting keyword_end
 
 def foo;return a: 1; end
 
  ^
+```
 
 matz rejected it because return is not a method call.  Matz wants to split kwargs versus trailing-hash-arg in a long term.  He wants to distinguish them mentally.  Rocket notation is not always related to kwargs while colon notation is tightly-connected, even though it is also used in hash literals.  When it comes to a method, calling a method with keyword-argument does not always create hashes.
 

--- a/2016/DevMeeting-2016-06-13.md
+++ b/2016/DevMeeting-2016-06-13.md
@@ -146,13 +146,15 @@ nobu: this patch requires some tests, and fixes.
 
 What’s happen?
 
+```ruby
 ary = [:a, :b, :c, :d, :e]
 
 ary.delete(:a, :f, :c) #=> ???
 
-\# (1) [:a, :c]
+# (1) [:a, :c]
 
-\# (2) [:a, nil, :c]
+# (2) [:a, nil, :c]
+```
 
 - ko1: who requires return value (array)?
 - sora_h: With (2), we can use a return value with multiple assignment

--- a/2018/DevMeeting-2018-03-15.md
+++ b/2018/DevMeeting-2018-03-15.md
@@ -165,21 +165,22 @@ Maintainers starting Apr 2018:
 
 - [[Feature #14044]](https://bugs.ruby-lang.org/issues/14044) Introduce a new attribute step in Range (mrkn)
 
-\# current
+```ruby
+# current
 
 p 1.step(10, by: 2) #=> #<Enumerator: 1:step(10, {:by=>2})>
 
-p 1.step(by: 2)         #=> #<Enumerator: 1:step({:by=>2})>
+p 1.step(by: 2)         #=> #<Enumerator: 1:step({:by=>2})>
 
-\# extend
+# extend
 
 class Enumerator::ArithmeticSequence < Enumerator
 
  def first; end # already in Enumerator
 
- def last; end  # new
+ def last; end  # new
 
- def step; end  # new
+ def step; end  # new
 
  def inspect
 
@@ -189,13 +190,14 @@ class Enumerator::ArithmeticSequence < Enumerator
 
 end
 
-p 1.step                #=> (1.step)
+p 1.step                #=> (1.step)
 
-p 1.step(10)            #=> (1.step(10))
+p 1.step(10)            #=> (1.step(10))
 
 p 1.step(10, by: 2) #=> (1.step(10, by:2))
 
-p 1.step(by: 2)         #=> (1.step(by:2))
+p 1.step(by: 2)         #=> (1.step(by:2))
+```
 
 - do-else-end
 
@@ -253,14 +255,15 @@ p 1.step(by: 2)         #=> (1.step(by:2))
 
 Example of “toplevel” and “overtaken”  warning; note that “overtaken” is only shown with -w.
 
+```
 % ruby -w -e '
 class A
- @@v = :A
- def self.show() p @@v end
+ @@v = :A
+ def self.show() p @@v end
 end
 class B
- @@v = :B
- def self.show() p @@v end
+ @@v = :B
+ def self.show() p @@v end
 end
 A.show
 B.show
@@ -270,11 +273,12 @@ B.show
 '
 :A
 :B
-\-e:12: warning: class variable access from toplevel
-\-e:4: warning: class variable @@v of A is overtaken by Object
+-e:12: warning: class variable access from toplevel
+-e:4: warning: class variable @@v of A is overtaken by Object
 :TOP
-\-e:8: warning: class variable @@v of B is overtaken by Object
+-e:8: warning: class variable @@v of B is overtaken by Object
 :TOP
+```
 
 - Matz likes changing warnings to error
 


### PR DESCRIPTION
## Summary

Several meeting notes from 2014-2018 contain code examples that were not wrapped in code fences. Because `#` and `-` have special meaning in Markdown at the start of a line, these characters were escaped with backslashes (`\#`, `\-`) to prevent them from being rendered as headings or list items. This PR wraps these code blocks in proper fences and removes the now-unnecessary escaping.

## Changes (7 files)

- **2014/DevMeeting-2014-07-26.md** — Unescape `\->` to `->` (plain text arrow, not code)
- **2014/DevMeeting-2014-09-04.md** — Unescape `\-` to `-` (these were list items, not code)
- **2015/DevMeeting-2015-08-20.md** — Wrap Ruby error output + OCaml REPL session in code fence
- **2015/DevMeeting-2015-11-09.md** — Wrap three code blocks in fences (`### Before/After`, `# OK/NG`, `# 2 spaces` heredoc example)
- **2016/DevMeeting-2016-02-16.md** — Wrap error output in code fence
- **2016/DevMeeting-2016-06-13.md** — Wrap `ary.delete` code example in code fence
- **2018/DevMeeting-2018-03-15.md** — Wrap two code blocks in fences (`ArithmeticSequence` example + class variable warning example)

**Disclosure**: I am trying to make sure all Meeting Notes are formatted correctly, and using LLMs to help me do that. Changes have been made by Claude Opus 4.6, but reviewed by me.